### PR TITLE
fix: Don't reset eme options

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -168,11 +168,11 @@ const setupEmeOptions = (hlsHandler) => {
   const player = videojs.players[hlsHandler.tech_.options_.playerId];
 
   if (player.eme) {
-    player.eme.options = emeOptions(
+    player.eme.options = videojs.mergeOptions(player.eme.options, emeOptions(
       hlsHandler.source_.keySystems,
       hlsHandler.playlists.media(),
       hlsHandler.masterPlaylistController_.mediaTypes_.AUDIO.activePlaylistLoader.media()
-    );
+    ));
   }
 };
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -2835,7 +2835,7 @@ QUnit.test('populates quality levels list when available', function(assert) {
 });
 
 QUnit.test('configures eme if present on selectedinitialmedia', function(assert) {
-  this.player.eme = {};
+  this.player.eme = { previousSetting: 1 };
   this.player.src({
     src: 'manifest/master.mpd',
     type: 'application/dash+xml',
@@ -2877,6 +2877,7 @@ QUnit.test('configures eme if present on selectedinitialmedia', function(assert)
   this.player.tech_.hls.masterPlaylistController_.trigger('selectedinitialmedia');
 
   assert.deepEqual(this.player.eme.options, {
+    previousSetting: 1,
     keySystems: {
       keySystem1: {
         url: 'url1',

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -2835,7 +2835,11 @@ QUnit.test('populates quality levels list when available', function(assert) {
 });
 
 QUnit.test('configures eme if present on selectedinitialmedia', function(assert) {
-  this.player.eme.options = { previousSetting: 1 };
+  this.player.eme = { 
+    options: {
+      previousSetting: 1 
+    }
+  };
   this.player.src({
     src: 'manifest/master.mpd',
     type: 'application/dash+xml',

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -2835,7 +2835,7 @@ QUnit.test('populates quality levels list when available', function(assert) {
 });
 
 QUnit.test('configures eme if present on selectedinitialmedia', function(assert) {
-  this.player.eme = { previousSetting: 1 };
+  this.player.eme.options = { previousSetting: 1 };
   this.player.src({
     src: 'manifest/master.mpd',
     type: 'application/dash+xml',

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -2835,9 +2835,9 @@ QUnit.test('populates quality levels list when available', function(assert) {
 });
 
 QUnit.test('configures eme if present on selectedinitialmedia', function(assert) {
-  this.player.eme = { 
+  this.player.eme = {
     options: {
-      previousSetting: 1 
+      previousSetting: 1
     }
   };
   this.player.src({


### PR DESCRIPTION
## Description
The source handler is currently resetting a player's eme options if they exist before source load, let's merge these options instead.

## Specific Changes proposed
Merge existing `player.eme()` options

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [x] Reviewed by Two Core Contributors
