### PR TITLE
ignore: Don't apply browserify transform globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,25 +36,6 @@
         "negotiator": "0.6.1"
       }
     },
-    "accessory": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/accessory/-/accessory-1.1.0.tgz",
-      "integrity": "sha1-eDPpg5oy3tdtJgIfNqQXB6Ug9ZM=",
-      "dev": true,
-      "requires": {
-        "ap": "0.2.0",
-        "balanced-match": "0.2.1",
-        "dot-parts": "1.0.1"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-          "integrity": "sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc=",
-          "dev": true
-        }
-      }
-    },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -155,12 +136,6 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
-    },
-    "ap": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
-      "integrity": "sha1-rglCYAspkS8NKxTsYMRejzMLYRA=",
-      "dev": true
     },
     "argparse": {
       "version": "1.0.9",
@@ -1496,6 +1471,15 @@
         "inherits": "2.0.3"
       }
     },
+    "browserify-global-shim": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browserify-global-shim/-/browserify-global-shim-1.0.3.tgz",
+      "integrity": "sha1-svDePXIg4jCboKjEtWOOwdl4aKg=",
+      "dev": true,
+      "requires": {
+        "browserify-transform-tools": "1.7.0"
+      }
+    },
     "browserify-istanbul": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/browserify-istanbul/-/browserify-istanbul-2.0.0.tgz",
@@ -1527,27 +1511,6 @@
         "randombytes": "2.0.5"
       }
     },
-    "browserify-shim": {
-      "version": "3.8.14",
-      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.14.tgz",
-      "integrity": "sha1-vxBXAmky0yU8de991xTzuHft7Gs=",
-      "dev": true,
-      "requires": {
-        "exposify": "0.5.0",
-        "mothership": "0.2.0",
-        "rename-function-calls": "0.1.1",
-        "resolve": "0.6.3",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
-          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
-          "dev": true
-        }
-      }
-    },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
@@ -1561,6 +1524,16 @@
         "elliptic": "6.4.0",
         "inherits": "2.0.3",
         "parse-asn1": "5.1.0"
+      }
+    },
+    "browserify-transform-tools": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz",
+      "integrity": "sha1-g+J3Ih9jJZvtLn6yooOpcKUB9MQ=",
+      "dev": true,
+      "requires": {
+        "falafel": "2.1.0",
+        "through": "2.3.8"
       }
     },
     "browserify-versionify": {
@@ -2686,12 +2659,6 @@
         "domelementtype": "1.3.0"
       }
     },
-    "dot-parts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dot-parts/-/dot-parts-1.0.1.tgz",
-      "integrity": "sha1-iEvXvPwwgv+tL+XbU+SU2PPgdD8=",
-      "dev": true
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -3059,42 +3026,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
-      "integrity": "sha1-xmOSP24gqtSNDA+knzHG1PSTYM8=",
-      "dev": true,
-      "requires": {
-        "esprima": "1.0.4",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
@@ -3278,12 +3209,6 @@
         }
       }
     },
-    "estraverse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-      "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=",
-      "dev": true
-    },
     "estraverse-fb": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
@@ -3453,70 +3378,6 @@
         "os-homedir": "1.0.2"
       }
     },
-    "exposify": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/exposify/-/exposify-0.5.0.tgz",
-      "integrity": "sha1-+S0AlMJls/VT4fpFagOhiD0QWcw=",
-      "dev": true,
-      "requires": {
-        "globo": "1.1.0",
-        "map-obj": "1.0.1",
-        "replace-requires": "1.0.4",
-        "through2": "0.4.2",
-        "transformify": "0.1.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        }
-      }
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -3617,12 +3478,6 @@
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
       }
-    },
-    "find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-      "dev": true
     },
     "find-root": {
       "version": "0.1.2",
@@ -4799,17 +4654,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "globo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/globo/-/globo-1.1.0.tgz",
-      "integrity": "sha1-DSYJiVXepCLrIAGxBImLChAcqvM=",
-      "dev": true,
-      "requires": {
-        "accessory": "1.1.0",
-        "is-defined": "1.0.0",
-        "ternary": "1.0.0"
-      }
-    },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -4916,15 +4760,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
-    },
-    "has-require": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.2.2.tgz",
-      "integrity": "sha1-khZ1qxMNvZdo/I2o8ajiQt+kF3Q=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
     },
     "hash-base": {
       "version": "2.0.2",
@@ -5314,12 +5149,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-defined/-/is-defined-1.0.0.tgz",
-      "integrity": "sha1-HwfKZ9Vx9ZTEsUQVpF9774j5K/U=",
       "dev": true
     },
     "is-dotfile": {
@@ -6987,15 +6816,6 @@
         }
       }
     },
-    "mothership": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
-      "integrity": "sha1-k9SKL7w+UOKl/I7VhvW8RMZfmpk=",
-      "dev": true,
-      "requires": {
-        "find-parent-dir": "0.3.0"
-      }
-    },
     "mpd-parser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.3.0.tgz",
@@ -7646,12 +7466,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
-    },
-    "patch-text": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/patch-text/-/patch-text-1.0.2.tgz",
-      "integrity": "sha1-S/NuZeUXM9bpjwz2LgkDTaoDSKw=",
       "dev": true
     },
     "path-browserify": {
@@ -8312,33 +8126,6 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
-    "rename-function-calls": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
-      "integrity": "sha1-f4M2nAB6MAf2q+MDPM+BaGoQjgE=",
-      "dev": true,
-      "requires": {
-        "detective": "3.1.0"
-      },
-      "dependencies": {
-        "detective": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
-          "integrity": "sha1-d3gkRKt1K4jKG+Lp0KA5Xx2iXu0=",
-          "dev": true,
-          "requires": {
-            "escodegen": "1.1.0",
-            "esprima-fb": "3001.1.0-dev-harmony-fb"
-          }
-        },
-        "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-          "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE=",
-          "dev": true
-        }
-      }
-    },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -8350,18 +8137,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
-    },
-    "replace-requires": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/replace-requires/-/replace-requires-1.0.4.tgz",
-      "integrity": "sha1-AUtzMLa54lV7cQQ7ZvsCZgw79mc=",
-      "dev": true,
-      "requires": {
-        "detective": "4.5.0",
-        "has-require": "1.2.2",
-        "patch-text": "1.0.2",
-        "xtend": "4.0.1"
-      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -9146,12 +8921,6 @@
         "execa": "0.7.0"
       }
     },
-    "ternary": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ternary/-/ternary-1.0.0.tgz",
-      "integrity": "sha1-RXAnJWCMlJnUapYQ6bDkn/JveJ4=",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9279,41 +9048,6 @@
           "requires": {
             "abbrev": "1.0.9"
           }
-        }
-      }
-    },
-    "transformify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
-      "integrity": "sha1-mk9CoVRDPdcnuAV1Qoo8nlSJ6/E=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "watch:docs": "nodemon --watch src/ --exec npm run docs",
     "watch:js": "npm-run-all -p watch:js:babel watch:js:browserify watch:js:switcher",
     "watch:js:babel": "npm run build:js:babel -- --watch",
-    "watch:js:browserify": "watchify . -v -g browserify-shim -o dist/videojs-http-streaming.js",
+    "watch:js:browserify": "watchify . -v -t browserify-shim -o dist/videojs-http-streaming.js",
     "watch:js:switcher": "watchify utils/switcher/switcher.js -v -t babelify -g browserify-shim -o dist/switcher.js",
     "watch:test:browserify": "watchify test/browserify-test.js -o dist-test/browserify-test.js",
     "watch:test:webpack": "watchify test/webpack-test.js -o dist-test/webpack-test.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:js": "npm-run-all build:js:babel build:js:browserify build:js:bannerize build:js:collapse build:js:uglify",
     "build:js:babel": "babel src -d es5",
     "build:js:bannerize": "bannerize dist/videojs-http-streaming.js --banner=scripts/banner.ejs",
-    "build:js:browserify": "browserify . -s videojs-http-streaming -g browserify-shim -o dist/videojs-http-streaming.js",
+    "build:js:browserify": "browserify . -s videojs-http-streaming -t browserify-global-shim -o dist/videojs-http-streaming.js",
     "build:js:collapse": "bundle-collapser dist/videojs-http-streaming.js -o dist/videojs-http-streaming.min.js",
     "build:js:uglify": "uglifyjs dist/videojs-http-streaming.min.js --support-ie8 --comments -m -c -o dist/videojs-http-streaming.min.js",
     "build:test:browserify": "browserify test/browserify-test.js -o dist-test/browserify-test.js",
@@ -41,8 +41,8 @@
     "watch:docs": "nodemon --watch src/ --exec npm run docs",
     "watch:js": "npm-run-all -p watch:js:babel watch:js:browserify watch:js:switcher",
     "watch:js:babel": "npm run build:js:babel -- --watch",
-    "watch:js:browserify": "watchify . -v -t browserify-shim -o dist/videojs-http-streaming.js",
-    "watch:js:switcher": "watchify utils/switcher/switcher.js -v -t babelify -g browserify-shim -o dist/switcher.js",
+    "watch:js:browserify": "watchify . -v -t browserify-global-shim -o dist/videojs-http-streaming.js",
+    "watch:js:switcher": "watchify utils/switcher/switcher.js -v -t babelify -t browserify-global-shim -o dist/switcher.js",
     "watch:test:browserify": "watchify test/browserify-test.js -o dist-test/browserify-test.js",
     "watch:test:webpack": "watchify test/webpack-test.js -o dist-test/webpack-test.js",
     "watch:test": "npm-run-all -p watch:test:manifest watch:test:js watch:test:webpack watch:test:browserify",
@@ -56,10 +56,10 @@
   ],
   "author": "Brightcove, Inc",
   "license": "Apache-2.0",
-  "browserify-shim": {
-    "qunit": "global:QUnit",
-    "sinon": "global:sinon",
-    "video.js": "global:videojs"
+  "browserify-global-shim": {
+    "qunit": "QUnit",
+    "sinon": "sinon",
+    "video.js": "videojs"
   },
   "vjsstandard": {
     "ignore": [
@@ -99,8 +99,8 @@
     "babelify": "^8.0.0",
     "bannerize": "^1.0.0",
     "browserify": "^11.0.0",
+    "browserify-global-shim": "^1.0.3",
     "browserify-istanbul": "^2.0.0",
-    "browserify-shim": "^3.0.0",
     "bundle-collapser": "^1.2.1",
     "connect": "^3.4.0",
     "cowsay": "^1.1.0",

--- a/scripts/build-test.js
+++ b/scripts/build-test.js
@@ -5,7 +5,7 @@ var glob = require('glob');
 glob('test/**/*.test.js', function(err, files) {
   browserify(files)
     .transform('babelify')
-    .transform('browserify-shim', {global: true})
+    .transform('browserify-global-shim')
     .bundle()
     .pipe(fs.createWriteStream('dist-test/videojs-http-streaming.js'));
 });

--- a/scripts/watch-test.js
+++ b/scripts/watch-test.js
@@ -10,7 +10,7 @@ glob('test/**/*.test.js', function(err, files) {
     plugin: [watchify]
   })
   .transform('babelify')
-  .transform('browserify-shim', {global: true});
+  .transform('browserify-global-shim');
 
   var bundle = function() {
     b.bundle().pipe(fs.createWriteStream('dist-test/videojs-http-streaming.js'));

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -105,7 +105,7 @@ module.exports = function(config) {
       debug: true,
       transform: [
         'babelify',
-        ['browserify-shim', { global: true }]
+        'browserify-global-shim'
       ],
       noParse: [
         'test/data/**',


### PR DESCRIPTION
## Description
Previously the build would apply the `browserify-shim` transform globally so that the `videojs-contrib-media-sources` dependency would not pull in video.js. Now that we no longer have that dependency the transform only needs to be applied within the project itself.

## Requirements Checklist
- [ ] Reviewed by Two Core Contributors
