### PR TITLE
Fix program date time handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6684,9 +6684,9 @@
       "dev": true
     },
     "m3u8-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-2.1.0.tgz",
-      "integrity": "sha1-yBcDKewc1RXQ1Yu4t2LamJbLA2g="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
+      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
     },
     "make-dir": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   "dependencies": {
     "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
-    "m3u8-parser": "2.1.0",
     "mpd-parser": "0.4.0",
+    "m3u8-parser": "4.2.0",
     "mux.js": "4.3.2",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.2.0",

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -53,13 +53,11 @@ export const syncPointStrategies = [
             break;
           }
 
-          if (!syncPoint || lastDistance === null || lastDistance >= distance) {
-            lastDistance = distance;
-            syncPoint = {
-              time: segmentStart,
-              segmentIndex: i
-            };
-          }
+          lastDistance = distance;
+          syncPoint = {
+            time: segmentStart,
+            segmentIndex: i
+          };
         }
       }
       return syncPoint;

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -359,8 +359,11 @@ export default class SyncController extends videojs.EventTarget {
    * @param {Playlist} playlist - The currently active playlist
    */
   setDateTimeMapping(playlist) {
-    if (!this.datetimeToDisplayTime && playlist.dateTimeObject) {
-      let playlistTimestamp = playlist.dateTimeObject.getTime() / 1000;
+    if (!this.datetimeToDisplayTime &&
+        playlist.segments &&
+        playlist.segments.length &&
+        playlist.segments[0].dateTimeObject) {
+      let playlistTimestamp = playlist.segments[0].dateTimeObject.getTime() / 1000;
 
       this.datetimeToDisplayTime = -playlistTimestamp;
     }

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -46,7 +46,7 @@ QUnit.test('returns correct sync point for ProgramDateTime strategy', function(a
 
   assert.equal(syncPoint, null, 'no syncpoint when datetimeToDisplayTime not set');
 
-  playlist.dateTimeObject = datetime;
+  playlist.segments[0].dateTimeObject = datetime;
 
   this.syncController.setDateTimeMapping(playlist);
 
@@ -56,7 +56,7 @@ QUnit.test('returns correct sync point for ProgramDateTime strategy', function(a
 
   assert.equal(syncPoint, null, 'no syncpoint when datetimeObject not set on playlist');
 
-  newPlaylist.dateTimeObject = new Date(2012, 11, 12, 12, 12, 22);
+  newPlaylist.segments[0].dateTimeObject = new Date(2012, 11, 12, 12, 12, 22);
 
   syncPoint = strategy.run(this.syncController, newPlaylist, duration, timeline);
 


### PR DESCRIPTION
The previous version of m3u8-parser had a bug that would associate the last `EXT-X-PROGRAM-DATE-TIME` tag with the start of the playlist.

This could cause problems in  live streams with the following properties
* ONE of:
  1. `EXT-X-PLAYLIST-TYPE:EVENT`
  2. a playlist with a sliding window, but viewed as the initial window is being filled, i.e. the playlist is still growing and segments are not yet being removed from the front
* Every segment has its own `EXT-X-PROGRAM-DATE-TIME` tag

When these conditions are met, each playlist refresh causes the `SyncController` to believe that there is a new sync point at the start of the playlist shifted by an amount that is equal to the amount of time added by new segments at the end. Since the playlist window is not actually sliding yet, the sync point for the start of the playlist should not be changed. This could cause issues when seeking backwards and then forwards. This is because seeking backwards causes a new `timestampOffset` to be set (because the segment that is being seeked to starts before the currently set `timestampOffset`). When `timestampOffset` changes, the `SyncController` also updates its PTS to Display time mapping. Since the `SyncController` has an incorrect sync point as described above, the mapping that gets set is incorrect. Seeking forward again after this can cause the player to select a segment that is beyond the playhead and stall indefinitely.

This PR updates the m3u8-parser version, which attaches date time info on each segment for each tag, instead of just on the playlist object. The `ProgramDateTime` strategy in `SyncController` will now look for the nearest segment to `currentTime` with date time information for an accurate sync point.