### PR TITLE
Live support for DASH

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6997,9 +6997,9 @@
       }
     },
     "mpd-parser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.4.0.tgz",
-      "integrity": "sha512-lmvrkS0AypJ/BJQUY98Iwy44Goj/bTaSIbeLxpJrBG4xNzMBOUlIFHUMy7yc0kk08FoiR8Oc3I79dvzp1pq8kw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.5.0.tgz",
+      "integrity": "sha512-eexEhIcAZO7zdqLAA3qwAQqxPSnvqdWHsvskYc9RNUj7g+/OXtwO2g0iEEewkeAVkLp7zOOWaI08bjeTMWRFXg==",
       "requires": {
         "global": "4.3.2",
         "url-toolkit": "2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7027,9 +7027,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.3.2.tgz",
-      "integrity": "sha512-g0q6DPdvb3yYcoK7ElBGobdSSrhY/RjPt19U7uUc733aqvc5bCS/aCvL9z+448y+IoCZnYDwyZfQBBXMSmGOaQ=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.4.1.tgz",
+      "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw=="
     },
     "nan": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   "dependencies": {
     "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
-    "mpd-parser": "0.4.0",
     "m3u8-parser": "4.2.0",
+    "mpd-parser": "0.5.0",
     "mux.js": "4.3.2",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "4.2.0",
     "mpd-parser": "0.5.0",
-    "mux.js": "4.3.2",
+    "mux.js": "4.4.1",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.2.0",
     "webwackify": "0.1.3"

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -1,15 +1,48 @@
-import { EventTarget } from 'video.js';
+import { EventTarget, mergeOptions } from 'video.js';
 import mpdParser from 'mpd-parser';
 import {
+  refreshDelay,
   setupMediaPlaylists,
-  resolveMediaGroupUris
+  resolveMediaGroupUris,
+  updateMaster as updatePlaylist,
+  forEachMediaGroup
 } from './playlist-loader';
+
+export const updateMaster = (oldMaster, newMaster) => {
+  let update = mergeOptions(oldMaster, {
+    // These are top level properties that can be updated
+    duration: newMaster.duration,
+    minimumUpdatePeriod: newMaster.minimumUpdatePeriod
+  });
+
+  // First update the playlists in playlist list
+  for (let i = 0; i < newMaster.playlists.length; i++) {
+    const playlistUpdate = updatePlaylist(update, newMaster.playlists[i]);
+
+    if (playlistUpdate) {
+      update = playlistUpdate;
+    }
+  }
+
+  // Then update media group playlists
+  forEachMediaGroup(newMaster, (properties) => {
+    if (properties.playlists && properties.playlists.length) {
+      const playlistUpdate = updatePlaylist(update, properties.playlists[0]);
+
+      if (playlistUpdate) {
+        update = playlistUpdate;
+      }
+    }
+  });
+
+  return update;
+};
 
 export default class DashPlaylistLoader extends EventTarget {
   // DashPlaylistLoader must accept either a src url or a playlist because subsequent
   // playlist loader setups from media groups will expect to be able to pass a playlist
   // (since there aren't external URLs to media playlists with DASH)
-  constructor(srcUrlOrPlaylist, hls, withCredentials) {
+  constructor(srcUrlOrPlaylist, hls, withCredentials, masterPlaylistLoader) {
     super();
 
     this.hls_ = hls;
@@ -19,6 +52,16 @@ export default class DashPlaylistLoader extends EventTarget {
       throw new Error('A non-empty playlist URL or playlist is required');
     }
 
+    // event naming?
+    this.on('minimumUpdatePeriod', () => {
+      this.refreshXml_();
+    });
+
+    // live playlist staleness timeout
+    this.on('mediaupdatetimeout', () => {
+      this.refreshMedia_();
+    });
+
     // initialize the loader state
     if (typeof srcUrlOrPlaylist === 'string') {
       this.srcUrl = srcUrlOrPlaylist;
@@ -26,9 +69,11 @@ export default class DashPlaylistLoader extends EventTarget {
       return;
     }
 
+    this.masterPlaylistLoader_ = masterPlaylistLoader;
+
     this.state = 'HAVE_METADATA';
     this.started = true;
-    // we only should have one, so select it
+    // we only should have one playlist so select it
     this.media(srcUrlOrPlaylist);
     // trigger async to mimic behavior of HLS, where it must request a playlist
     setTimeout(() => {
@@ -61,6 +106,8 @@ export default class DashPlaylistLoader extends EventTarget {
       throw new Error('Cannot switch media playlist from ' + this.state);
     }
 
+    const startingState = this.state;
+
     // find the playlist object if the target playlist has been specified by URI
     if (typeof playlist === 'string') {
       if (!this.master.playlists[playlist]) {
@@ -72,16 +119,25 @@ export default class DashPlaylistLoader extends EventTarget {
     const mediaChange = !this.media_ || playlist.uri !== this.media_.uri;
 
     this.state = 'HAVE_METADATA';
+
+    // switching to the active playlist is a no-op
+    if (!mediaChange) {
+      return;
+    }
+
+    // switching from an already loaded playlist
+    if (this.media_) {
+      this.trigger('mediachanging');
+    }
+
     this.media_ = playlist;
 
+    this.refreshMedia_();
+
     // trigger media change if the active media has been updated
-    if (mediaChange) {
-      this.trigger('mediachanging');
-      // since every playlist is technically loaded, trigger that we loaded it
-      this.trigger('loadedplaylist');
+    if (startingState !== 'HAVE_MASTER') {
       this.trigger('mediachange');
     }
-    return;
   }
 
   pause() {
@@ -102,6 +158,40 @@ export default class DashPlaylistLoader extends EventTarget {
     }
 
     this.trigger('loadedplaylist');
+  }
+
+  parseMasterXml() {
+    const master = mpdParser.parse(this.masterXml_, this.srcUrl);
+
+    master.uri = this.srcUrl;
+
+    // TODO: Should we create the dummy uris in mpd-parser as well (leaning towards yes)
+    // set up phony URIs for the playlists since we won't have external URIs for DASH
+    // but reference playlists by their URI throughout the project
+    for (let i = 0; i < master.playlists.length; i++) {
+      const phonyUri = `placeholder-uri-${i}`;
+
+      master.playlists[i].uri = phonyUri;
+      // set up by URI references
+      master.playlists[phonyUri] = master.playlists[i];
+    }
+
+    // set up phony URIs for the media group playlists since we won't have external
+    // URIs for DASH but reference playlists by their URI throughout the project
+    forEachMediaGroup(master, (properties, mediaType, groupKey, labelKey) => {
+      if (properties.playlists && properties.playlists.length) {
+        const phonyUri = `placeholder-uri-${mediaType}-${groupKey}-${labelKey}`;
+
+        properties.playlists[0].uri = phonyUri;
+        // setup URI references
+        master.playlists[phonyUri] = properties.playlists[0];
+      }
+    });
+
+    setupMediaPlaylists(master);
+    resolveMediaGroupUris(master);
+
+    return master;
   }
 
   start() {
@@ -134,38 +224,14 @@ export default class DashPlaylistLoader extends EventTarget {
         return this.trigger('error');
       }
 
-      this.master = mpdParser.parse(req.responseText, this.srcUrl);
-      this.master.uri = this.srcUrl;
+      this.masterXml_ = req.responseText;
+
+      this.master = this.parseMasterXml();
 
       this.state = 'HAVE_MASTER';
 
-      // TODO mediaSequence will be added in mpd-parser
-      this.master.playlists.forEach((playlist) => {
-        playlist.mediaSequence = 0;
-      });
-      for (let groupKey in this.master.mediaGroups.AUDIO) {
-        for (let labelKey in this.master.mediaGroups.AUDIO[groupKey]) {
-          this.master.mediaGroups.AUDIO[groupKey][labelKey].playlists.forEach(
-            (playlist) => {
-              playlist.mediaSequence = 0;
-            });
-        }
-      }
-
-      // set up phony URIs for the playlists since we won't have external URIs for DASH
-      // but reference playlists by their URI throughout the project
-      for (let i = 0; i < this.master.playlists.length; i++) {
-        const phonyUri = `placeholder-uri-${i}`;
-
-        this.master.playlists[i].uri = phonyUri;
-        // set up by URI references
-        this.master.playlists[phonyUri] = this.master.playlists[i];
-      }
-
-      setupMediaPlaylists(this.master);
-      resolveMediaGroupUris(this.master);
-
       this.trigger('loadedplaylist');
+
       if (!this.media_) {
         // no media playlist was specifically selected so start
         // from the first listed one
@@ -176,6 +242,85 @@ export default class DashPlaylistLoader extends EventTarget {
       setTimeout(() => {
         this.trigger('loadedmetadata');
       }, 0);
+
+      // if (this.master.minimumUpdatePeriod) {
+      //   setTimeout(() => {
+      //     this.trigger('minimumUpdatePeriod');
+      //   }, this.master.minimumUpdatePeriod);
+      // }
     });
+  }
+
+  refreshXml_() {
+    this.request = this.hls_.xhr({
+      uri: this.srcUrl,
+      withCredentials: this.withCredentials
+    }, (error, req) => {
+      // disposed
+      if (!this.request) {
+        return;
+      }
+
+      // clear the loader's request reference
+      this.request = null;
+
+      if (error) {
+        this.error = {
+          status: req.status,
+          message: 'DASH playlist request error at URL: ' + this.srcUrl,
+          responseText: req.responseText,
+          // MEDIA_ERR_NETWORK
+          code: 2
+        };
+        if (this.state === 'HAVE_NOTHING') {
+          this.started = false;
+        }
+        return this.trigger('error');
+      }
+
+      this.masterXml_ = req.responseText;
+
+      const newMaster = this.parseMasterXml();
+
+      this.master = updateMaster(this.master, newMaster);
+
+      setTimeout(() => {
+        this.trigger('minimumUpdatePeriod');
+      }, this.master.minimumUpdatePeriod);
+    });
+  }
+
+  refreshMedia_() {
+    let oldMaster;
+    let newMaster;
+
+    if (this.masterPlaylistLoader_) {
+      oldMaster = this.masterPlaylistLoader_.master;
+      newMaster = this.masterPlaylistLoader_.parseMasterXml();
+    } else {
+      oldMaster = this.master;
+      newMaster = this.parseMasterXml();
+    }
+
+    const updatedMaster = updateMaster(oldMaster, newMaster);
+
+    if (updatedMaster) {
+      if (this.masterPlaylistLoader_) {
+        this.masterPlaylistLoader_.master = updatedMaster;
+      } else {
+        this.master = updatedMaster;
+      }
+      this.media_ = updatedMaster.playlists[this.media_.uri];
+    } else {
+      this.trigger('playlistunchanged');
+    }
+
+    if (!this.media().endList) {
+      this.mediaUpdateTimeout = setTimeout(()=> {
+        this.trigger('mediaupdatetimeout');
+      }, refreshDelay(this.media(), !!updatedMaster));
+    }
+
+    this.trigger('loadedplaylist');
   }
 }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -8,6 +8,7 @@ import {
   forEachMediaGroup
 } from './playlist-loader';
 import resolveUrl from './resolve-url';
+import window from 'global/window';
 
 /**
  * Returns a new master manifest that is the result of merging an updated master manifest
@@ -92,7 +93,7 @@ export default class DashPlaylistLoader extends EventTarget {
     // we only should have one playlist so select it
     this.media(srcUrlOrPlaylist);
     // trigger async to mimic behavior of HLS, where it must request a playlist
-    setTimeout(() => {
+    window.setTimeout(() => {
       this.trigger('loadedmetadata');
     }, 0);
   }
@@ -339,7 +340,7 @@ export default class DashPlaylistLoader extends EventTarget {
     }
     // trigger loadedmetadata to resolve setup of media groups
     // trigger async to mimic behavior of HLS, where it must request a playlist
-    setTimeout(() => {
+    window.setTimeout(() => {
       this.trigger('loadedmetadata');
     }, 0);
 
@@ -350,7 +351,7 @@ export default class DashPlaylistLoader extends EventTarget {
     // would be to update the manifest at the same rate that the media playlists
     // are "refreshed", i.e. every targetDuration.
     if (this.master.minimumUpdatePeriod) {
-      setTimeout(() => {
+      window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
       }, this.master.minimumUpdatePeriod);
     }
@@ -393,7 +394,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
       this.master = updateMaster(this.master, newMaster);
 
-      setTimeout(() => {
+      window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
       }, this.master.minimumUpdatePeriod);
     });
@@ -430,7 +431,7 @@ export default class DashPlaylistLoader extends EventTarget {
     }
 
     if (!this.media().endList) {
-      this.mediaUpdateTimeout = setTimeout(()=> {
+      this.mediaUpdateTimeout = window.setTimeout(()=> {
         this.trigger('mediaupdatetimeout');
       }, refreshDelay(this.media(), !!updatedMaster));
     }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -169,9 +169,9 @@ export default class DashPlaylistLoader extends EventTarget {
 
     master.uri = this.srcUrl;
 
-    // TODO: Should we create the dummy uris in mpd-parser as well (leaning towards yes)
-    // set up phony URIs for the playlists since we won't have external URIs for DASH
+    // Set up phony URIs for the playlists since we won't have external URIs for DASH
     // but reference playlists by their URI throughout the project
+    // TODO: Should we create the dummy uris in mpd-parser as well (leaning towards yes).
     for (let i = 0; i < master.playlists.length; i++) {
       const phonyUri = `placeholder-uri-${i}`;
 

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -99,6 +99,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
   dispose() {
     this.stopRequest();
+    window.clearTimeout(this.mediaUpdateTimeout);
   }
 
   stopRequest() {

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -359,7 +359,8 @@ export const initialize = {
           groups,
           tracks
         }
-      }
+      },
+      masterPlaylistLoader
     } = settings;
 
     // force a default if we have none
@@ -406,7 +407,8 @@ export const initialize = {
         } else if (properties.playlists && sourceType === 'dash') {
           playlistLoader = new DashPlaylistLoader(properties.playlists[0],
                                                   hls,
-                                                  withCredentials);
+                                                  withCredentials,
+                                                  masterPlaylistLoader);
         } else {
           // no resolvedUri means the audio is muxed with the video when using this
           // audio track
@@ -460,7 +462,8 @@ export const initialize = {
           groups,
           tracks
         }
-      }
+      },
+      masterPlaylistLoader
     } = settings;
 
     for (let groupId in mediaGroups[type]) {
@@ -489,8 +492,10 @@ export const initialize = {
           playlistLoader =
             new PlaylistLoader(properties.resolvedUri, hls, withCredentials);
         } else if (sourceType === 'dash') {
-          playlistLoader =
-            new DashPlaylistLoader(properties.playlists[0], hls, withCredentials);
+          playlistLoader = new DashPlaylistLoader(properties.playlists[0],
+                                                  hls,
+                                                  withCredentials,
+                                                  masterPlaylistLoader);
         }
 
         properties = videojs.mergeOptions({

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -337,6 +337,10 @@ export const setupListeners = {
   }
 };
 
+const byGroupId = (type, groupId) => (playlist) => playlist.attributes[type] === groupId;
+
+const byResolvedUri = (resolvedUri) => (playlist) => playlist.resolvedUri === resolvedUri;
+
 export const initialize = {
   /**
    * Setup PlaylistLoaders and AudioTracks for the audio groups
@@ -376,18 +380,15 @@ export const initialize = {
 
       // List of playlists that have an AUDIO attribute value matching the current
       // group ID
-      const groupPlaylists = playlists.filter(playlist => {
-        return playlist.attributes[type] === groupId;
-      });
+      const groupPlaylists = playlists.filter(byGroupId(type, groupId));
 
       for (let variantLabel in mediaGroups[type][groupId]) {
         let properties = mediaGroups[type][groupId][variantLabel];
 
         // List of playlists for the current group ID that have a matching uri with
         // this alternate audio variant
-        const matchingPlaylists = groupPlaylists.filter(playlist => {
-          return playlist.resolvedUri === properties.resolvedUri;
-        });
+        const matchingPlaylists =
+          groupPlaylists.filter(byResolvedUri(properties.resolvedUri));
 
         if (matchingPlaylists.length) {
           // If there is a playlist that has the same uri as this audio variant, assume

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -10,6 +10,18 @@ import { mergeOptions, EventTarget, log } from 'video.js';
 import m3u8 from 'm3u8-parser';
 import window from 'global/window';
 
+export const forEachMediaGroup = (master, callback) => {
+  ['AUDIO', 'SUBTITLES'].forEach((mediaType) => {
+    for (let groupKey in master.mediaGroups[mediaType]) {
+      for (let labelKey in master.mediaGroups[mediaType][groupKey]) {
+        const mediaProperties = master.mediaGroups[mediaType][groupKey][labelKey];
+
+        callback(mediaProperties, mediaType, groupKey, labelKey);
+      }
+    }
+  });
+};
+
 /**
   * Returns a new array of segments that is the result of merging
   * properties from an older list of segments onto an updated
@@ -63,7 +75,7 @@ export const resolveSegmentUris = (segment, baseUri) => {
   */
 export const updateMaster = (master, media) => {
   const result = mergeOptions(master, {});
-  const playlist = result.playlists.filter((p) => p.uri === media.uri)[0];
+  const playlist = result.playlists[media.uri];
 
   if (!playlist) {
     return null;
@@ -132,15 +144,9 @@ export const setupMediaPlaylists = (master) => {
 };
 
 export const resolveMediaGroupUris = (master) => {
-  ['AUDIO', 'SUBTITLES'].forEach((mediaType) => {
-    for (let groupKey in master.mediaGroups[mediaType]) {
-      for (let labelKey in master.mediaGroups[mediaType][groupKey]) {
-        let mediaProperties = master.mediaGroups[mediaType][groupKey][labelKey];
-
-        if (mediaProperties.uri) {
-          mediaProperties.resolvedUri = resolveUrl(master.uri, mediaProperties.uri);
-        }
-      }
+  forEachMediaGroup(master, (properties) => {
+    if (properties.uri) {
+      properties.resolvedUri = resolveUrl(master.uri, properties.uri);
     }
   });
 };

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -10,6 +10,15 @@ import { mergeOptions, EventTarget, log } from 'video.js';
 import m3u8 from 'm3u8-parser';
 import window from 'global/window';
 
+/**
+ * Loops through all supported media groups in master and calls the provided
+ * callback for each group
+ *
+ * @param {Object} master
+ *        The parsed master manifest object
+ * @param {Function} callback
+ *        Callback to call for each media group
+ */
 export const forEachMediaGroup = (master, callback) => {
   ['AUDIO', 'SUBTITLES'].forEach((mediaType) => {
     for (let groupKey in master.mediaGroups[mediaType]) {

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -47,6 +47,10 @@ const xhrFactory = function() {
         }
       }
 
+      if (response.headers) {
+        request.responseHeaders = response.headers;
+      }
+
       // videojs.xhr now uses a specific code on the error
       // object to signal that a request has timed out instead
       // of setting a boolean on the request object

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -1,9 +1,10 @@
 import QUnit from 'qunit';
-import DashPlaylistLoader from '../src/dash-playlist-loader';
+import { default as DashPlaylistLoader, updateMaster } from '../src/dash-playlist-loader';
 import xhrFactory from '../src/xhr';
 import {
   useFakeEnvironment,
-  standardXHRResponse
+  standardXHRResponse,
+  urlTo
 } from './test-helpers';
 
 QUnit.module('DASH Playlist Loader', {
@@ -207,4 +208,192 @@ QUnit.test('triggers an event when the active media changes', function(assert) {
   loader.media(loader.master.playlists[0]);
   assert.strictEqual(mediaChangings, 2, 'ignored the no-op media change');
   assert.strictEqual(mediaChanges, 2, 'ignored the no-op media change');
+});
+
+QUnit.test('parseMasterXml parses master manifest and sets up uri references',
+function(assert) {
+  let loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
+
+  loader.load();
+
+  standardXHRResponse(this.requests.shift());
+
+  assert.equal(loader.master.playlists[0].uri, 'placeholder-uri-0',
+    'setup phony uri for media playlist');
+  assert.strictEqual(loader.master.playlists['placeholder-uri-0'],
+    loader.master.playlists[0], 'set reference by uri for easy access');
+  assert.equal(loader.master.playlists[1].uri, 'placeholder-uri-1',
+    'setup phony uri for media playlist');
+  assert.strictEqual(loader.master.playlists['placeholder-uri-1'],
+    loader.master.playlists[1], 'set reference by uri for easy access');
+  assert.equal(loader.master.mediaGroups.AUDIO.audio.main.playlists[0].uri,
+    'placeholder-uri-AUDIO-audio-main', 'setup phony uri for media groups');
+  assert.strictEqual(loader.master.playlists['placeholder-uri-AUDIO-audio-main'],
+    loader.master.mediaGroups.AUDIO.audio.main.playlists[0],
+    'set reference by uri for easy access');
+});
+
+QUnit.test('updateMaster updates playlists and mediaGroups', function(assert) {
+  const master = {
+    duration: 10,
+    minimumUpdatePeriod: 0,
+    mediaGroups: {
+      AUDIO: {
+        audio: {
+          main: {
+            playlists: [{
+              mediaSequence: 0,
+              attributes: {},
+              uri: 'audio-0-uri',
+              resolvedUri: urlTo('audio-0-uri'),
+              segments: [{
+                duration: 10,
+                uri: 'audio-segment-0-uri',
+                resolvedUri: urlTo('audio-segment-0-uri')
+              }]
+            }]
+          }
+        }
+      }
+    },
+    playlists: [{
+      mediaSequence: 0,
+      attributes: {
+        BANDWIDTH: 9
+      },
+      uri: 'playlist-0-uri',
+      resolvedUri: urlTo('playlist-0-uri'),
+      segments: [{
+        duration: 10,
+        uri: 'segment-0-uri',
+        resolvedUri: urlTo('segment-0-uri')
+      }]
+    }]
+  };
+  const update = {
+    duration: 20,
+    minimumUpdatePeriod: 0,
+    mediaGroups: {
+      AUDIO: {
+        audio: {
+          main: {
+            playlists: [{
+              mediaSequence: 1,
+              attributes: {},
+              uri: 'audio-0-uri',
+              resolvedUri: urlTo('audio-0-uri'),
+              segments: [{
+                duration: 10,
+                uri: 'audio-segment-0-uri',
+                resolvedUri: urlTo('audio-segment-0-uri')
+              }]
+            }]
+          }
+        }
+      }
+    },
+    playlists: [{
+      mediaSequence: 1,
+      attributes: {
+        BANDWIDTH: 9
+      },
+      uri: 'playlist-0-uri',
+      resolvedUri: urlTo('playlist-0-uri'),
+      segments: [{
+        duration: 10,
+        uri: 'segment-0-uri',
+        resolvedUri: urlTo('segment-0-uri')
+      }]
+    }]
+  };
+
+  master.playlists['playlist-0-uri'] = master.playlists[0];
+  master.playlists['audio-0-uri'] = master.mediaGroups.AUDIO.audio.main.playlists[0];
+
+  assert.deepEqual(
+    updateMaster(master, update),
+    {
+      duration: 20,
+      minimumUpdatePeriod: 0,
+      mediaGroups: {
+        AUDIO: {
+          audio: {
+            main: {
+              playlists: [{
+                mediaSequence: 1,
+                attributes: {},
+                uri: 'audio-0-uri',
+                resolvedUri: urlTo('audio-0-uri'),
+                segments: [{
+                  duration: 10,
+                  uri: 'audio-segment-0-uri',
+                  resolvedUri: urlTo('audio-segment-0-uri')
+                }]
+              }]
+            }
+          }
+        }
+      },
+      playlists: [{
+        mediaSequence: 1,
+        attributes: {
+          BANDWIDTH: 9
+        },
+        uri: 'playlist-0-uri',
+        resolvedUri: urlTo('playlist-0-uri'),
+        segments: [{
+          duration: 10,
+          uri: 'segment-0-uri',
+          resolvedUri: urlTo('segment-0-uri')
+        }]
+      }]
+    },
+    'updates playlists and media groups');
+});
+
+QUnit.test('refreshes the xml if there is a minimumUpdatePeriod', function(assert) {
+  let loader = new DashPlaylistLoader('dash-live.mpd', this.fakeHls);
+  let minimumUpdatePeriods = 0;
+
+  loader.on('minimumUpdatePeriod', () => minimumUpdatePeriods++);
+
+  loader.load();
+
+  assert.equal(minimumUpdatePeriods, 0, 'no refreshs to start');
+
+  standardXHRResponse(this.requests.shift());
+
+  assert.equal(minimumUpdatePeriods, 0, 'no refreshs immediately after response');
+
+  this.clock.tick(4 * 1000);
+
+  assert.equal(this.requests.length, 1, 'refreshed manifest');
+  assert.equal(this.requests[0].uri, 'dash-live.mpd', 'refreshed manifest');
+  assert.equal(minimumUpdatePeriods, 1, 'refreshed manifest');
+});
+
+QUnit.test('media playlists "refresh" by re-parsing master xml', function(assert) {
+  let loader = new DashPlaylistLoader('dash-live.mpd', this.fakeHls);
+  const parseMasterXml_ = loader.parseMasterXml.bind(loader);
+  let refreshes = 0;
+
+  loader.on('mediaupdatetimeout', () => refreshes++);
+
+  loader.parseMasterXml = () => {
+    const result = parseMasterXml_();
+
+    // add segment to segment list for proper refresh delay functionality
+    result.playlists[0].segments.push({ duration: 2, uri: 'segment-0' });
+
+    return result;
+  }
+
+  loader.load();
+
+  standardXHRResponse(this.requests.shift());
+
+  // 2s, last segment duration
+  this.clock.tick(2 * 1000);
+
+  assert.equal(refreshes, 1, 'refreshed playlist after last segment duration');
 });

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -386,7 +386,7 @@ QUnit.test('media playlists "refresh" by re-parsing master xml', function(assert
     result.playlists[0].segments.push({ duration: 2, uri: 'segment-0' });
 
     return result;
-  }
+  };
 
   loader.load();
 

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -774,8 +774,10 @@ QUnit.test('initialize audio correctly uses DASH source type', function(assert) 
 
   this.master.mediaGroups.AUDIO.aud1 = {
     // playlists are resolved, no URI for DASH
-    en: { default: true, language: 'en', playlists: [{}] },
-    fr: { default: false, language: 'fr', playlists: [{}] }
+    // use strings as playlists to simplify test to prevent playlist object code path
+    // which assumes there a MastPlaylistLoader
+    en: { default: true, language: 'en', playlists: ['playlist-1'] },
+    fr: { default: false, language: 'fr', playlists: ['playlist-2'] }
   };
   this.settings.sourceType = 'dash';
 
@@ -851,8 +853,10 @@ QUnit.test('initialize subtitles correctly uses DASH source type', function(asse
 
   this.master.mediaGroups.SUBTITLES.sub1 = {
     // playlists are resolved, no URI for DASH
-    en: { language: 'en', playlists: [{}] },
-    fr: { language: 'fr', playlists: [{}] }
+    // use strings as playlists to simplify test to prevent playlist object code path
+    // which assumes there a MastPlaylistLoader
+    en: { language: 'en', playlists: ['playlist-1'] },
+    fr: { language: 'fr', playlists: ['playlist-2'] }
   };
   this.settings.sourceType = 'dash';
 

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -81,3 +81,44 @@ QUnit.test('Advanced Bip Bop preload=none', function(assert) {
   });
 });
 
+QUnit.test('Big Buck Bunny', function(assert) {
+  let done = assert.async();
+
+  assert.expect(2);
+  let player = this.player;
+
+  player.autoplay(true);
+
+  playFor(player, 2, function() {
+    assert.ok(true, 'played for at least two seconds');
+    assert.equal(player.error(), null, 'has no player errors');
+
+    done();
+  });
+
+  player.src({
+    src: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',
+    type: 'application/dash+xml'
+  });
+});
+
+QUnit.test('Live DASH', function(assert) {
+  let done = assert.async();
+
+  assert.expect(2);
+  let player = this.player;
+
+  player.autoplay(true);
+
+  playFor(player, 2, function() {
+    assert.ok(true, 'played for at least two seconds');
+    assert.equal(player.error(), null, 'has no player errors');
+
+    done();
+  });
+
+  player.src({
+    src: 'https://vm2.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd',
+    type: 'application/dash+xml'
+  });
+});

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -178,6 +178,8 @@ QUnit.test('updateMaster updates master when new media sequence', function(asser
     }]
   };
 
+  master.playlists[media.uri] = master.playlists[0];
+
   assert.deepEqual(
     updateMaster(master, media),
     {
@@ -233,6 +235,8 @@ QUnit.test('updateMaster retains top level values in master', function(assert) {
       uri: 'segment-0-uri'
     }]
   };
+
+  master.playlists[media.uri] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -300,6 +304,8 @@ QUnit.test('updateMaster adds new segments to master', function(assert) {
       uri: 'segment-1-uri'
     }]
   };
+
+  master.playlists[media.uri] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -373,6 +379,8 @@ QUnit.test('updateMaster changes old values', function(assert) {
     }]
   };
 
+  master.playlists[media.uri] = master.playlists[0];
+
   assert.deepEqual(
     updateMaster(master, media),
     {
@@ -432,6 +440,8 @@ QUnit.test('updateMaster retains saved segment values', function(assert) {
       uri: 'segment-1-uri'
     }]
   };
+
+  master.playlists[media.uri] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -502,6 +512,8 @@ QUnit.test('updateMaster resolves key and map URIs', function(assert) {
       }
     }]
   };
+
+  master.playlists[media.uri] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -8,18 +8,8 @@ import {
   refreshDelay
 } from '../src/playlist-loader';
 import xhrFactory from '../src/xhr';
-import { useFakeEnvironment } from './test-helpers';
+import { useFakeEnvironment, urlTo } from './test-helpers';
 import window from 'global/window';
-
-// Attempts to produce an absolute URL to a given relative path
-// based on window.location.href
-const urlTo = function(path) {
-  return window.location.href
-    .split('/')
-    .slice(0, -1)
-    .concat([path])
-    .join('/');
-};
 
 QUnit.module('Playlist Loader', {
   beforeEach(assert) {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -405,3 +405,13 @@ export const playlistWithDuration = function(time, conf) {
   }
   return result;
 };
+
+// Attempts to produce an absolute URL to a given relative path
+// based on window.location.href
+export const urlTo = function(path) {
+  return window.location.href
+    .split('/')
+    .slice(0, -1)
+    .concat([path])
+    .join('/');
+};

--- a/utils/manifest/dash-live.mpd
+++ b/utils/manifest/dash-live.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:full:2011" minBufferTime="1.5" minimumUpdatePeriod="PT4S" type="dynamic" availabilityStartTime="1970-01-01T00:00:00Z" timeShiftBufferDepth="PT1H0M0S">
+  <Period start="PT0S">
+    <BaseURL>main/</BaseURL>
+    <AdaptationSet mimeType="video/mp4">
+      <BaseURL>video/</BaseURL>
+      <Representation id="1080p" bandwidth="6800000" width="1920" height="1080">
+        <BaseURL>1080/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$-segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="5" startNumber="0" />
+      </Representation>
+      <Representation id="720p" bandwidth="2400000" width="1280" height="720">
+        <BaseURL>720/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$-segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="5" startNumber="0" />
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4">
+      <BaseURL>audio/</BaseURL>
+      <Representation id="audio" bandwidth="128000">
+        <BaseURL>720/</BaseURL>
+        <SegmentTemplate media="segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="5" startNumber="0" />
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
## Description
This PR adds live support for DASH manifests. Since dash doesn't always need to update the playlists to get new segments (e.g. when template is in use, all future segments are known), playlists are "refreshed" by just re-parsing the manifest. The mpd-parser uses `Date.now` to calculate the current live window, which VHS can operate on like it does with HLS. Dash still has the concept of manifest refreshes that is separate from the live window, so the `masterPlaylistLoader` handles refreshing the xml, while the other loaders just ask the master loader for a freshly parsed xml whenever a "refresh" needs to happen.

NOTE: This will require the next version of mpd-parser that includes https://github.com/videojs/mpd-parser/pull/22

edit: merged https://github.com/mjneil/http-streaming/pull/1
