### PR TITLE
use webwackify for webworkers to support webpack bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10344,10 +10344,10 @@
         }
       }
     },
-    "webworkify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
-      "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g=="
+    "webwackify": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.3.tgz",
+      "integrity": "sha512-ttgVaQAd+9kYmZxgAuP8LMlYQRwDa8CujTEIxjXzb/XzMkF9Rg5jN7J4tus1kJvFHeINDa0MlM3pZqR+iRmkAg=="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mux.js": "4.3.2",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.2.0",
-    "webworkify": "^1.5.0"
+    "webwackify": "0.1.3"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -45,7 +45,9 @@ const workerResolve = () => {
 
   try {
     result = require.resolve('./decrypter-worker');
-  } catch (e) {}
+  } catch (e) {
+    // no result
+  }
 
   return result;
 };

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -10,7 +10,7 @@ import * as Ranges from './ranges';
 import videojs from 'video.js';
 import AdCueTags from './ad-cue-tags';
 import SyncController from './sync-controller';
-import worker from 'webworkify';
+import worker from 'webwackify';
 import Decrypter from './decrypter-worker';
 import Config from './config';
 import {
@@ -38,6 +38,16 @@ const loaderStats = [
 const sumLoaderStat = function(stat) {
   return this.audioSegmentLoader_[stat] +
          this.mainSegmentLoader_[stat];
+};
+
+const workerResolve = () => {
+  let result;
+
+  try {
+    result = require.resolve('./decrypter-worker');
+  } catch (e) {}
+
+  return result;
 };
 
 /**
@@ -105,7 +115,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       label: 'segment-metadata'
     }, false).track;
 
-    this.decrypter_ = worker(Decrypter);
+    this.decrypter_ = worker(Decrypter, workerResolve());
 
     const segmentLoaderSettings = {
       hls: this.hls_,

--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -5,9 +5,19 @@ import videojs from 'video.js';
 import createTextTracksIfNecessary from './create-text-tracks-if-necessary';
 import removeCuesFromTrack from './remove-cues-from-track';
 import {addTextTrackData} from './add-text-track-data';
-import work from 'webworkify';
+import work from 'webwackify';
 import transmuxWorker from './transmuxer-worker';
 import {isAudioCodec, isVideoCodec} from './codec-utils';
+
+const workerResolve = () => {
+  let result;
+
+  try {
+    result = require.resolve('./transmuxer-worker');
+  } catch (e) {}
+
+  return result;
+};
 
 // We create a wrapper around the SourceBuffer so that we can manage the
 // state of the `updating` property manually. We have to do this because
@@ -197,7 +207,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
 
     // append muxed segments to their respective native buffers as
     // soon as they are available
-    this.transmuxer_ = work(transmuxWorker);
+    this.transmuxer_ = work(transmuxWorker, workerResolve());
     this.transmuxer_.postMessage({action: 'init', options });
 
     this.transmuxer_.onmessage = (event) => {

--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -14,7 +14,9 @@ const workerResolve = () => {
 
   try {
     result = require.resolve('./transmuxer-worker');
-  } catch (e) {}
+  } catch (e) {
+    // no result
+  }
 
   return result;
 };

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -10,7 +10,19 @@ import {
 import { MasterPlaylistController } from '../src/master-playlist-controller';
 import SyncController from '../src/sync-controller';
 import Decrypter from '../src/decrypter-worker';
-import worker from 'webworkify';
+import worker from 'webwackify';
+
+const workerResolve = () => {
+  let result;
+
+  try {
+    result = require.resolve('../src/decrypter-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
+};
 
 /**
  * beforeEach and afterEach hooks that should be run segment loader tests regardless of
@@ -44,7 +56,7 @@ export const LoaderCommonHooks = {
     this.mediaSource = new videojs.MediaSource();
     this.mediaSource.trigger('sourceopen');
     this.syncController = new SyncController();
-    this.decrypter = worker(Decrypter);
+    this.decrypter = worker(Decrypter, workerResolve());
   },
   afterEach(assert) {
     this.env.restore();

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -3,7 +3,19 @@ import {mediaSegmentRequest, REQUEST_ERRORS} from '../src/media-segment-request'
 import xhrFactory from '../src/xhr';
 import {useFakeEnvironment} from './test-helpers';
 import Decrypter from '../src/decrypter-worker';
-import worker from 'webworkify';
+import worker from 'webwackify';
+
+const workerResolve = () => {
+  let result;
+
+  try {
+    result = require.resolve('../src/decrypter-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
+};
 
 QUnit.module('Media Segment Request', {
   beforeEach(assert) {
@@ -11,7 +23,7 @@ QUnit.module('Media Segment Request', {
     this.clock = this.env.clock;
     this.requests = this.env.requests;
     this.xhr = xhrFactory();
-    this.realDecrypter = worker(Decrypter);
+    this.realDecrypter = worker(Decrypter, workerResolve());
     this.mockDecrypter = {
       listeners: [],
       postMessage(message) {


### PR DESCRIPTION
Regarding the `require.resolve`:

webpack resolves module names to ids during compile time. One of the issues with webworkify-webpack-dropin was that it used regex to search for the `require` statements to get the resolved module id so it could properly setup the bootstrapfn to start at the right module. This broke in some cases with minification because the regex would get messed up. By passing the module id directly from require.resolve, you dont have to do any of the regex work, and can just build the entire module list and have the starting id given to you. This problem is described in more detail here https://github.com/videojs/videojs-contrib-hls/issues/600#issuecomment-293550845