### PR TITLE
ignore: Remove unecessary files from npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,14 +79,8 @@
     ]
   },
   "files": [
-    "CONTRIBUTING.md",
     "dist/",
-    "docs/",
-    "es5/",
-    "index.html",
-    "scripts/",
-    "src/",
-    "test/"
+    "es5/"
   ],
   "dependencies": {
     "aes-decrypter": "1.0.3",


### PR DESCRIPTION
## Description
Only publishes the required files for importing this module in a downstream project.

## Specific Changes proposed
Closes #56 

## Requirements Checklist
- [ ] Reviewed by Two Core Contributors