### PR TITLE
fix: videojs doesn't export individual items but an object

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -1,4 +1,4 @@
-import { EventTarget, mergeOptions } from 'video.js';
+import videojs from 'video.js';
 import { parse as parseMpd, parseUTCTiming } from 'mpd-parser';
 import {
   refreshDelay,
@@ -9,6 +9,8 @@ import {
 } from './playlist-loader';
 import resolveUrl from './resolve-url';
 import window from 'global/window';
+
+const { EventTarget, mergeOptions } = videojs;
 
 /**
  * Returns a new master manifest that is the result of merging an updated master manifest

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -11,6 +11,7 @@ import { Parser as M3u8Parser } from 'm3u8-parser';
 import window from 'global/window';
 
 const { mergeOptions, EventTarget, log } = videojs;
+
 /**
  * Loops through all supported media groups in master and calls the provided
  * callback for each group

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -6,10 +6,11 @@
  *
  */
 import resolveUrl from './resolve-url';
-import { mergeOptions, EventTarget, log } from 'video.js';
+import videojs from 'video.js';
 import { Parser as M3u8Parser } from 'm3u8-parser';
 import window from 'global/window';
 
+const { mergeOptions, EventTarget, log } = videojs;
 /**
  * Loops through all supported media groups in master and calls the provided
  * callback for each group

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -3,8 +3,10 @@
  *
  * Playlist related utilities.
  */
-import {createTimeRange} from 'video.js';
+import videojs from 'video.js';
 import window from 'global/window';
+
+const {createTimeRange} = videojs;
 
 /**
  * walk backward until we find a duration we can use

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -72,7 +72,7 @@ const INITIAL_BANDWIDTH = 4194304;
   });
 });
 
-export const simpleTypeFromSourceType = (type) => {
+const simpleTypeFromSourceType = (type) => {
   const mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
 
   if (mpegurlRE.test(type)) {
@@ -698,7 +698,7 @@ if (videojs.registerPlugin) {
   videojs.plugin('reloadSourceOnError', reloadSourceOnError);
 }
 
-export default {
+export {
   Hls,
   HlsHandler,
   HlsSourceHandler,

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -698,7 +698,7 @@ if (videojs.registerPlugin) {
   videojs.plugin('reloadSourceOnError', reloadSourceOnError);
 }
 
-module.exports = {
+export default {
   Hls,
   HlsHandler,
   HlsSourceHandler,

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -9,11 +9,12 @@
  * @param {Function} callback the callback to call when done
  * @return {Request} the xhr request that is going to be made
  */
-import {
-  xhr as videojsXHR,
-  mergeOptions,
-  default as videojs
-} from 'video.js';
+import videojs from 'video.js';
+
+const {
+  xhr: videojsXHR,
+  mergeOptions
+} = videojs;
 
 const xhrFactory = function() {
   const xhr = function XhrFunction(options, callback) {


### PR DESCRIPTION
Video.js exports an object and you can't do destructuring in imports, it's a special construct for named exports.
Also, modify the default export. Though, I can move that to a separate PR.