### PR TITLE
docs: update docs for overrideNative

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Description
 Briefly describe the issue.
-Include a [reduced test case](https://css-tricks.com/reduced-test-cases/), we have a [starter template](http://jsbin.com/nofafidabo/edit?html,output) on JSBin you can use.
+Include a [reduced test case](https://css-tricks.com/reduced-test-cases/), we have a [starter template](https://jsbin.com/gejugat/edit?html,output) on JSBin you can use.
 
 ## Sources
 Is a certain source or a certain segment affected? please provide a public (accesible over the internet) link to it below.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ Please list the specific changes involved in this pull request.
 - [ ] If necessary, more likely in a feature request than a bug fix
   - [ ] Unit Tests updated or fixed
   - [ ] Docs/guides updated
-  - [ ] Example created ([starter template on JSBin](http://jsbin.com/nofafidabo/edit?html,output))
+  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
 - [ ] Reviewed by Two Core Contributors

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ player.play();
 
 Check out our [live example](https://jsbin.com/gejugat/edit?html,output) if you're having trouble.
 
+Is it recommended to use the `<video-js>` element or load a source with `player.src(sourceObject)` in order to prevent the video element from playing the source natively where HLS is supported.
+
 ## Compatibility
 
 ### Via MSE

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Maintenance Status: Stable
 - [Contributing](#contributing)
 - [Talk to us](#talk-to-us)
 - [Getting Started](#getting-started)
+- [Compatibility](#compatibility)
+  - [Via MSE](#via-mse)
+  - [Via MSE with the [overrideNative](#overridenative) option](#via-mse-with-the-overridenativeoverridenative-option)
   - [Flash Support](#flash-support)
 - [Documentation](#documentation)
   - [Options](#options)
@@ -113,6 +116,18 @@ player.play();
 ```
 
 Check out our [live example](https://jsbin.com/gejugat/edit?html,output) if you're having trouble.
+
+## Compatibility
+
+### Via MSE
+- Chrome
+- Firefox
+- Internet Explorer 11 Windows 10 or 8.1
+
+### Via MSE with the [overrideNative](#overridenative) option
+- Chrome Android
+- Edge
+- Mac Safari
 
 ### Flash Support
 This plugin does not support Flash playback. Instead, it is recommended that users use the [videojs-flashls-source-handler](https://github.com/brightcove/videojs-flashls-source-handler) plugin as a fallback option for browsers that don't have a native
@@ -266,8 +281,7 @@ videojs-http-streaming will take over HLS playback to provide a more
 consistent experience.
 
 __NOTE__: If you use this option, you must also set
-`html5.nativeAudioTracks` and
-`html5.nativeVideoTracks` to
+`html5.nativeAudioTracks`, `html5.nativeVideoTracks` and `html5.nativeTextTracks` to
 `false`. videojs-http-streaming relies on audio and video tracks to play
 streams with alternate audio and requires additional capabilities only
 supported by non-native tracks in video.js.
@@ -277,6 +291,7 @@ var player = videojs('playerId', {
   html5: {
     nativeAudioTracks: false,
     nativeVideoTracks: false,
+    nativeTextTracks: false,
     hls: {
       overrideNative: true
     }

--- a/README.md
+++ b/README.md
@@ -283,17 +283,16 @@ videojs-http-streaming will take over HLS playback to provide a more
 consistent experience.
 
 __NOTE__: If you use this option, you must also set
-`html5.nativeAudioTracks`, `html5.nativeVideoTracks` and `html5.nativeTextTracks` to
+`html5.nativeAudioTracks` and `html5.nativeVideoTracks` to
 `false`. videojs-http-streaming relies on audio and video tracks to play
 streams with alternate audio and requires additional capabilities only
 supported by non-native tracks in video.js.
 
-```
+```javascript
 var player = videojs('playerId', {
   html5: {
     nativeAudioTracks: false,
     nativeVideoTracks: false,
-    nativeTextTracks: false,
     hls: {
       overrideNative: true
     }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Video.js Compatibility: 6.0
 - [Compatibility](#compatibility)
   - [Via MSE](#via-mse)
   - [Via MSE with the [overrideNative](#overridenative) option](#via-mse-with-the-overridenativeoverridenative-option)
+  - [Native only](#native-only)
   - [Flash Support](#flash-support)
 - [Documentation](#documentation)
   - [Options](#options)
@@ -131,7 +132,10 @@ Is it recommended to use the `<video-js>` element or load a source with `player.
 ### Via MSE with the [overrideNative](#overridenative) option
 - Chrome Android
 - Edge
+
+### Native only
 - Mac Safari
+- iOS Safari
 
 ### Flash Support
 This plugin does not support Flash playback. Instead, it is recommended that users use the [videojs-flashls-source-handler](https://github.com/brightcove/videojs-flashls-source-handler) plugin as a fallback option for browsers that don't have a native

--- a/README.md
+++ b/README.md
@@ -99,20 +99,20 @@ Drop by our slack channel (#playback) on the [Video.js slack][slack-link].
 Get a copy of [videojs-http-streaming](#installation) and include it in your page along with video.js:
 
 ```html
-<video id=example-video width=600 height=300 class="video-js vjs-default-skin" controls>
+<video-js id=vid1 width=600 height=300 class="vjs-default-skin" controls>
   <source
      src="https://example.com/index.m3u8"
      type="application/x-mpegURL">
-</video>
+</video-js>
 <script src="video.js"></script>
 <script src="videojs-http-streaming.min.js"></script>
 <script>
-var player = videojs('example-video');
+var player = videojs('vid1');
 player.play();
 </script>
 ```
 
-Check out our [live example](http://jsbin.com/vokipos/8/edit?html,output) if you're having trouble.
+Check out our [live example](https://jsbin.com/gejugat/edit?html,output) if you're having trouble.
 
 ### Flash Support
 This plugin does not support Flash playback. Instead, it is recommended that users use the [videojs-flashls-source-handler](https://github.com/brightcove/videojs-flashls-source-handler) plugin as a fallback option for browsers that don't have a native
@@ -182,20 +182,13 @@ parts of video.js:
 
 ```javascript
 // html5 for html hls
-videojs(video, {html5: {
-  hls: {
-    withCredentials: true
+videojs(video, {
+  html5: {
+    hls: {
+      withCredentials: true
+    }
   }
-}});
-
-// or
-
-var options = {hls: {
-  withCredentials: true;
-}};
-
-videojs(video, {html5: options});
-
+});
 ```
 
 ##### Source
@@ -273,11 +266,23 @@ videojs-http-streaming will take over HLS playback to provide a more
 consistent experience.
 
 __NOTE__: If you use this option, you must also set
-`videojs.options.html5.nativeAudioTracks` and
-`videojs.options.html5.nativeVideoTracks` to
+`html5.nativeAudioTracks` and
+`html5.nativeVideoTracks` to
 `false`. videojs-http-streaming relies on audio and video tracks to play
 streams with alternate audio and requires additional capabilities only
 supported by non-native tracks in video.js.
+
+```
+var player = videojs('playerId', {
+  html5: {
+    nativeAudioTracks: false,
+    nativeVideoTracks: false,
+    hls: {
+      overrideNative: true
+    }
+  }
+});
+```
 
 ##### blacklistDuration
 * Type: `number`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Lead Maintainers:
 
 Maintenance Status: Stable
 
+Video.js Compatibility: 6.0
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

--- a/README.md
+++ b/README.md
@@ -703,8 +703,9 @@ videojs-http-streaming will have created all of the files for using it in a dist
 ## Development
 
 ### Tools
-* Download stream locally with the [HLS Fetcher](https://github.com/imbcmdth/hls-fetcher)
-* Simulate errors with [Murphy](https://github.com/mrocajr/murphy)
+* Download stream locally with the [HLS Fetcher](https://github.com/videojs/hls-fetcher)
+* Simulate errors with [Murphy](https://github.com/videojs/murphy)
+* Inspect content with [Thumbcoil](http://thumb.co.il)
 
 ### Commands
 All commands for development are listed in the `package.json` file and are run using

--- a/index.html
+++ b/index.html
@@ -60,11 +60,10 @@
     (function(window, videojs) {
       var player = window.player = videojs('videojs-http-streaming-player', {
         html5: {
-          nativeAudioTracks: false,
-          nativeVideoTracks: false,
-          nativeTextTracks: false,
+          nativeAudioTracks: !!videojs.browser.IS_SAFARI,
+          nativeVideoTracks: !!videojs.browser.IS_SAFARI,
           hls: {
-            overrideNative: true
+            overrideNative: !videojs.browser.IS_SAFARI
           }
         }
       });

--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@
   <div class="info">
     <p>The video below is an <a href="https://developer.apple.com/library/ios/documentation/networkinginternet/conceptual/streamingmediaguide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40008332-CH1-SW1">HTTP Live Stream</a>.</p>
   </div>
-  <video id="videojs-http-streaming-player" class="video-js vjs-default-skin" controls>
+  <video-js id="videojs-http-streaming-player" class="vjs-default-skin" controls>
     <source src="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8" type="application/x-mpegURL">
-  </video>
+  </video-js>
 
   <form id=load-url>
     <label>
@@ -54,10 +54,20 @@
 
   <script src="node_modules/video.js/dist/video.js"></script>
   <script src="node_modules/videojs-contrib-eme/dist/videojs-contrib-eme.js"></script>
+
   <script src="dist/videojs-http-streaming.js"></script>
   <script>
     (function(window, videojs) {
-      var player = window.player = videojs('videojs-http-streaming-player');
+      var player = window.player = videojs('videojs-http-streaming-player', {
+        html5: {
+          nativeAudioTracks: false,
+          nativeVideoTracks: false,
+          nativeTextTracks: false,
+          hls: {
+            overrideNative: true
+          }
+        }
+      });
 
       // configure videojs-contrib-eme
       player.eme();

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,12 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -3344,6 +3350,42 @@
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
+    "fs-extra": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.4.5"
+      },
+      "dependencies": {
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
+      }
+    },
+    "fs-promise": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.5.0.tgz",
+      "integrity": "sha1-Q0fWv2JGVacGGkMZITw5MnatPvM=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "fs-extra": "0.26.7",
+        "mz": "2.7.0",
+        "thenify-all": "1.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5521,6 +5563,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -5691,6 +5742,22 @@
       "resolved": "https://registry.npmjs.org/karma-qunit/-/karma-qunit-1.2.1.tgz",
       "integrity": "sha1-iCUq/SEnvAOwzDGXjtaIKxOfRwo=",
       "dev": true
+    },
+    "karma-safari-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
+      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+      "dev": true
+    },
+    "karma-safaritechpreview-launcher": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/karma-safaritechpreview-launcher/-/karma-safaritechpreview-launcher-0.0.6.tgz",
+      "integrity": "sha512-2QMxAGXPQ37H3KoR9SCdh0OoktQZ5MyrxkvBiZ+VVOQfYVrcyOQXGrPea0/DKvf8qoQvrvP2FHcP/BxsuxuyHw==",
+      "dev": true,
+      "requires": {
+        "fs-promise": "0.5.0",
+        "marcosc-async": "3.0.5"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -6158,6 +6225,12 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
+    "marcosc-async": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/marcosc-async/-/marcosc-async-3.0.5.tgz",
+      "integrity": "sha1-QebVbGVsgRhZ00uXoKJgk/cdw2A=",
+      "dev": true
+    },
     "marked": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
@@ -6439,6 +6512,17 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.4.1.tgz",
       "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw=="
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
+      }
     },
     "nan": {
       "version": "2.7.0",
@@ -8185,6 +8269,24 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": "3.3.0"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -8320,9 +8422,16 @@
       "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "dev": true,
       "requires": {
+        "commander": "2.13.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8542,18 +8651,25 @@
       }
     },
     "video.js": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.2.8.tgz",
-      "integrity": "sha1-5ElxC/hRP2B0Vik64dqXVZqU+5c=",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.8.0.tgz",
+      "integrity": "sha512-Yig2ImqVQVaOidXUoKXh6tuVhRkHjeH9jMjBjwRQcsy07XDbGHzaJw9hjESHK1crIm2XnTnKXYdo24lbpNTENg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
         "safe-json-parse": "4.0.0",
         "tsml": "1.0.1",
-        "videojs-font": "2.0.0",
+        "videojs-font": "2.1.0",
         "videojs-ie8": "1.1.2",
-        "videojs-vtt.js": "0.12.4",
+        "videojs-vtt.js": "0.12.6",
         "xhr": "2.4.0"
+      },
+      "dependencies": {
+        "videojs-font": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-2.1.0.tgz",
+          "integrity": "sha1-olkwpn9snPvyu4jay4xrRR8JM3k="
+        }
       }
     },
     "videojs-contrib-eme": {
@@ -8635,13 +8751,14 @@
       "requires": {
         "browserify-versionify": "1.0.6",
         "global": "4.3.2",
-        "video.js": "6.2.8"
+        "video.js": "6.8.0"
       }
     },
     "videojs-font": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-2.0.0.tgz",
-      "integrity": "sha1-r3Rh751LleAzS/+3iy8v8DZKkDQ="
+      "integrity": "sha1-r3Rh751LleAzS/+3iy8v8DZKkDQ=",
+      "dev": true
     },
     "videojs-ie8": {
       "version": "1.1.2",
@@ -8668,9 +8785,9 @@
       "dev": true
     },
     "videojs-vtt.js": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.4.tgz",
-      "integrity": "sha1-OPJJnjHvs/qTWQ3a1MtmMnWksWE=",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.6.tgz",
+      "integrity": "sha512-XFXeGBQiljnElMhwCcZst0RDbZn2n8LU7ZScXryd3a00OaZsHAjdZu/7/RdSr7Z1jHphd45FnOvOQkGK4YrWCQ==",
       "requires": {
         "global": "4.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mpd-parser": "0.6.0",
     "mux.js": "4.4.1",
     "url-toolkit": "^2.1.3",
-    "video.js": "^6.2.0"
+    "video.js": "^6.8.0"
   },
   "devDependencies": {
     "@gkatsev/rollup-plugin-bundle-worker": "^1.0.2",
@@ -88,6 +88,8 @@
     "karma-detect-browsers": "^2.2.6",
     "karma-firefox-launcher": "^1.1.0",
     "karma-qunit": "^1.2.1",
+    "karma-safari-launcher": "^1.0.0",
+    "karma-safaritechpreview-launcher": "0.0.6",
     "lodash": "^4.17.4",
     "lodash-compat": "^3.10.0",
     "npm-run-all": "^4.1.2",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -57,6 +57,12 @@ module.exports = function(config) {
         os: 'Windows',
         os_version: '10'
       },
+      SafariBrowserStack: {
+        base: 'BrowserStack',
+        browser: 'safari',
+        os: 'OS X',
+        os_version: 'High Sierra'
+      },
       FirefoxBrowserStack: {
         base: 'BrowserStack',
         browser: 'firefox',


### PR DESCRIPTION
## Description
This PR is to clean up the `overrideNative` option

## Specific Changes proposed
- [x] Update JSbin demos and guides to use the `video-js` element, how to use `overrideNative` and prefer https

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/nofafidabo/edit?html,output))
- [ ] Reviewed by Two Core Contributors
