### PR TITLE
feat: use PlayReady license url from manifest

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -149,11 +149,16 @@ const emeKeySystems = (keySystemOptions, videoPlaylist, audioPlaylist) => {
       videoContentType: `video/mp4; codecs="${videoPlaylist.attributes.CODECS}"`
     };
 
-    if (videoPlaylist.contentProtection &&
-        videoPlaylist.contentProtection[keySystem] &&
-        videoPlaylist.contentProtection[keySystem].pssh) {
-      keySystemContentTypes[keySystem].pssh =
-        videoPlaylist.contentProtection[keySystem].pssh;
+    const contentProtection = videoPlaylist.contentProtection &&
+        videoPlaylist.contentProtection[keySystem];
+    if (contentProtection) {
+      if (contentProtection.pssh) {
+        keySystemContentTypes[keySystem].pssh = contentProtection.pssh;
+      }
+
+      if (videoPlaylist.contentProtection[keySystem].licenseUrl) {
+        keySystemContentTypes[keySystem].url = contentProtection.licenseUrl;
+      }
     }
 
     // videojs-contrib-eme accepts the option of specifying: 'com.some.cdm': 'url'


### PR DESCRIPTION
## Description
This PR uses a PlayReady license URL from the manifest.

Needs tests and https://github.com/videojs/mpd-parser/pull/26

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors