### PR TITLE
fix: minified build

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -75,6 +75,9 @@ export default [
     external: ['video.js'],
     plugins: umdPlugins
       .concat([uglify({
+        compress: {
+          typeofs: false
+        },
         output: {
           comments: 'some'
         }


### PR DESCRIPTION
## Description
The minified build seems to be broken, this fixes the build by turning off the `typeof` transform.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
