### PR TITLE
fix: make sure that es build is babelified

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -111,7 +111,8 @@ export default [
       json({
         preferConst: true
       }),
-      worker()
+      worker(),
+      babel()
     ],
     output: [{
       name: 'videojsHttpStreaming',


### PR DESCRIPTION
In videojs/video.js#5186, we noticed that the es builds weren't running babel, this can cause issues with uglify.