### PR TITLE
chore: update tests and pages for video.js 7

### DIFF
--- a/examples/multiple-alternative-audio-tracks/index.html
+++ b/examples/multiple-alternative-audio-tracks/index.html
@@ -15,7 +15,7 @@
       <select id="enabled-audio-track" name="enabled-audio-track">
       </select>
     </div>
-    <script src="/node_modules/video.js/dist/video.js"></script>
+    <script src="/node_modules/video.js/dist/alt/video.core.js"></script>
     <script src="/dist/videojs-http-streaming.js"></script>
     <script>
       (function(window, videojs) {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <li><a href="examples">Browse Examples</a></li>
   </ul>
 
-  <script src="node_modules/video.js/dist/video.js"></script>
+  <script src="node_modules/video.js/dist/alt/video.core.js"></script>
   <script src="node_modules/videojs-contrib-eme/dist/videojs-contrib-eme.js"></script>
 
   <script src="dist/videojs-http-streaming.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,20 @@
       "integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==",
       "dev": true
     },
+    "@videojs/http-streaming": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-1.0.2.tgz",
+      "integrity": "sha512-AM+n4O1KhzbjzjAWBFAwRm2dh2YEB+HSWW159H/xz1VR4BvqkB0c+9GSGJIuFytjqCf7LJhAVGWN/e2BBSAzwg==",
+      "requires": {
+        "aes-decrypter": "3.0.0",
+        "global": "4.3.2",
+        "m3u8-parser": "4.2.0",
+        "mpd-parser": "0.6.1",
+        "mux.js": "4.4.1",
+        "url-toolkit": "2.1.3",
+        "video.js": "7.0.3"
+      }
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -2749,7 +2763,8 @@
     "es5-shim": {
       "version": "4.5.9",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
-      "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA="
+      "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA=",
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -8651,24 +8666,24 @@
       }
     },
     "video.js": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.8.0.tgz",
-      "integrity": "sha512-Yig2ImqVQVaOidXUoKXh6tuVhRkHjeH9jMjBjwRQcsy07XDbGHzaJw9hjESHK1crIm2XnTnKXYdo24lbpNTENg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.0.3.tgz",
+      "integrity": "sha512-/ShuukEmxQy8O4MmKfRaTfeFdFKGfa8XdpHvnM6p41ifhobN1NW5oloasAETfGHVyoXB9lMY7v3Ajs8unkwnFA==",
       "requires": {
+        "@videojs/http-streaming": "1.0.2",
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
         "safe-json-parse": "4.0.0",
         "tsml": "1.0.1",
-        "videojs-font": "2.1.0",
-        "videojs-ie8": "1.1.2",
-        "videojs-vtt.js": "0.12.6",
+        "videojs-font": "3.0.0",
+        "videojs-vtt.js": "0.14.1",
         "xhr": "2.4.0"
       },
       "dependencies": {
         "videojs-font": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-2.1.0.tgz",
-          "integrity": "sha1-olkwpn9snPvyu4jay4xrRR8JM3k="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.0.0.tgz",
+          "integrity": "sha512-XS6agz2T7p2cFuuXulJD70md8XMlAN617SJkMWjoTPqZWv+RU8NcZCKsE3Tk73inzxnQdihOp0cvI7NGz2ngHg=="
         }
       }
     },
@@ -8751,7 +8766,40 @@
       "requires": {
         "browserify-versionify": "1.0.6",
         "global": "4.3.2",
-        "video.js": "6.8.0"
+        "video.js": "6.10.1"
+      },
+      "dependencies": {
+        "video.js": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.10.1.tgz",
+          "integrity": "sha512-LW6aVunBFlfnvL986U/E77tfcbNBz23R0IPqZFlerL/y5nRWktrl/CFd3SyYPyHsnQQg+TyHQR0xT2UbN+wnpQ==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "global": "4.3.2",
+            "safe-json-parse": "4.0.0",
+            "tsml": "1.0.1",
+            "videojs-font": "2.1.0",
+            "videojs-ie8": "1.1.2",
+            "videojs-vtt.js": "0.12.6",
+            "xhr": "2.4.0"
+          }
+        },
+        "videojs-font": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-2.1.0.tgz",
+          "integrity": "sha1-olkwpn9snPvyu4jay4xrRR8JM3k=",
+          "dev": true
+        },
+        "videojs-vtt.js": {
+          "version": "0.12.6",
+          "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.6.tgz",
+          "integrity": "sha512-XFXeGBQiljnElMhwCcZst0RDbZn2n8LU7ZScXryd3a00OaZsHAjdZu/7/RdSr7Z1jHphd45FnOvOQkGK4YrWCQ==",
+          "dev": true,
+          "requires": {
+            "global": "4.3.2"
+          }
+        }
       }
     },
     "videojs-font": {
@@ -8764,6 +8812,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/videojs-ie8/-/videojs-ie8-1.1.2.tgz",
       "integrity": "sha1-oj09hgitcZK2nGB3/E64SJmNNdk=",
+      "dev": true,
       "requires": {
         "es5-shim": "4.5.9"
       }
@@ -8785,9 +8834,9 @@
       "dev": true
     },
     "videojs-vtt.js": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.6.tgz",
-      "integrity": "sha512-XFXeGBQiljnElMhwCcZst0RDbZn2n8LU7ZScXryd3a00OaZsHAjdZu/7/RdSr7Z1jHphd45FnOvOQkGK4YrWCQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.14.1.tgz",
+      "integrity": "sha512-YxOiywx6N9t3J5nqsE5WN2Sw4CSqVe3zV+AZm2T4syOc2buNJaD6ZoexSdeszx2sHLU/RRo2r4BJAXFDQ7Qo2Q==",
       "requires": {
         "global": "4.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mpd-parser": "0.6.1",
     "mux.js": "4.4.1",
     "url-toolkit": "^2.1.3",
-    "video.js": "^6.8.0 || ^7.0.0"
+    "video.js": "^6.8.0 || ^7.0.3"
   },
   "devDependencies": {
     "@gkatsev/rollup-plugin-bundle-worker": "^1.0.2",

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,7 @@
   <!-- NOTE in order for test to pass we require sinon 1.10.2 exactly -->
   <script src="../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
-  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../node_modules/video.js/dist/alt/video.core.js"></script>
   <script src="../dist-test/videojs-http-streaming.test.js"></script>
 
 </body>

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
     },
     files: [
       'node_modules/sinon/pkg/sinon.js',
-      'node_modules/video.js/dist/video.js',
+      'node_modules/video.js/dist/alt/video.core.js',
       'node_modules/video.js/dist/video-js.css',
       'dist-test/videojs-http-streaming.test.js'
     ],

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -7,7 +7,7 @@
   <link href="../../node_modules/video.js/dist/video-js.css" rel="stylesheet">
 
   <!-- video.js -->
-  <script src="../../node_modules/video.js/dist/alt/video.novtt.js"></script>
+  <script src="../../node_modules/video.js/dist/alt/video.core.js"></script>
 
   <!-- EME (Encrypted Media Extensions) plugin -->
   <script src="../../node_modules/videojs-contrib-eme/dist/videojs-contrib-eme.js"></script>

--- a/utils/switcher/index.html
+++ b/utils/switcher/index.html
@@ -189,7 +189,7 @@
   </div>
   <div id="qunit-fixture"></div>
   <script src="/node_modules/sinon/pkg/sinon.js"></script>
-  <script src="/node_modules/video.js/dist/video.js"></script>
+  <script src="/node_modules/video.js/dist/alt/video.core.js"></script>
   <script src="/node_modules/d3/d3.min.js"></script>
   <script src="/dist-test/switcher.js"></script>
 </body>


### PR DESCRIPTION
## Description
This PR updates all references to the video.js script to video.core.js so that VHS doesn't double up. This isn't totally necessary since VHS should be prepended to the source handler list but it's better to be safe.

This PR requires https://github.com/videojs/video.js/pull/5220

## Requirements Checklist
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
