### PR TITLE
feat(captions): write in-band captions from DASH fmp4 segments to the textTrack API

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -106,6 +106,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     }, false).track;
 
     this.decrypter_ = new Decrypter();
+    this.inbandTextTracks_ = {};
 
     const segmentLoaderSettings = {
       hls: this.hls_,
@@ -119,7 +120,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       bandwidth,
       syncController: this.syncController_,
       decrypter: this.decrypter_,
-      sourceType: this.sourceType_
+      sourceType: this.sourceType_,
+      inbandTextTracks: this.inbandTextTracks_
     };
 
     this.masterPlaylistLoader_ = this.sourceType_ === 'dash' ?

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
 import { createTransferableMessage } from './bin-utils';
+import mp4probe from 'mux.js/lib/mp4/probe';
 
 export const REQUEST_ERRORS = {
   FAILURE: 2,
@@ -227,6 +228,12 @@ const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) 
     segment.encryptedBytes = new Uint8Array(request.response);
   } else {
     segment.bytes = new Uint8Array(request.response);
+  }
+
+  // TODO: wip
+  // This is an FMP4 and has the init segment
+  if (segment.map && segment.map.bytes) {
+    segment.captions = mp4probe.parseEmbeddedCaptions(segment.map.bytes, segment.bytes);
   }
 
   return finishProcessingFn(null, segment);

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -1,6 +1,6 @@
 import videojs from 'video.js';
 import { createTransferableMessage } from './bin-utils';
-import mp4probe from 'mux.js/lib/mp4/probe';
+import { captionsParser } from 'mux.js/lib/mp4';
 
 export const REQUEST_ERRORS = {
   FAILURE: 2,
@@ -233,7 +233,7 @@ const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) 
   // TODO: wip
   // This is an FMP4 and has the init segment
   if (segment.map && segment.map.bytes) {
-    segment.captions = mp4probe.parseEmbeddedCaptions(segment.map.bytes, segment.bytes);
+    segment.captions = captionsParser.parse(segment.map.bytes, segment.bytes);
   }
 
   return finishProcessingFn(null, segment);

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -230,7 +230,6 @@ const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) 
     segment.bytes = new Uint8Array(request.response);
   }
 
-  // TODO: wip
   // This is an FMP4 and has the init segment
   if (segment.map && segment.map.bytes) {
     segment.captions = captionsParser.parse(segment.map.bytes, segment.bytes);

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -172,7 +172,7 @@ const handleKeyResponse = (segment, finishProcessingFn) => (error, request) => {
  * @param {Function} finishProcessingFn - a callback to execute to continue processing
  *                                        this request
  */
-const handleInitSegmentResponse = (segment, captionsParser, finishProcessingFn) => (error, request) => {
+const handleInitSegmentResponse = (segment, captionParser, finishProcessingFn) => (error, request) => {
   const response = request.response;
   const errorObj = handleErrors(error, request);
 
@@ -192,9 +192,9 @@ const handleInitSegmentResponse = (segment, captionsParser, finishProcessingFn) 
 
   segment.map.bytes = new Uint8Array(request.response);
 
-  // Initialize CaptionsParser if it hasn't been yet
-  if (!captionsParser.isInitialized()) {
-    captionsParser.init();
+  // Initialize CaptionParser if it hasn't been yet
+  if (!captionParser.isInitialized()) {
+    captionParser.init();
   }
 
   segment.map.timescales = mp4probe.timescale(segment.map.bytes);
@@ -213,7 +213,7 @@ const handleInitSegmentResponse = (segment, captionsParser, finishProcessingFn) 
  * @param {Function} finishProcessingFn - a callback to execute to continue processing
  *                                        this request
  */
-const handleSegmentResponse = (segment, captionsParser, finishProcessingFn) => (error, request) => {
+const handleSegmentResponse = (segment, captionParser, finishProcessingFn) => (error, request) => {
   const response = request.response;
   const errorObj = handleErrors(error, request);
   let parsed;
@@ -241,14 +241,14 @@ const handleSegmentResponse = (segment, captionsParser, finishProcessingFn) => (
   }
 
   // This is likely an FMP4 and has the init segment.
-  // Run through the CaptionsParser in case there are captions.
+  // Run through the CaptionParser in case there are captions.
   if (segment.map && segment.map.bytes) {
-    // Initialize CaptionsParser if it hasn't been yet
-    if (!captionsParser.isInitialized()) {
-      captionsParser.init();
+    // Initialize CaptionParser if it hasn't been yet
+    if (!captionParser.isInitialized()) {
+      captionParser.init();
     }
 
-    parsed = captionsParser.parse(
+    parsed = captionParser.parse(
       segment.bytes,
       segment.map.videoTrackIds,
       segment.map.timescales);
@@ -423,7 +423,7 @@ const handleProgress = (segment, progressFn) => (event) => {
 export const mediaSegmentRequest = (xhr,
                                     xhrOptions,
                                     decryptionWorker,
-                                    captionsParser,
+                                    captionParser,
                                     segment,
                                     progressFn,
                                     doneFn) => {
@@ -451,7 +451,7 @@ export const mediaSegmentRequest = (xhr,
       headers: segmentXhrHeaders(segment.map)
     });
     const initSegmentRequestCallback = handleInitSegmentResponse(segment,
-                                                                 captionsParser,
+                                                                 captionParser,
                                                                  finishProcessingFn);
     const initSegmentXhr = xhr(initSegmentOptions, initSegmentRequestCallback);
 
@@ -464,7 +464,7 @@ export const mediaSegmentRequest = (xhr,
     headers: segmentXhrHeaders(segment)
   });
   const segmentRequestCallback = handleSegmentResponse(segment,
-                                                       captionsParser,
+                                                       captionParser,
                                                        finishProcessingFn);
   const segmentXhr = xhr(segmentRequestOptions, segmentRequestCallback);
 

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -207,6 +207,7 @@ const handleInitSegmentResponse = (segment, finishProcessingFn) => (error, reque
 const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) => {
   const response = request.response;
   const errorObj = handleErrors(error, request);
+  let parsedCaptions;
 
   if (errorObj) {
     return finishProcessingFn(errorObj, segment);
@@ -232,7 +233,11 @@ const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) 
 
   // This is an FMP4 and has the init segment
   if (segment.map && segment.map.bytes) {
-    segment.captions = captionsParser.parse(segment.map.bytes, segment.bytes);
+    parsedCaptions = captionsParser.parse(segment.map.bytes, segment.bytes);
+    if (parsedCaptions) {
+      segment.fmp4Captions = parsedCaptions.captions;
+      segment.captionStreams = parsedCaptions.captionStreams;
+    }
   }
 
   return finishProcessingFn(null, segment);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -12,6 +12,7 @@ import { mediaSegmentRequest, REQUEST_ERRORS } from './media-segment-request';
 import { TIME_FUDGE_FACTOR, timeUntilRebuffer as timeUntilRebuffer_ } from './ranges';
 import { minRebufferMaxBandwidthSelector } from './playlist-selectors';
 import logger from './util/logger';
+import handleCaptions from './util/608-captions';
 
 // in ms
 const CHECK_BUFFER_DELAY = 500;
@@ -1112,6 +1113,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     segmentInfo.endOfAllRequests = simpleSegment.endOfAllRequests;
+
+    // TODO: wip
+    if (simpleSegment.map && simpleSegment.captions) {
+      handleCaptions(this.mediaSource_, this.sourceUpdater_.sourceBuffer_, simpleSegment);
+    }
+
     this.handleSegment_();
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1114,7 +1114,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     segmentInfo.endOfAllRequests = simpleSegment.endOfAllRequests;
 
-    // TODO: wip
+    // This is an fmp4 with captions
     if (simpleSegment.map && simpleSegment.captions) {
       handleCaptions(this.mediaSource_, this.sourceUpdater_.sourceBuffer_, simpleSegment);
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -12,7 +12,7 @@ import { mediaSegmentRequest, REQUEST_ERRORS } from './media-segment-request';
 import { TIME_FUDGE_FACTOR, timeUntilRebuffer as timeUntilRebuffer_ } from './ranges';
 import { minRebufferMaxBandwidthSelector } from './playlist-selectors';
 import { addCaptionData, createCaptionsTrackIfNotExists } from './util/text-tracks';
-import { CaptionsParser } from 'mux.js/lib/mp4';
+import { CaptionParser } from 'mux.js/lib/mp4';
 import logger from './util/logger';
 
 // in ms
@@ -183,8 +183,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Fragmented mp4 playback
     this.activeInitSegmentId_ = null;
     this.initSegments_ = {};
-    // Fmp4 CaptionsParser
-    this.captionsParser_ = new CaptionsParser();
+    // Fmp4 CaptionParser
+    this.captionParser_ = new CaptionParser();
 
     this.decrypter_ = settings.decrypter;
 
@@ -245,7 +245,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.sourceUpdater_.dispose();
     }
     this.resetStats_();
-    this.captionsParser_.reset();
+    this.captionParser_.reset();
   }
 
   /**
@@ -553,7 +553,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.resetLoader();
     this.remove(0, this.duration_());
     // clears fmp4 captions
-    this.captionsParser_.clearAllCaptions();
+    this.captionParser_.clearAllCaptions();
     this.trigger('reseteverything');
   }
 
@@ -688,7 +688,7 @@ export default class SegmentLoader extends videojs.EventTarget {
         segmentInfo.startOfSegment < this.sourceUpdater_.timestampOffset())) {
       this.syncController_.reset();
       segmentInfo.timestampOffset = segmentInfo.startOfSegment;
-      this.captionsParser_.clearAllCaptions();
+      this.captionParser_.clearAllCaptions();
     }
 
     this.loadSegment_(segmentInfo);
@@ -970,7 +970,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     segmentInfo.abortRequests = mediaSegmentRequest(this.hls_.xhr,
       this.xhrOptions_,
       this.decrypter_,
-      this.captionsParser_,
+      this.captionParser_,
       this.createSimplifiedSegmentObj_(segmentInfo),
       // progress callback
       this.handleProgress_.bind(this),
@@ -1146,7 +1146,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       });
       // Reset stored captions since we added parsed
       // captions to a text track at this point
-      this.captionsParser_.clearParsedCaptions();
+      this.captionParser_.clearParsedCaptions();
     }
 
     this.handleSegment_();

--- a/src/util/608-captions.js
+++ b/src/util/608-captions.js
@@ -1,0 +1,47 @@
+const getOrCreateTextTrack = function(mediaSource, caption) {
+  const player = mediaSource.player_;
+  const trackId = caption.stream;
+  let track = player.textTracks().getTrackById(trackId);
+
+  if (!track) {
+    track = player.addRemoteTextTrack({
+      kind: 'captions',
+      id: trackId,
+      label: trackId
+    }, false).track;
+  }
+
+  return track;
+};
+
+const addTextTrackData = function(track, caption) {
+  const Cue = window.WebKitDataCue || window.VTTCue;
+
+  track.addCue(
+    new Cue(
+      caption.startTime,
+      caption.endTime,
+      caption.text
+    ));
+};
+
+const handleCaptions = function(sourceHandler, sourceBuffer, segment) {
+  var player = sourceHandler.player_;
+
+  // Match the contract
+  if (segment.captions.length) {
+    for (var i = 0; i < segment.captions.length; i ++) {
+      const caption = segment.captions[i];
+      let track;
+
+      caption.startTime = caption.startPts / 90e3;
+      caption.endTime = caption.endPts / 90e3;
+
+      track = getOrCreateTextTrack(sourceHandler, caption);
+
+      addTextTrackData(track, caption);
+    }
+  }
+};
+
+export default handleCaptions;

--- a/src/util/608-captions.js
+++ b/src/util/608-captions.js
@@ -28,7 +28,6 @@ const addTextTrackData = function(track, caption) {
 const handleCaptions = function(sourceHandler, sourceBuffer, segment) {
   var player = sourceHandler.player_;
 
-  // Match the contract
   if (segment.captions.length) {
     for (var i = 0; i < segment.captions.length; i ++) {
       const caption = segment.captions[i];

--- a/src/util/608-captions.js
+++ b/src/util/608-captions.js
@@ -32,12 +32,7 @@ const handleCaptions = function(sourceHandler, sourceBuffer, segment) {
   if (segment.captions.length) {
     for (var i = 0; i < segment.captions.length; i ++) {
       const caption = segment.captions[i];
-      let track;
-
-      caption.startTime = caption.startPts / 90e3;
-      caption.endTime = caption.endPts / 90e3;
-
-      track = getOrCreateTextTrack(sourceHandler, caption);
+      let track = getOrCreateTextTrack(sourceHandler, caption);
 
       addTextTrackData(track, caption);
     }

--- a/src/util/608-captions.js
+++ b/src/util/608-captions.js
@@ -1,41 +1,63 @@
-const getOrCreateTextTrack = function(mediaSource, caption) {
-  const player = mediaSource.player_;
-  const trackId = caption.stream;
-  let track = player.textTracks().getTrackById(trackId);
+/**
+ * Create captions text tracks on video.js if they do not exist
+ *
+ * @param {Object} inbandTextTracks a reference to current inbandTextTracks
+ * @param {Object} tech the video.js tech
+ * @param {Object} captionStreams the caption streams to create
+ * @private
+ */
+export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, captionStreams) {
+  for (let trackId in captionStreams) {
+    if (!inbandTextTracks[trackId]) {
+      tech.trigger({type: 'usage', name: 'hls-608'});
+      let track = tech.textTracks().getTrackById(trackId);
 
-  if (!track) {
-    track = player.addRemoteTextTrack({
-      kind: 'captions',
-      id: trackId,
-      label: trackId
-    }, false).track;
-  }
-
-  return track;
-};
-
-const addTextTrackData = function(track, caption) {
-  const Cue = window.WebKitDataCue || window.VTTCue;
-
-  track.addCue(
-    new Cue(
-      caption.startTime,
-      caption.endTime,
-      caption.text
-    ));
-};
-
-const handleCaptions = function(sourceHandler, sourceBuffer, segment) {
-  var player = sourceHandler.player_;
-
-  if (segment.captions.length) {
-    for (var i = 0; i < segment.captions.length; i ++) {
-      const caption = segment.captions[i];
-      let track = getOrCreateTextTrack(sourceHandler, caption);
-
-      addTextTrackData(track, caption);
+      if (track) {
+        // Resuse an existing track with a CC# id because this was
+        // very likely created by videojs-contrib-hls from information
+        // in the m3u8 for us to use
+        inbandTextTracks[trackId] = track;
+      } else {
+        // Otherwise, create a track with the default `CC#` label and
+        // without a language
+        inbandTextTracks[trackId] = tech.addRemoteTextTrack({
+          kind: 'captions',
+          id: trackId,
+          label: trackId
+        }, false).track;
+      }
     }
   }
 };
 
-export default handleCaptions;
+export const addCaptionData = function({
+    inbandTextTracks,
+    captionArray,
+    timestampOffset
+  }) {
+    if (!captionArray) {
+      return;
+    }
+
+    const Cue = window.WebKitDataCue || window.VTTCue;
+
+    captionArray.forEach((caption) => {
+      const track = caption.stream;
+      let startTime = caption.startTime;
+      let endTime = caption.endTime;
+
+      if (!inbandTextTracks[track]) {
+        return;
+      }
+
+      startTime += timestampOffset;
+      endTime += timestampOffset;
+
+      inbandTextTracks[track].addCue(
+        new Cue(
+          startTime,
+          endTime,
+          caption.text
+        ));
+    });
+  };

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -35,29 +35,29 @@ export const addCaptionData = function({
     captionArray,
     timestampOffset
   }) {
-    if (!captionArray) {
+  if (!captionArray) {
+    return;
+  }
+
+  const Cue = window.WebKitDataCue || window.VTTCue;
+
+  captionArray.forEach((caption) => {
+    const track = caption.stream;
+    let startTime = caption.startTime;
+    let endTime = caption.endTime;
+
+    if (!inbandTextTracks[track]) {
       return;
     }
 
-    const Cue = window.WebKitDataCue || window.VTTCue;
+    startTime += timestampOffset;
+    endTime += timestampOffset;
 
-    captionArray.forEach((caption) => {
-      const track = caption.stream;
-      let startTime = caption.startTime;
-      let endTime = caption.endTime;
-
-      if (!inbandTextTracks[track]) {
-        return;
-      }
-
-      startTime += timestampOffset;
-      endTime += timestampOffset;
-
-      inbandTextTracks[track].addCue(
-        new Cue(
-          startTime,
-          endTime,
-          caption.text
-        ));
-    });
-  };
+    inbandTextTracks[track].addCue(
+      new Cue(
+        startTime,
+        endTime,
+        caption.text
+      ));
+  });
+};

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -28,6 +28,19 @@ QUnit.module('Media Segment Request', {
         this.listeners = this.listeners.filter((fn)=>fn !== listener);
       }
     };
+    this.mockCaptionParser = {
+      initialized: false,
+      parsed: false,
+      isInitialized() {
+        return this.initialized;
+      },
+      init() {
+        this.initialized = true;
+      },
+      parse(segment, videoTrackIds, timescales) {
+        this.parsed = true;
+      }
+    };
     this.xhrOptions = {
       timeout: 1000
     };
@@ -47,6 +60,7 @@ QUnit.test('cancels outstanding segment request on abort', function(assert) {
   const abort = mediaSegmentRequest(
     this.xhr,
     this.xhrOptions,
+    this.noop,
     this.noop,
     { resolvedUri: '0-test.ts' },
     this.noop,
@@ -77,6 +91,7 @@ QUnit.test('cancels outstanding key requests on abort', function(assert) {
   const abort = mediaSegmentRequest(
     this.xhr,
     this.xhrOptions,
+    this.noop,
     this.noop,
     {
       resolvedUri: '0-test.ts',
@@ -116,6 +131,7 @@ QUnit.test('cancels outstanding key requests on failure', function(assert) {
     this.xhr,
     this.xhrOptions,
     this.noop,
+    this.noop,
     {
       resolvedUri: '0-test.ts',
       key: {
@@ -150,6 +166,7 @@ QUnit.test('cancels outstanding key requests on timeout', function(assert) {
   mediaSegmentRequest(
     this.xhr,
     this.xhrOptions,
+    this.noop,
     this.noop,
     {
       resolvedUri: '0-test.ts',
@@ -197,6 +214,7 @@ QUnit.test('the key response is converted to the correct format', function(asser
     this.xhr,
     this.xhrOptions,
     this.mockDecrypter,
+    this.noop,
     {
       resolvedUri: '0-test.ts',
       key: {
@@ -237,6 +255,7 @@ QUnit.test('segment with key has bytes decrypted', function(assert) {
     this.xhr,
     this.xhrOptions,
     this.realDecrypter,
+    this.noop,
     {
       resolvedUri: '0-test.ts',
       key: {
@@ -282,6 +301,7 @@ function(assert) {
     this.xhr,
     this.xhrOptions,
     this.realDecrypter,
+    this.mockCaptionParser,
     {
       resolvedUri: '0-test.ts',
       key: {
@@ -328,4 +348,135 @@ function(assert) {
 
   // Allow the decrypter to decrypt
   this.clock.tick(100);
+});
+
+QUnit.test('non-TS segment will get parsed for captions', function(assert) {
+  const done = assert.async();
+
+  mediaSegmentRequest(
+    this.xhr,
+    this.xhrOptions,
+    this.mockDecrypter,
+    this.mockCaptionParser,
+    {
+      resolvedUri: '0-test.m4s',
+      map: {
+        resolvedUri: '0-init.mp4'
+      }
+    },
+    this.noop,
+    (error, segmentData) => {
+      assert.notOk(error, 'there are no errors');
+      assert.ok(segmentData.map.bytes, 'init segment bytes in map');
+
+      // verify stats
+      assert.equal(segmentData.stats.bytesReceived, 8, '8 bytes');
+      // verify cached map
+      assert.ok(segmentData.map.timescales, 'looked for timescales');
+      assert.ok(segmentData.map.videoTrackIds, 'looked for videoTrackIds');
+      // verify the caption parser
+      assert.equal(this.mockCaptionParser.parsed, true, 'tried to parse captions');
+      done();
+    });
+
+  assert.equal(this.requests.length, 2, 'there are two requests');
+
+  const initReq = this.requests.shift();
+  const segmentReq = this.requests.shift();
+
+  assert.equal(initReq.uri, '0-init.mp4', 'the first request is for the init segment');
+  assert.equal(segmentReq.uri, '0-test.m4s', 'the second request is for a segment');
+
+  initReq.response = new Uint32Array([0, 1, 2, 3]).buffer;
+  initReq.respond(200, null, '');
+  this.clock.tick(200);
+
+  segmentReq.response = new Uint8Array(8).buffer;
+  segmentReq.respond(200, null, '');
+  this.clock.tick(200);
+});
+
+QUnit.test('non-TS segment will get parsed for captions on next segment request if init is late', function(assert) {
+  const done = assert.async();
+  let initBytes;
+
+  mediaSegmentRequest(
+    this.xhr,
+    this.xhrOptions,
+    this.mockDecrypter,
+    this.mockCaptionParser,
+    {
+      resolvedUri: '0-test.m4s',
+      map: {
+        resolvedUri: '0-init.mp4'
+      }
+    },
+    this.noop,
+    (error, segmentData) => {
+      assert.notOk(error, 'there are no errors');
+      assert.ok(segmentData.map.bytes, 'init segment bytes in map');
+      initBytes = segmentData.map.bytes;
+
+      // verify stats
+      assert.equal(segmentData.stats.bytesReceived, 8, '8 bytes');
+      // verify cached map
+      assert.ok(segmentData.map.timescales, 'looked for timescales');
+      assert.ok(segmentData.map.videoTrackIds, 'looked for videoTrackIds');
+      // verify the caption parser
+      assert.equal(this.mockCaptionParser.parsed, false, 'tried to parse captions');
+    });
+
+  assert.equal(this.requests.length, 2, 'there are two requests');
+
+  let initReq = this.requests.shift();
+  let segmentReq = this.requests.shift();
+
+  assert.equal(initReq.uri, '0-init.mp4', 'the first request is for the init segment');
+  assert.equal(segmentReq.uri, '0-test.m4s', 'the second request is for a segment');
+
+  segmentReq.response = new Uint8Array(8).buffer;
+  segmentReq.respond(200, null, '');
+  this.clock.tick(200);
+
+  initReq.response = new Uint32Array([0, 1, 2, 3]).buffer;
+  initReq.respond(200, null, '');
+  this.clock.tick(200);
+
+  mediaSegmentRequest(
+    this.xhr,
+    this.xhrOptions,
+    this.mockDecrypter,
+    this.mockCaptionParser,
+    {
+      resolvedUri: '1-test.m4s',
+      map: {
+        resolvedUri: '0-init.mp4',
+        bytes: initBytes,
+        timescales: {},
+        videoTrackIds: [1]
+      }
+    },
+    this.noop,
+    (error, segmentData) => {
+      assert.notOk(error, 'there are no errors');
+      assert.ok(segmentData.map.bytes, 'init segment bytes in map');
+
+      // verify stats
+      assert.equal(segmentData.stats.bytesReceived, 8, '8 bytes');
+      // verify cached map
+      assert.ok(segmentData.map.timescales, 'looked for timescales');
+      assert.ok(segmentData.map.videoTrackIds, 'looked for videoTrackIds');
+      // verify the caption parser
+      assert.equal(this.mockCaptionParser.parsed, true, 'tried to parse captions');
+      done();
+    });
+
+  assert.equal(this.requests.length, 1, 'there is one request');
+
+  segmentReq = this.requests.shift();
+  assert.equal(segmentReq.uri, '1-test.m4s', 'the next request is for a segment');
+
+  segmentReq.response = new Uint8Array(8).buffer;
+  segmentReq.respond(200, null, '');
+  this.clock.tick(200);
 });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -950,20 +950,20 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
       this.startTime.restore();
     });
 
-    QUnit.test(`CaptionsParser is handled as expected`,
+    QUnit.test(`CaptionParser is handled as expected`,
     function(assert) {
-      let mockCaptionsParserReset;
-      let mockCaptionsParserClear;
-      let mockCaptionsParserClearParsedCaptions;
+      let mockCaptionParserReset;
+      let mockCaptionParserClear;
+      let mockCaptionParserClearParsedCaptions;
       let originalCurrentTimeline;
       let originalPendingSegment;
       let segment;
 
-      assert.ok(loader.captionsParser_, 'there is a captions parser');
+      assert.ok(loader.captionParser_, 'there is a captions parser');
 
-      mockCaptionsParserReset = sinon.stub(loader.captionsParser_, 'reset');
-      mockCaptionsParserClear = sinon.stub(loader.captionsParser_, 'clearAllCaptions');
-      mockCaptionsParserClearParsedCaptions = sinon.stub(loader.captionsParser_, 'clearParsedCaptions');
+      mockCaptionParserReset = sinon.stub(loader.captionParser_, 'reset');
+      mockCaptionParserClear = sinon.stub(loader.captionParser_, 'clearAllCaptions');
+      mockCaptionParserClearParsedCaptions = sinon.stub(loader.captionParser_, 'clearParsedCaptions');
 
       loader.load();
       loader.playlist(playlistWithDuration(10, 'm4s'));
@@ -972,16 +972,16 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
       loader.mimeType(this.mimeType);
       this.clock.tick(1);
       assert.equal(this.requests.length, 1, 'made a request');
-      assert.equal(mockCaptionsParserClear.callCount, 2, 'captions cleared on load and mimeType');
+      assert.equal(mockCaptionParserClear.callCount, 2, 'captions cleared on load and mimeType');
 
       // Simulate a rendition switch
       loader.resetEverything();
-      assert.equal(mockCaptionsParserClear.callCount, 3, 'captions cleared on rendition switch');
+      assert.equal(mockCaptionParserClear.callCount, 3, 'captions cleared on rendition switch');
 
       // Simulate a discontinuity
       originalCurrentTimeline = loader.currentTimeline_;
       loader.currentTimeline_ = originalCurrentTimeline + 1;
-      assert.equal(mockCaptionsParserClear.callCount, 3, 'captions cleared on discontinuity');
+      assert.equal(mockCaptionParserClear.callCount, 3, 'captions cleared on discontinuity');
       loader.currentTimeline_ = originalCurrentTimeline;
 
       // Add to the inband text track, then call remove
@@ -994,7 +994,7 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
       assert.equal(this.inbandTextTracks.CC1.cues.length, 0, 'all cues have been removed');
 
       // Check that captions are added to track when found in the segment
-      // and then captionsParser is cleared
+      // and then captionParser is cleared
       segment = {
         resolvedUri: '0.m4s',
         bytes: new Uint8Array([0, 0, 1]),
@@ -1022,12 +1022,12 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
       loader.processSegmentResponse_(segment);
       assert.ok(this.inbandTextTracks.CC1, 'text track created');
       assert.ok(this.inbandTextTracks.CC1.cues.length, 1, 'cue added');
-      assert.equal(mockCaptionsParserClearParsedCaptions.callCount, 1, 'captions cleared after adding to text track');
+      assert.equal(mockCaptionParserClearParsedCaptions.callCount, 1, 'captions cleared after adding to text track');
       loader.pendingSegment_ = originalPendingSegment;
 
       // Dispose the loader
       loader.dispose();
-      assert.equal(mockCaptionsParserReset.callCount, 1, 'CaptionsParser reset');
+      assert.equal(mockCaptionParserReset.callCount, 1, 'CaptionParser reset');
     });
   });
 });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -129,7 +129,7 @@ function(assert) {
     'within target duration');
 });
 
-QUnit.module('SegmentLoader', function(hooks) {
+QUnit.module('SegmentLoader: M2TS', function(hooks) {
   hooks.beforeEach(LoaderCommonHooks.beforeEach);
   hooks.afterEach(LoaderCommonHooks.afterEach);
 
@@ -908,6 +908,126 @@ QUnit.module('SegmentLoader', function(hooks) {
       this.requests.shift().respond(200, null, '');
 
       assert.equal(errors.length, 0, 'no errors');
+    });
+  });
+});
+
+QUnit.module('SegmentLoader: FMP4', function(hooks) {
+  hooks.beforeEach(LoaderCommonHooks.beforeEach);
+  hooks.afterEach(LoaderCommonHooks.afterEach);
+
+  LoaderCommonFactory(SegmentLoader,
+                      { loaderType: 'main' },
+                      (loader) => loader.mimeType('video/mp4'));
+
+  // Tests specific to the main segment loader go in this module
+  QUnit.module('Loader Main', function(nestedHooks) {
+    let loader;
+
+    nestedHooks.beforeEach(function(assert) {
+      this.segmentMetadataTrack = new MockTextTrack();
+      this.inbandTextTracks = {
+        CC1: new MockTextTrack()
+      };
+      this.startTime = sinon.stub(mp4probe, 'startTime');
+      this.mimeType = 'video/mp4';
+
+      loader = new SegmentLoader(LoaderCommonSettings.call(this, {
+        loaderType: 'main',
+        segmentMetadataTrack: this.segmentMetadataTrack,
+        inbandTextTracks: this.inbandTextTracks
+      }), {});
+
+      // shim updateend trigger to be a noop if the loader has no media source
+      this.updateend = function() {
+        if (loader.mediaSource_) {
+          loader.mediaSource_.sourceBuffers[0].trigger('updateend');
+        }
+      };
+    });
+
+    nestedHooks.afterEach(function(assert) {
+      this.startTime.restore();
+    });
+
+    QUnit.test(`CaptionsParser is handled as expected`,
+    function(assert) {
+      let mockCaptionsParserReset;
+      let mockCaptionsParserClear;
+      let mockCaptionsParserClearParsedCaptions;
+      let originalCurrentTimeline;
+      let originalPendingSegment;
+      let segment;
+
+      assert.ok(loader.captionsParser_, 'there is a captions parser');
+
+      mockCaptionsParserReset = sinon.stub(loader.captionsParser_, 'reset');
+      mockCaptionsParserClear = sinon.stub(loader.captionsParser_, 'clearAllCaptions');
+      mockCaptionsParserClearParsedCaptions = sinon.stub(loader.captionsParser_, 'clearParsedCaptions');
+
+      loader.load();
+      loader.playlist(playlistWithDuration(10, 'm4s'));
+      assert.equal(this.requests.length, 0, 'have not made a request yet');
+
+      loader.mimeType(this.mimeType);
+      this.clock.tick(1);
+      assert.equal(this.requests.length, 1, 'made a request');
+      assert.equal(mockCaptionsParserClear.callCount, 2, 'captions cleared on load and mimeType');
+
+      // Simulate a rendition switch
+      loader.resetEverything();
+      assert.equal(mockCaptionsParserClear.callCount, 3, 'captions cleared on rendition switch');
+
+      // Simulate a discontinuity
+      originalCurrentTimeline = loader.currentTimeline_;
+      loader.currentTimeline_ = originalCurrentTimeline + 1;
+      assert.equal(mockCaptionsParserClear.callCount, 3, 'captions cleared on discontinuity');
+      loader.currentTimeline_ = originalCurrentTimeline;
+
+      // Add to the inband text track, then call remove
+      this.inbandTextTracks.CC1.addCue({
+        startTime: 1,
+        endTime: 2,
+        text: 'test'
+      });
+      loader.remove(0, 2);
+      assert.equal(this.inbandTextTracks.CC1.cues.length, 0, 'all cues have been removed');
+
+      // Check that captions are added to track when found in the segment
+      // and then captionsParser is cleared
+      segment = {
+        resolvedUri: '0.m4s',
+        bytes: new Uint8Array([0, 0, 1]),
+        map: {
+          bytes: new Uint8Array([0, 0, 1])
+        },
+        endOfAllRequests: 0,
+        fmp4Captions: [{
+          startTime: 1,
+          endTime: 2,
+          text: 'test',
+          stream: 'CC1'
+        }],
+        captionStreams: {
+          CC1: true
+        }
+      };
+      originalPendingSegment = loader.pendingSegment_;
+      loader.pendingSegment_ = {
+        segment,
+        playlist: {
+          syncInfo: null
+        }
+      };
+      loader.processSegmentResponse_(segment);
+      assert.ok(this.inbandTextTracks.CC1, 'text track created');
+      assert.ok(this.inbandTextTracks.CC1.cues.length, 1, 'cue added');
+      assert.equal(mockCaptionsParserClearParsedCaptions.callCount, 1, 'captions cleared after adding to text track');
+      loader.pendingSegment_ = originalPendingSegment;
+
+      // Dispose the loader
+      loader.dispose();
+      assert.equal(mockCaptionsParserReset.callCount, 1, 'CaptionsParser reset');
     });
   });
 });

--- a/test/text-tracks.test.js
+++ b/test/text-tracks.test.js
@@ -1,0 +1,119 @@
+import Qunit from 'qunit';
+import {
+  createCaptionsTrackIfNotExists,
+  addCaptionData
+} from '../src/util/text-tracks';
+
+const { module, test } = Qunit;
+
+class MockTextTrack {
+  constructor() {
+    this.cues = [];
+  }
+  addCue(cue) {
+    this.cues.push(cue);
+  }
+}
+
+class MockTech {
+  constructor() {
+    this.tracks = {
+      getTrackById(id) {
+        return this[id];
+      }
+    };
+  }
+  addRemoteTextTrack({kind, id, label}) {
+    this.tracks[id] = new MockTextTrack();
+    return { track: this.tracks[id] };
+  }
+  trigger() {}
+  textTracks() {
+    return this.tracks;
+  }
+}
+
+module('Text Tracks', {
+  beforeEach() {
+    this.inbandTextTracks = {
+      CC1: new MockTextTrack(),
+      CC2: new MockTextTrack(),
+      CC3: new MockTextTrack(),
+      CC4: new MockTextTrack(),
+      metadataTrack_: new MockTextTrack()
+    };
+    this.timestampOffset = 0;
+    this.videoDuration = NaN;
+  }
+});
+
+test('creates a track if it does not exist yet', function(assert) {
+  const inbandTracks = {};
+  const tech = new MockTech();
+
+  createCaptionsTrackIfNotExists(inbandTracks, tech, {CC1: true});
+  assert.ok(inbandTracks.CC1, 'CC1 track was added');
+});
+
+test('fills inbandTextTracks if a track already exists', function(assert) {
+  const inbandTracks = {};
+  const tech = new MockTech();
+  const track = tech.addRemoteTextTrack({kind: 'captions', id: 'CC1', label: 'CC1'});
+
+  createCaptionsTrackIfNotExists(inbandTracks, tech, {CC1: true});
+  assert.ok(inbandTracks.CC1, 'CC1 track is now available on inbandTextTracks');
+  assert.strictEqual(inbandTracks.CC1, track.track);
+});
+
+test('does nothing if no captions are specified', function(assert) {
+  addCaptionData({
+    inbandTextTracks: this.inbandTextTracks,
+    timestampOffset: this.timestampOffset,
+    captionArray: []
+  });
+  assert.strictEqual(this.inbandTextTracks.CC1.cues.length, 0, 'added no 608 cues');
+});
+
+test('creates cues for 608 captions with "stream" property in ccX', function(assert) {
+  addCaptionData({
+    inbandTextTracks: this.inbandTextTracks,
+    timestampOffset: this.timestampOffset,
+    videoDuration: this.videoDuration,
+    captionArray: [{
+      startTime: 0,
+      endTime: 1,
+      text: 'CC1 text',
+      stream: 'CC1'
+    }, {
+      startTime: 0,
+      endTime: 1,
+      text: 'CC2 text',
+      stream: 'CC2'
+    }, {
+      startTime: 0,
+      endTime: 1,
+      text: 'CC3 text',
+      stream: 'CC3'
+    }, {
+      startTime: 0,
+      endTime: 1,
+      text: 'CC4 text',
+      stream: 'CC4'
+    }]
+  });
+  assert.strictEqual(this.inbandTextTracks.CC1.cues.length,
+                     1,
+                     'added one 608 cue to CC1');
+  assert.strictEqual(this.inbandTextTracks.CC2.cues.length,
+                     1,
+                     'added one 608 cue to CC2');
+  assert.strictEqual(this.inbandTextTracks.CC3.cues.length,
+                     1,
+                     'added one 608 cue to CC3');
+  assert.strictEqual(this.inbandTextTracks.CC4.cues.length,
+                     1,
+                     'added one 608 cue to CC4');
+  assert.strictEqual(this.inbandTextTracks.metadataTrack_.cues.length,
+                     0,
+                     'added no metadata cues');
+});


### PR DESCRIPTION
## Description
Depends on https://github.com/videojs/mux.js/pull/197. 

This will parse captions from DASH fmp4 segments as each segment request is finished and add them to a corresponding text track(i.e CC1, CC2, CC3, CC4).

## Specific Changes proposed
- requires an update to the mux.js dependency

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [x] Reviewed by Two Core Contributors
