### PR TITLE
ignore: remove issue stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status][travis-icon]][travis-link]
 [![Slack Status][slack-icon]][slack-link]
-[![Issue Stats][issue-stats-pr-icon]][issue-stats-link]
-[![Issue Stats][issue-stats-issues-icon]][issue-stats-link]
 [![Greenkeeper badge][greenkeeper-icon]][greenkeeper-link]
 
 Play HLS, DASH, and future HTTP streaming protocols with video.js, even where they're not


### PR DESCRIPTION
issuestats.com seems to be down. I opened https://github.com/hstove/issue_stats/issues/50. Removing the badges because issuestats seems to be relatively inactive. Will add the badges back if this is resolved.