### PR TITLE
Fix stalls for demuxed content when reconnect after connection is broken

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -255,6 +255,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
       // a playlist (e.g., in case the playlist errored and we re-requested it).
       if (!this.tech_.paused()) {
         this.mainSegmentLoader_.load();
+        if (this.audioSegmentLoader_) {
+          this.audioSegmentLoader_.load();
+        }
       }
 
       if (!updatedPlaylist.endList) {


### PR DESCRIPTION
We have been seeing issues with streams starting back up after a disconnect.

To reproduce:
1. Load demuxed content, a sample can be found:  https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8
2. Allow the buffer to fill up.
3. Kill your internet connection
4. Allow the buffer to run out
5. Reconnect

Playback should continue, but instead it stays in a frozen state.

## Description
Without this fix, if there are separate audio/video streams that are loaded, the player will download the video streams (not the audio streams) and playback will freeze.  

I believe it is due to https://github.com/videojs/http-streaming/blob/master/src/media-groups.js#L189 since that will set the `activePlaylistLoader` to `null` here: https://github.com/videojs/http-streaming/blob/master/src/media-groups.js#L37 -> https://github.com/videojs/http-streaming/blob/master/src/master-playlist-controller.js#L484 -> https://github.com/videojs/http-streaming/blob/master/src/master-playlist-controller.js#L257.  Thus the `audioSegmentLoader` is never restarted (and playback freezes).

There could be a better fix here, but I'm a little unclear what that might look like/how much work that would be (so any input there would be appreciated.

## Specific Changes proposed
Restart the `audioSegmentLoader` if the tech is not in a paused state.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
