### PR TITLE
fix: fix replay functionality

### DIFF
--- a/src/middleware-set-current-time.js
+++ b/src/middleware-set-current-time.js
@@ -21,6 +21,9 @@ videojs.use('*', (player) => {
       return time;
     },
 
+    // Sync VHS after play requests.
+    // This specifically handles replay where the video element will
+    // seek to 0, skipping the setCurrentTime middleware, then play
     play() {
       if (player.vhs &&
           player.currentSource().src === player.vhs.source_.src) {

--- a/src/middleware-set-current-time.js
+++ b/src/middleware-set-current-time.js
@@ -21,10 +21,10 @@ videojs.use('*', (player) => {
       return time;
     },
 
-    callPlay() {
+    play() {
       if (player.vhs &&
           player.currentSource().src === player.vhs.source_.src) {
-        player.vhs.play();
+        player.vhs.setCurrentTime(player.currentTime());
       }
     }
   };

--- a/src/middleware-set-current-time.js
+++ b/src/middleware-set-current-time.js
@@ -3,7 +3,7 @@ import videojs from 'video.js';
 // since VHS handles HLS and DASH (and in the future, more types), use * to capture all
 videojs.use('*', (player) => {
   return {
-    setSource: (srcObj, next) => {
+    setSource(srcObj, next) {
       // pass null as the first argument to indicate that the source is not rejected
       next(null, srcObj);
     },
@@ -12,12 +12,20 @@ videojs.use('*', (player) => {
     // level), this middleware will capture the action. For internal seeks (generated at
     // the tech level), we use a wrapped function so that we can handle it on our own
     // (specified elsewhere).
-    setCurrentTime: (time) => {
-      if (player.vhs && player.currentSource().src === player.vhs.source_.src) {
+    setCurrentTime(time) {
+      if (player.vhs &&
+          player.currentSource().src === player.vhs.source_.src) {
         player.vhs.setCurrentTime(time);
       }
 
       return time;
+    },
+
+    callPlay() {
+      if (player.vhs &&
+          player.currentSource().src === player.vhs.source_.src) {
+        player.vhs.play();
+      }
     }
   };
 });

--- a/src/middleware-set-current-time.js
+++ b/src/middleware-set-current-time.js
@@ -22,8 +22,9 @@ videojs.use('*', (player) => {
     },
 
     // Sync VHS after play requests.
-    // This specifically handles replay where the video element will
-    // seek to 0, skipping the setCurrentTime middleware, then play
+    // This specifically handles replay where the order of actions is
+    // play, video element will seek to 0 (skipping the setCurrentTime middleware)
+    // then triggers a play event.
     play() {
       if (player.vhs &&
           player.currentSource().src === player.vhs.source_.src) {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -328,8 +328,6 @@ class HlsHandler extends Component {
         this.masterPlaylistController_.pauseLoading();
       }
     });
-
-    this.on(this.tech_, 'play', this.play);
   }
 
   setOptions_() {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -328,6 +328,8 @@ class HlsHandler extends Component {
         this.masterPlaylistController_.pauseLoading();
       }
     });
+
+    this.on(this.tech_, 'play', this.play);
   }
 
   setOptions_() {

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -30,7 +30,10 @@ QUnit.module('Playback', {
     video.width = 600;
     video.height = 300;
     this.fixture.appendChild(video);
-    this.player = videojs(video, { muted: true });
+    this.player = videojs(video, {
+      muted: true,
+      autoplay: true
+    });
     this.player.ready(done);
   },
   afterEach() {
@@ -43,8 +46,6 @@ QUnit.test('Advanced Bip Bop', function(assert) {
 
   assert.expect(2);
   let player = this.player;
-
-  player.autoplay(true);
 
   playFor(player, 2, function() {
     assert.ok(true, 'played for at least two seconds');
@@ -64,8 +65,6 @@ QUnit.test('replay', function(assert) {
 
   assert.expect(2);
   let player = this.player;
-
-  player.autoplay(true);
 
   // seek to near the end of the video
   playFor(player, 1, function() {
@@ -95,8 +94,6 @@ QUnit.skip('playlist with fmp4 and ts segments', function(assert) {
   assert.expect(2);
   let player = this.player;
 
-  player.autoplay(true);
-
   playFor(player, 6, function() {
     assert.ok(true, 'played for at least six seconds to hit the change in container format');
     assert.equal(player.error(), null, 'has no player errors');
@@ -116,7 +113,6 @@ QUnit.test('Advanced Bip Bop preload=none', function(assert) {
   assert.expect(2);
   let player = this.player;
 
-  player.autoplay(true);
   player.preload('none');
 
   playFor(player, 2, function() {
@@ -138,8 +134,6 @@ QUnit.test('Big Buck Bunny', function(assert) {
   assert.expect(2);
   let player = this.player;
 
-  player.autoplay(true);
-
   playFor(player, 2, function() {
     assert.ok(true, 'played for at least two seconds');
     assert.equal(player.error(), null, 'has no player errors');
@@ -158,8 +152,6 @@ QUnit.test('Live DASH', function(assert) {
 
   assert.expect(2);
   let player = this.player;
-
-  player.autoplay(true);
 
   playFor(player, 2, function() {
     assert.ok(true, 'played for at least two seconds');

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -74,7 +74,7 @@ QUnit.test('replay', function(assert) {
 
   player.one('ended', function() {
     player.one('timeupdate', function() {
-      assert.ok(true, 'played');
+      assert.ok(player.currentTime() < 10, 'played');
       assert.equal(player.error(), null, 'has no player errors');
 
       done();

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -59,6 +59,36 @@ QUnit.test('Advanced Bip Bop', function(assert) {
   });
 });
 
+QUnit.test('replay', function(assert) {
+  let done = assert.async();
+
+  assert.expect(2);
+  let player = this.player;
+
+  player.autoplay(true);
+
+  // seek to near the end of the video
+  playFor(player, 1, function() {
+    player.currentTime(player.duration() - 1);
+  });
+
+  player.one('ended', function() {
+    player.one('timeupdate', function() {
+      assert.ok(true, 'played');
+      assert.equal(player.error(), null, 'has no player errors');
+
+      done();
+    });
+
+    player.play();
+  });
+
+  player.src({
+    src: 'http://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8',
+    type: 'application/x-mpegURL'
+  });
+});
+
 QUnit.skip('playlist with fmp4 and ts segments', function(assert) {
   let done = assert.async();
 


### PR DESCRIPTION
## Description
Fixes #201 

## Specific Changes proposed
Replay is broken because VHS is not loading the buffer when the video element seeks on replay. This previously worked because VHS would react to video element seek events. The seek caused by replay does not call `player.currentTime()` so the middleware does not kick in. This adds an additional middleware to call VHS's during play calls. 

Previously the play method of VHS would not go down the ended -> seek to 0 path because the tech would have already seeked to 0 on it's own, then emitted a play event.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
