### PR TITLE
fix: stutter after fast quality change in IE/Edge

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -534,15 +534,15 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     // Delete all buffered data to allow an immediate quality switch, then seek
     // forward slightly to give the browser a kick to remove any cached frames from the
-    // previous rendition (.02 seconds ahead is roughly the minimum that will accomplish this
-    // in IE and Edge)
+    // previous rendition (.04 seconds ahead is roughly the minimum that will accomplish this
+    // across a variety of content in IE and Edge)
     // Edge/IE bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14600375/
     // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=651904
     this.mainSegmentLoader_.resetEverything(() => {
       // Since this is not a typical seek, we avoid the seekTo method which can cause
       // segments from the previously enabled rendition to load before the new playlist
       // has finished loading
-      this.tech_.setCurrentTime(this.tech_.currentTime() + .02);
+      this.tech_.setCurrentTime(this.tech_.currentTime() + .04);
 
       if (!isPaused) {
         this.tech_.play();

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -542,7 +542,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       // Since this is not a typical seek, we avoid the seekTo method which can cause
       // segments from the previously enabled rendition to load before the new playlist
       // has finished loading
-      this.tech_.setCurrentTime(this.tech_.currentTime() + .04);
+      this.tech_.setCurrentTime(this.tech_.currentTime() + 0.04);
 
       if (!isPaused) {
         this.tech_.play();

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -523,7 +523,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
    */
   fastQualityChange_() {
     const media = this.selectPlaylist();
-    const isPaused = this.tech_.paused();
 
     if (media === this.masterPlaylistLoader_.media()) {
       return;

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -529,23 +529,21 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
 
-    this.tech_.pause();
     this.masterPlaylistLoader_.media(media);
 
-    // Delete all buffered data to allow an immediate quality switch, then seek
-    // forward slightly to give the browser a kick to remove any cached frames from the
-    // previous rendition (.04 seconds ahead is roughly the minimum that will accomplish this
-    // across a variety of content in IE and Edge)
+    // Delete all buffered data to allow an immediate quality switch, then seek to give
+    // the browser a kick to remove any cached frames from the previous rendtion (.04 seconds
+    // ahead is roughly the minimum that will accomplish this across a variety of content
+    // in IE and Edge, but seeking in place is sufficient on all other browsers)
     // Edge/IE bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14600375/
     // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=651904
     this.mainSegmentLoader_.resetEverything(() => {
-      // Since this is not a typical seek, we avoid the seekTo method which can cause
-      // segments from the previously enabled rendition to load before the new playlist
-      // has finished loading
-      this.tech_.setCurrentTime(this.tech_.currentTime() + 0.04);
-
-      if (!isPaused) {
-        this.tech_.play();
+      // Since this is not a typical seek, we avoid the seekTo method which can cause segments
+      // from the previously enabled rendition to load before the new playlist has finished loading
+      if (videojs.browser.IE_VERSION || videojs.browser.IS_EDGE) {
+        this.tech_.setCurrentTime(this.tech_.currentTime() + 0.04);
+      } else {
+        this.tech_.setCurrentTime(this.tech_.currentTime());
       }
     });
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -409,6 +409,8 @@ QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', fun
 });
 
 QUnit.test('seeks forward 0.04 sec for fast quality switch on Edge', function(assert) {
+  let oldIEVersion = videojs.browser.IE_VERSION;
+  let oldIsEdge = videojs.browser.IS_EDGE;
   let seeks = 0;
 
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
@@ -442,9 +444,14 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on Edge', function(as
 
   assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeks forward on fast quality switch');
   assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
+
+  videojs.browser.IE_VERSION = oldIEVersion;
+  videojs.browser.IS_EDGE = oldIsEdge;
 });
 
 QUnit.test('seeks forward 0.04 sec for fast quality switch on IE', function(assert) {
+  let oldIEVersion = videojs.browser.IE_VERSION;
+  let oldIsEdge = videojs.browser.IS_EDGE;
   let seeks = 0;
 
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
@@ -478,6 +485,9 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on IE', function(asse
 
   assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeks forward on fast quality switch');
   assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
+
+  videojs.browser.IE_VERSION = oldIEVersion;
+  videojs.browser.IS_EDGE = oldIsEdge;
 });
 
 QUnit.test('audio segment loader is reset on audio track change', function(assert) {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -376,43 +376,56 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
 });
 
 QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', function(assert) {
+  let seeks = 0;
+
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
   // master
   this.standardXHRResponse(this.requests.shift());
   // media
   this.standardXHRResponse(this.requests.shift());
+  // segment
+  this.standardXHRResponse(this.requests.shift());
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
 
   // media is changed
   this.masterPlaylistController.selectPlaylist = () => {
     return this.masterPlaylistController.master().playlists[0];
   };
 
-  // makes sure the resetEverything callback is queued when sourceUpdater_.remove() gets called
-  this.masterPlaylistController.mainSegmentLoader_.sourceUpdater_.processedAppend_ = true;
+  this.player.tech_.on('seeking', function() {
+    seeks++;
+  });
 
   const timeBeforeSwitch = this.player.currentTime();
 
   this.masterPlaylistController.fastQualityChange_();
-
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(1);
 
-  assert.equal(this.player.currentTime(), timeBeforeSwitch, 'seeks in place on fast quality switch');
+  assert.equal(this.player.currentTime(), timeBeforeSwitch, 'current time remains the same on fast quality switch');
+  assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
 });
 
 QUnit.test('seeks forward 0.04 sec for fast quality switch on Edge', function(assert) {
+  let seeks = 0;
+
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
   // master
   this.standardXHRResponse(this.requests.shift());
   // media
   this.standardXHRResponse(this.requests.shift());
+  // segment
+  this.standardXHRResponse(this.requests.shift());
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
 
   // media is changed
   this.masterPlaylistController.selectPlaylist = () => {
     return this.masterPlaylistController.master().playlists[0];
   };
 
-  // makes sure the resetEverything callback is queued when sourceUpdater_.remove() gets called
-  this.masterPlaylistController.mainSegmentLoader_.sourceUpdater_.processedAppend_ = true;
+  this.player.tech_.on('seeking', function() {
+    seeks++;
+  });
 
   const timeBeforeSwitch = this.player.currentTime();
 
@@ -420,26 +433,33 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on Edge', function(as
   videojs.browser.IS_EDGE = true;
 
   this.masterPlaylistController.fastQualityChange_();
-
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(1);
 
-  assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeks in place on fast quality switch');
+  assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeks forward on fast quality switch');
+  assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
 });
 
 QUnit.test('seeks forward 0.04 sec for fast quality switch on IE', function(assert) {
+  let seeks = 0;
+
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
   // master
   this.standardXHRResponse(this.requests.shift());
   // media
   this.standardXHRResponse(this.requests.shift());
+  // segment
+  this.standardXHRResponse(this.requests.shift());
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
 
   // media is changed
   this.masterPlaylistController.selectPlaylist = () => {
     return this.masterPlaylistController.master().playlists[0];
   };
 
-  // makes sure the resetEverything callback is queued when sourceUpdater_.remove() gets called
-  this.masterPlaylistController.mainSegmentLoader_.sourceUpdater_.processedAppend_ = true;
+  this.player.tech_.on('seeking', function() {
+    seeks++;
+  });
 
   const timeBeforeSwitch = this.player.currentTime();
 
@@ -447,10 +467,11 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on IE', function(asse
   videojs.browser.IS_EDGE = false;
 
   this.masterPlaylistController.fastQualityChange_();
-
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(1);
 
-  assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeks in place on fast quality switch');
+  assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeks forward on fast quality switch');
+  assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
 });
 
 QUnit.test('audio segment loader is reset on audio track change', function(assert) {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -385,6 +385,7 @@ QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', fun
   this.standardXHRResponse(this.requests.shift());
   // segment
   this.standardXHRResponse(this.requests.shift());
+  // trigger updateend to indicate the end of the append operation
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
 
   // media is changed
@@ -399,6 +400,7 @@ QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', fun
   const timeBeforeSwitch = this.player.currentTime();
 
   this.masterPlaylistController.fastQualityChange_();
+  // trigger updateend to indicate the end of the remove operation
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
   this.clock.tick(1);
 
@@ -416,6 +418,7 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on Edge', function(as
   this.standardXHRResponse(this.requests.shift());
   // segment
   this.standardXHRResponse(this.requests.shift());
+  // trigger updateend to indicate the end of the append operation
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
 
   // media is changed
@@ -433,6 +436,7 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on Edge', function(as
   videojs.browser.IS_EDGE = true;
 
   this.masterPlaylistController.fastQualityChange_();
+  // trigger updateend to indicate the end of the remove operation
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
   this.clock.tick(1);
 
@@ -450,6 +454,7 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on IE', function(asse
   this.standardXHRResponse(this.requests.shift());
   // segment
   this.standardXHRResponse(this.requests.shift());
+  // trigger updateend to indicate the end of the append operation
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
 
   // media is changed
@@ -467,6 +472,7 @@ QUnit.test('seeks forward 0.04 sec for fast quality switch on IE', function(asse
   videojs.browser.IS_EDGE = false;
 
   this.masterPlaylistController.fastQualityChange_();
+  // trigger updateend to indicate the end of the remove operation
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
   this.clock.tick(1);
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -375,6 +375,30 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
   assert.deepEqual(removeFuncArgs, {start: 0, end: 60}, 'remove() called with correct arguments if media is changed');
 });
 
+QUnit.test('seeks forward 0.04 seconds for fast quality switch', function(assert) {
+  this.masterPlaylistController.mediaSource.trigger('sourceopen');
+  // master
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  // media is changed
+  this.masterPlaylistController.selectPlaylist = () => {
+    return this.masterPlaylistController.master().playlists[0];
+  };
+
+  // makes sure the resetEverything callback is queued when sourceUpdater_.remove() gets called
+  this.masterPlaylistController.mainSegmentLoader_.sourceUpdater_.processedAppend_ = true;
+
+  const timeBeforeSwitch = this.player.currentTime();
+
+  this.masterPlaylistController.fastQualityChange_();
+
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+
+  assert.equal(this.player.currentTime(), timeBeforeSwitch + 0.04, 'seeked forward on fast quality switch');
+});
+
 QUnit.test('audio segment loader is reset on audio track change', function(assert) {
   this.requests.length = 0;
   this.player = createPlayer();


### PR DESCRIPTION
## Description

This tweaks the changes in https://github.com/videojs/http-streaming/pull/113 to fix a stutter in IE/Edge after the buffer is cleared. In the initial PR, seeking in place was sufficient to address this issue in Chrome, but we need to seek further behind/ahead of the current time in order to also fix the issue in IE/Edge.