### PR TITLE
add back manual smooth quality changes via smoothQualityChange flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Video.js Compatibility: 6.0, 7.0
       - [blacklistDuration](#blacklistduration)
       - [bandwidth](#bandwidth)
       - [enableLowInitialPlaylist](#enablelowinitialplaylist)
+      - [limitRenditionByPlayerDimensions](#limitrenditionbyplayerdimensions)
+      - [smoothQualityChange](#smoothqualitychange)
   - [Runtime Properties](#runtime-properties)
     - [hls.playlists.master](#hlsplaylistsmaster)
     - [hls.playlists.media](#hlsplaylistsmedia)
@@ -341,6 +343,22 @@ When `limitRenditionByPlayerDimensions` is set to true, rendition
 selection logic will take into account the player size and rendition
 resolutions when making a decision.
 This setting is `true` by default.
+
+##### smoothQualityChange
+* Type: `boolean`
+* can be used as a source option
+* can be used as an initialization option
+
+When the `smoothQualityChange` property is set to `true`, a manual quality
+change triggered via the [representations API](#hlsrepresentations) will use
+smooth quality switching rather than the default fast (buffer-ejecting)
+quality switching. Using smooth quality switching will mean no loading spinner
+will appear during quality switches, but will cause quality switches to only
+be visible after a few seconds.
+
+Note that this _only_ affects quality changes triggered via the representations
+API; automatic quality switches based on available bandwidth will always be
+smooth switches.
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -48,11 +48,13 @@ const enableFunction = (loader, playlistUri, changePlaylistFn) => (enable) => {
  */
 class Representation {
   constructor(hlsHandler, playlist, id) {
-    // Get a reference to a bound version of fastQualityChange_
-    let fastChangeFunction = hlsHandler
-                              .masterPlaylistController_
-                              .fastQualityChange_
-                              .bind(hlsHandler.masterPlaylistController_);
+    const {
+      masterPlaylistController_: mpc,
+      options_: { smoothQualityChange }
+    } = hlsHandler;
+    // Get a reference to a bound version of the quality change function
+    const changeType = smoothQualityChange ? 'smooth' : 'fast';
+    const qualityChangeFunction = mpc[`${changeType}QualityChange_`].bind(mpc);
 
     // some playlist attributes are optional
     if (playlist.attributes.RESOLUTION) {
@@ -72,7 +74,7 @@ class Representation {
     // specific variant
     this.enabled = enableFunction(hlsHandler.playlists,
                                   playlist.uri,
-                                  fastChangeFunction);
+                                  qualityChangeFunction);
   }
 }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -341,6 +341,7 @@ class HlsHandler extends Component {
     // defaults
     this.options_.withCredentials = this.options_.withCredentials || false;
     this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions === false ? false : true;
+    this.options_.smoothQualityChange = this.options_.smoothQualityChange || false;
 
     if (typeof this.options_.blacklistDuration !== 'number') {
       this.options_.blacklistDuration = 5 * 60;
@@ -359,7 +360,7 @@ class HlsHandler extends Component {
       this.options_.bandwidth === Config.INITIAL_BANDWIDTH;
 
     // grab options passed to player.src
-    ['withCredentials', 'limitRenditionByPlayerDimensions', 'bandwidth'].forEach((option) => {
+    ['withCredentials', 'limitRenditionByPlayerDimensions', 'bandwidth', 'smoothQualityChange'].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];
       }

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -33,6 +33,11 @@ const options = [{
   default: 4194304,
   test: 5,
   alt: 555
+}, {
+  name: 'smoothQualityChange',
+  default: false,
+  test: true,
+  alt: false
 }];
 
 const CONFIG_KEYS = Object.keys(Config);


### PR DESCRIPTION
## Description
#113 unfortunately _completely_ removed smooth quality switching for manual quality switches. This PR adds it back via a configuration option.

## Specific Changes proposed
- Add `smoothQualityChange` config option
- Merge it with a possible source option of the same name
- Select `fastQualityChange` or `smoothQualityChange` using a ternary that checks the aforementioned config option

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
