### PR TITLE
Adding missing manifest information on to segments (EXT-X-PROGRAM-DATE-TIME)

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1371,6 +1371,8 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
+      dateTimeObject: segment.dateTimeObject || null,
+      dateTimeString: segment.dateTimeString || null,
       bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,
       resolution: segmentInfo.playlist.attributes.RESOLUTION,
       codecs: segmentInfo.playlist.attributes.CODECS,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1371,8 +1371,8 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
-      dateTimeObject: segment.dateTimeObject || null,
-      dateTimeString: segment.dateTimeString || null,
+      dateTimeObject: (segment && segment.dateTimeObject) || null,
+      dateTimeString: (segment && segment.dateTimeString) || null,
       bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,
       resolution: segmentInfo.playlist.attributes.RESOLUTION,
       codecs: segmentInfo.playlist.attributes.CODECS,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -450,7 +450,9 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10
+          byteLength: 10,
+          dateTimeObject: null,
+          dateTimeString: null
         };
 
         assert.equal(track.cues.length, 1, 'one cue added for segment');
@@ -471,7 +473,9 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10
+          byteLength: 10,
+          dateTimeObject: null,
+          dateTimeString: null
         };
 
         assert.equal(track.cues.length, 2, 'one cue added for segment');
@@ -492,7 +496,9 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10
+          byteLength: 10,
+          dateTimeObject: null,
+          dateTimeString: null
         };
 
         assert.equal(track.cues.length, 3, 'one cue added for segment');
@@ -515,7 +521,9 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10
+          byteLength: 10,
+          dateTimeObject: null,
+          dateTimeString: null
         };
 
         assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');


### PR DESCRIPTION


## Description
The segment metadata is currently missing the information that comes from the `EXT-X-PROGRAM-DATE-TIME`. 

## Specific Changes proposed
I've added the `dateTimeObject` & `dateTimeString` to the segment data object. The information as already coming through from the buffer, only missing to be added to the segment data object that's _published_.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors