### PR TITLE
add an option to ignore player size in selection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,16 @@ When `enableLowInitialPlaylist` is set to true, it will be used to select
 the lowest bitrate playlist initially.  This helps to decrease playback start time.
 This setting is `false` by default.
 
+##### ignorePlayerSize
+* Type: `boolean`
+* can be used as an initialization option
+
+When `ignorePlayerSize` is set to true, selection logic will ignore the
+player size and rendition resolutions when making a decision.  This should
+be used when doing per-title encoding which makes non-traditional
+rendition resolution decisions.
+This setting is `false` by default.
+
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in
 use. You can get a reference to the HLS source handler like this:

--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ When `enableLowInitialPlaylist` is set to true, it will be used to select
 the lowest bitrate playlist initially.  This helps to decrease playback start time.
 This setting is `false` by default.
 
-##### ignorePlayerSize
+##### limitRenditionByPlayerDimensions
 * Type: `boolean`
 * can be used as an initialization option
 
-When `ignorePlayerSize` is set to true, rendition selection logic will ignore
-the player size and rendition resolutions when making a decision.
-This setting is `false` by default.
+When `limitRenditionByPlayerDimensions` is set to true, rendition
+selection logic will take into account the player size and rendition
+resolutions when making a decision.
+This setting is `true` by default.
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/README.md
+++ b/README.md
@@ -337,10 +337,8 @@ This setting is `false` by default.
 * Type: `boolean`
 * can be used as an initialization option
 
-When `ignorePlayerSize` is set to true, selection logic will ignore the
-player size and rendition resolutions when making a decision.  This should
-be used when doing per-title encoding which makes non-traditional
-rendition resolution decisions.
+When `ignorePlayerSize` is set to true, rendition selection logic will ignore
+the player size and rendition resolutions when making a decision.
 This setting is `false` by default.
 
 ### Runtime Properties

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,8 @@ export default {
   GOAL_BUFFER_LENGTH: 30,
   MAX_GOAL_BUFFER_LENGTH: 60,
   GOAL_BUFFER_LENGTH_RATE: 1,
+  // 0.5 MB/s
+  INITIAL_BANDWIDTH: 4194304,
   // A fudge factor to apply to advertised playlist bitrates to account for
   // temporary flucations in client bandwidth
   BANDWIDTH_VARIANCE: 1.2,

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -194,7 +194,7 @@ export const simpleSelector = function(master,
   )[0];
 
   // if we're not going to limit renditions by player size, make an early decision.
-  if (!limitRenditionByPlayerDimensions) {
+  if (limitRenditionByPlayerDimensions === false) {
     let chosenRep = (
       bandwidthBestRep ||
       enabledPlaylistReps[0] ||

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -193,7 +193,7 @@ export const simpleSelector = function(master,
     (rep) => rep.bandwidth === highestRemainingBandwidthRep.bandwidth
   )[0];
 
-  // if we not going to limit renditions by player size, make an early decision.
+  // if we're not going to limit renditions by player size, make an early decision.
   if (!limitRenditionByPlayerDimensions) {
     let chosenRep = (
       bandwidthBestRep ||

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -200,6 +200,7 @@ export const simpleSelector = function(master,
       enabledPlaylistReps[0] ||
       sortedPlaylistReps[0]
     );
+
     return chosenRep ? chosenRep.playlist : null;
   }
 
@@ -230,7 +231,6 @@ export const simpleSelector = function(master,
     resolutionPlusOneList = haveResolution.filter(
       (rep) => rep.width > playerWidth || rep.height > playerHeight
     );
-    console.log('resolutionPlusOneList', haveResolution, resolutionPlusOneList, playerWidth, playerHeight);
 
     // find all the variants have the same smallest resolution
     resolutionPlusOneSmallest = resolutionPlusOneList.filter(

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -124,8 +124,8 @@ export const comparePlaylistResolution = function(left, right) {
  *        Current width of the player element
  * @param {Number} playerHeight
  *        Current height of the player element
- * @param {Boolean} ignorePlayerSize
- *        True if the player width and height should be ignored during the selection, false otherwise
+ * @param {Boolean} limitRenditionByPlayerDimensions
+ *        True if the player width and height should be used during the selection, false otherwise
  * @return {Playlist} the highest bitrate playlist less than the
  * currently detected bandwidth, accounting for some amount of
  * bandwidth variance
@@ -134,7 +134,7 @@ export const simpleSelector = function(master,
                                        playerBandwidth,
                                        playerWidth,
                                        playerHeight,
-                                       ignorePlayerSize) {
+                                       limitRenditionByPlayerDimensions) {
   // convert the playlists to an intermediary representation to make comparisons easier
   let sortedPlaylistReps = master.playlists.map((playlist) => {
     let width;
@@ -193,8 +193,8 @@ export const simpleSelector = function(master,
     (rep) => rep.bandwidth === highestRemainingBandwidthRep.bandwidth
   )[0];
 
-  // if we are ignoring the player size, make an early decision
-  if (ignorePlayerSize) {
+  // if we not going to limit renditions by player size, make an early decision.
+  if (!limitRenditionByPlayerDimensions) {
     let chosenRep = (
       bandwidthBestRep ||
       enabledPlaylistReps[0] ||
@@ -276,7 +276,7 @@ export const lastBandwidthSelector = function() {
                         this.systemBandwidth,
                         parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10),
                         parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10),
-                        this.ignorePlayerSize);
+                        this.limitRenditionByPlayerDimensions);
 };
 
 /**
@@ -310,7 +310,7 @@ export const movingAverageBandwidthSelector = function(decay) {
                           average,
                           parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10),
                           parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10),
-                          this.ignorePlayerSize);
+                          this.limitRenditionByPlayerDimensions);
   };
 };
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -332,7 +332,7 @@ class HlsHandler extends Component {
   setOptions_() {
     // defaults
     this.options_.withCredentials = this.options_.withCredentials || false;
-    this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions || true;
+    this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions === false ? false : true;
 
     if (typeof this.options_.blacklistDuration !== 'number') {
       this.options_.blacklistDuration = 5 * 60;

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -44,9 +44,6 @@ const Hls = {
   xhr: xhrFactory()
 };
 
-// 0.5 MB/s
-const INITIAL_BANDWIDTH = 4194304;
-
 // Define getter/setters for config properites
 [
   'GOAL_BUFFER_LENGTH',
@@ -335,6 +332,7 @@ class HlsHandler extends Component {
   setOptions_() {
     // defaults
     this.options_.withCredentials = this.options_.withCredentials || false;
+    this.options_.ignorePlayerSize = this.options_.ignorePlayerSize || false;
 
     if (typeof this.options_.blacklistDuration !== 'number') {
       this.options_.blacklistDuration = 5 * 60;
@@ -343,17 +341,17 @@ class HlsHandler extends Component {
     // start playlist selection at a reasonable bandwidth for
     // broadband internet (0.5 MB/s) or mobile (0.0625 MB/s)
     if (typeof this.options_.bandwidth !== 'number') {
-      this.options_.bandwidth = INITIAL_BANDWIDTH;
+      this.options_.bandwidth = Config.INITIAL_BANDWIDTH;
     }
 
     // If the bandwidth number is unchanged from the initial setting
     // then this takes precedence over the enableLowInitialPlaylist option
     this.options_.enableLowInitialPlaylist =
       this.options_.enableLowInitialPlaylist &&
-      this.options_.bandwidth === INITIAL_BANDWIDTH;
+      this.options_.bandwidth === Config.INITIAL_BANDWIDTH;
 
     // grab options passed to player.src
-    ['withCredentials', 'bandwidth'].forEach((option) => {
+    ['withCredentials', 'ignorePlayerSize', 'bandwidth'].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];
       }

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -358,6 +358,7 @@ class HlsHandler extends Component {
     });
 
     this.bandwidth = this.options_.bandwidth;
+    this.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions;
   }
   /**
    * called when player.src gets called, handle a new source

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -332,7 +332,7 @@ class HlsHandler extends Component {
   setOptions_() {
     // defaults
     this.options_.withCredentials = this.options_.withCredentials || false;
-    this.options_.ignorePlayerSize = this.options_.ignorePlayerSize || false;
+    this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions || true;
 
     if (typeof this.options_.blacklistDuration !== 'number') {
       this.options_.blacklistDuration = 5 * 60;
@@ -351,7 +351,7 @@ class HlsHandler extends Component {
       this.options_.bandwidth === Config.INITIAL_BANDWIDTH;
 
     // grab options passed to player.src
-    ['withCredentials', 'ignorePlayerSize', 'bandwidth'].forEach((option) => {
+    ['withCredentials', 'limitRenditionByPlayerDimensions', 'bandwidth'].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];
       }

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -24,8 +24,8 @@ const options = [{
   test: true,
   alt: false
 }, {
-  name: 'ignorePlayerSize',
-  default: false,
+  name: 'limitRenditionByPlayerDimensions',
+  default: true,
   test: true,
   alt: false
 }, {

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -26,7 +26,7 @@ const options = [{
 }, {
   name: 'limitRenditionByPlayerDimensions',
   default: true,
-  test: true,
+  test: false,
   alt: false
 }, {
   name: 'bandwidth',

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -24,6 +24,11 @@ const options = [{
   test: true,
   alt: false
 }, {
+  name: 'ignorePlayerSize',
+  default: false,
+  test: true,
+  alt: false
+}, {
   name: 'bandwidth',
   default: 4194304,
   test: 5,

--- a/test/playlist-selectors.test.js
+++ b/test/playlist-selectors.test.js
@@ -180,22 +180,22 @@ const trickyPlaylists = [
   { attributes: { BANDWIDTH: 6151620, RESOLUTION: { width: 1920, height: 1080 } } }
 ];
 
-test('simpleSelector accounts for resolution information when it exists', function(assert) {
-  let master = this.hls.playlists.master;
-
-  master.playlists = trickyPlaylists;
-
-  const selectedPlaylist = simpleSelector(master, Config.INITIAL_BANDWIDTH, 444, 790, false);
-
-  assert.equal(selectedPlaylist, master.playlists[3], 'selected the playlist with the lowest bandwidth higher than player resolution');
-});
-
-test('simpleSelector can ignore player size and resolutions', function(assert) {
+test('simpleSelector limits using resolution information when it exists', function(assert) {
   let master = this.hls.playlists.master;
 
   master.playlists = trickyPlaylists;
 
   const selectedPlaylist = simpleSelector(master, Config.INITIAL_BANDWIDTH, 444, 790, true);
+
+  assert.equal(selectedPlaylist, master.playlists[3], 'selected the playlist with the lowest bandwidth higher than player resolution');
+});
+
+test('simpleSelector can not limit based on resolution information', function(assert) {
+  let master = this.hls.playlists.master;
+
+  master.playlists = trickyPlaylists;
+
+  const selectedPlaylist = simpleSelector(master, Config.INITIAL_BANDWIDTH, 444, 790, false);
 
   assert.equal(selectedPlaylist, master.playlists[4], 'selected a playlist based solely on bandwidth');
 });

--- a/test/playlist-selectors.test.js
+++ b/test/playlist-selectors.test.js
@@ -163,7 +163,39 @@ test('simpleSelector switches up even without resolution information', function(
     { attributes: { BANDWIDTH: 1000 } }
   ];
 
-  const selectedPlaylist = simpleSelector(master, 2000, 1, 1);
+  const selectedPlaylist = simpleSelector(master, 2000, 1, 1, false);
 
   assert.equal(selectedPlaylist, master.playlists[1], 'selected the correct playlist');
+});
+
+// A set of playlists that were defined using non-traditional encoding.
+// The resolutions were selected using a per-title encoding technique
+// that ensures the resolution maximizes quality at a given bitrate.
+const trickyPlaylists = [
+  { attributes: { BANDWIDTH: 2362080, RESOLUTION: { width: 1280, height: 720 } } },
+  { attributes: { BANDWIDTH: 1390830, RESOLUTION: { width: 1280, height: 720 } } },
+  { attributes: { BANDWIDTH: 866114, RESOLUTION: { width: 1024, height: 576 } } },
+  { attributes: { BANDWIDTH: 573028, RESOLUTION: { width: 768, height: 432 } } },
+  { attributes: { BANDWIDTH: 3482070, RESOLUTION: { width: 1920, height: 1080 } } },
+  { attributes: { BANDWIDTH: 6151620, RESOLUTION: { width: 1920, height: 1080 } } }
+];
+
+test('simpleSelector accounts for resolution information when it exists', function(assert) {
+  let master = this.hls.playlists.master;
+
+  master.playlists = trickyPlaylists;
+
+  const selectedPlaylist = simpleSelector(master, Config.INITIAL_BANDWIDTH, 444, 790, false);
+
+  assert.equal(selectedPlaylist, master.playlists[3], 'selected the playlist with the lowest bandwidth higher than player resolution');
+});
+
+test('simpleSelector can ignore player size and resolutions', function(assert) {
+  let master = this.hls.playlists.master;
+
+  master.playlists = trickyPlaylists;
+
+  const selectedPlaylist = simpleSelector(master, Config.INITIAL_BANDWIDTH, 444, 790, true);
+
+  assert.equal(selectedPlaylist, master.playlists[4], 'selected a playlist based solely on bandwidth');
 });


### PR DESCRIPTION
## Description
Some modern encoding techniques target the best quality at a given bitrate, to some extent irrespective of resolution. In such scenarios, users should be able to tell the player that the player size should be ignored during rendition selection in order to favor a pure bandwidth based decision which will maximize quality for the playback. 

## Specific Changes proposed
- add a `limitRenditionByPlayerDimensions ` configuration option which can be set to false to ignore resolutions when doing rendition selection.

## Requirements Checklist
- [x] Feature implemented / Bug fixed - awww yea
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed - wrote some unit tests!
  - [x] Docs/guides updated - wrote docs in the README
  - [x] Example created - https://jsbin.com/gejugat/4/edit?html,output - I mean this is a pretty boring example as I'm just setting the config variable in it.
- [x] Reviewed by Two Core Contributors
