### PR TITLE
fix: ensure content loops

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -321,6 +321,7 @@ class HlsHandler extends Component {
       }
     });
 
+    // Handle seeking when looping - middleware doesn't handle this seek event from the tech
     this.on(this.tech_, 'seeking', function() {
       if (this.tech_.seeking() && this.tech_.currentTime() === 0 && this.tech_.player_.loop()) {
         this.setCurrentTime(0);

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -320,6 +320,13 @@ class HlsHandler extends Component {
         this.masterPlaylistController_.smoothQualityChange_();
       }
     });
+
+    this.on(this.tech_, 'seeking', function() {
+      if (this.tech_.seeking() && this.tech_.currentTime() === 0 && this.tech_.player_.loop()) {
+        this.setCurrentTime(0);
+      }
+    });
+
     this.on(this.tech_, 'error', function() {
       if (this.masterPlaylistController_) {
         this.masterPlaylistController_.pauseLoading();

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -178,9 +178,11 @@ QUnit.test('loops', function(assert) {
     type: 'application/x-mpegURL'
   });
   player.one('playing', function() {
-    player.vhs.mediaSource.on('sourceopen', () => {
-      assert.ok(true, 'sourceopen triggered after ending stream');
-      done();
+    player.vhs.mediaSource.one('sourceended', () => {
+      player.vhs.mediaSource.on('sourceopen', () => {
+        assert.ok(true, 'sourceopen triggered after ending stream');
+        done();
+      });
     });
     player.currentTime(player.duration());
   });

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -165,3 +165,24 @@ QUnit.test('Live DASH', function(assert) {
     type: 'application/dash+xml'
   });
 });
+
+QUnit.test('loops', function(assert) {
+  assert.timeout(5000);
+
+  let done = assert.async();
+  let player = this.player;
+
+  player.loop(true);
+  player.src({
+    src: 'http://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8',
+    type: 'application/x-mpegURL'
+  });
+  player.one('playing', function() {
+    player.vhs.mediaSource.on('sourceopen', () => {
+      assert.ok(true, 'sourceopen triggered after ending stream');
+      done();
+    });
+    player.currentTime(player.duration());
+  });
+  player.play();
+});


### PR DESCRIPTION
## Description
Fixes #231, playback stalls if looping

## Specific Changes proposed
On a seek to 0 when loop enabled, call `setCurrentTime(0)` on vhs.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
