### PR TITLE
fix: immediately setup EME if available

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -180,6 +180,10 @@ const setupEmeOptions = (hlsHandler) => {
 
     if (sourceOptions) {
       player.currentSource().keySystems = sourceOptions;
+
+      if (player.eme.initializeMediaKeys) {
+        player.eme.initializeMediaKeys();
+      }
     }
   }
 };

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -181,6 +181,7 @@ const setupEmeOptions = (hlsHandler) => {
     if (sourceOptions) {
       player.currentSource().keySystems = sourceOptions;
 
+      // works around https://bugs.chromium.org/p/chromium/issues/detail?id=895449
       if (player.eme.initializeMediaKeys) {
         player.eme.initializeMediaKeys();
       }


### PR DESCRIPTION
## Description
Uses a new videojs-contrib-eme API to set up EME immediately and not wait for `encrypted`
https://github.com/videojs/videojs-contrib-eme/pull/61

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
