### PR TITLE
Throttle final playlist reloads when using DASH

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -162,6 +162,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
   pause() {
     this.stopRequest();
+    window.clearTimeout(this.mediaUpdateTimeout);
     if (this.state === 'HAVE_NOTHING') {
       // If we pause the loader before any data has been retrieved, its as if we never
       // started, so reset to an unstarted state.
@@ -169,7 +170,18 @@ export default class DashPlaylistLoader extends EventTarget {
     }
   }
 
-  load() {
+  load(isFinalRendition) {
+    window.clearTimeout(this.mediaUpdateTimeout);
+
+    const media = this.media();
+
+    if (isFinalRendition) {
+      const delay = media ? (media.targetDuration / 2) * 1000 : 5 * 1000;
+
+      this.mediaUpdateTimeout = window.setTimeout(() => this.load(), delay);
+      return;
+    }
+
     // because the playlists are internal to the manifest, load should either load the
     // main manifest, or do nothing but trigger an event
     if (!this.started) {

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -397,3 +397,41 @@ QUnit.test('media playlists "refresh" by re-parsing master xml', function(assert
 
   assert.equal(refreshes, 1, 'refreshed playlist after last segment duration');
 });
+
+QUnit.test('delays load when on final rendition', function(assert) {
+  let loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
+  let loadedplaylistEvents = 0;
+
+  loader.on('loadedplaylist', () => loadedplaylistEvents++);
+
+  // do an initial load to start the loader
+  loader.load();
+  standardXHRResponse(this.requests.shift());
+
+  assert.equal(loadedplaylistEvents, 2, 'two loadedplaylist events after first load');
+
+  loader.load();
+
+  assert.equal(loadedplaylistEvents, 3, 'one more loadedplaylist event after load');
+
+  loader.load(false);
+
+  assert.equal(
+    loadedplaylistEvents,
+    4,
+    'one more loadedplaylist event after load with isFinalRendition false');
+
+  loader.load(true);
+
+  assert.equal(
+    loadedplaylistEvents,
+    4,
+    'no loadedplaylist event after load with isFinalRendition false');
+
+  this.clock.tick(loader.media().targetDuration / 2 * 1000);
+
+  assert.equal(
+    loadedplaylistEvents,
+    5,
+    'one more loadedplaylist event after final rendition delay');
+});

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -408,6 +408,7 @@ QUnit.test('delays load when on final rendition', function(assert) {
   loader.load();
   standardXHRResponse(this.requests.shift());
 
+  // one for master, one for media on first selection
   assert.equal(loadedplaylistEvents, 2, 'two loadedplaylist events after first load');
 
   loader.load();


### PR DESCRIPTION
## Description
HLS already throttles reloads of the final playlist, however, DASH does not. This adds the throttling behavior to the DASH playlist loader.

To see the behavior:
1) Go to https://videojs.github.io/http-streaming/
2) Enter the source as: https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd and the mime type as: application/dash+xml
3) Click play
4) Open the console and go to the network tab
5) Click "Offline"

The failed requests will shoot up as fast as can be processed (since the retries are immediate).

The fix makes it so that retries are only made at half the target duration.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
