### PR TITLE
chore: update mux.js to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6561,9 +6561,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.5.1.tgz",
-      "integrity": "sha512-j4rEyZKCRinGaSiBxPx9YD9B782TMPHPOlKyaMY07vIGTNYg4ouCEBvL6zX9Hh1k1fKZ5ZF3S7c+XVk6PB+Igw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.0.1.tgz",
+      "integrity": "sha512-yfmJ9CaLGSyRnEwqwzvISSZe6EdcvXIsgapZfuNNFuUQUlYDwltnCgZqV6IG90daY4dYTemK/hxMoxI1bB6RjA=="
     },
     "mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "4.2.0",
     "mpd-parser": "0.7.0",
-    "mux.js": "4.5.1",
+    "mux.js": "5.0.1",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.8.0 || ^7.0.0"
   },


### PR DESCRIPTION
Includes the changes for [5.0.0 and 5.0.1](https://github.com/videojs/mux.js/compare/v4.5.1...v5.0.1)