### PR TITLE
Don't wait for requests to finish when encountering an error in media…

### DIFF
--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -193,6 +193,50 @@ QUnit.test('cancels outstanding key requests on timeout', function(assert) {
   this.clock.tick(2000);
 });
 
+QUnit.test('does not wait for other requests to finish when one request errors',
+function(assert) {
+  let keyReq;
+  let abortedKeyReq = false;
+  const done = assert.async();
+
+  assert.expect(8);
+  mediaSegmentRequest(
+    this.xhr,
+    this.xhrOptions,
+    this.noop,
+    this.noop,
+    {
+      resolvedUri: '0-test.ts',
+      key: {
+        resolvedUri: '0-key.php'
+      }
+    },
+    this.noop,
+    (error, segmentData) => {
+      assert.notOk(keyReq.aborted, 'did not run original abort function');
+      assert.ok(abortedKeyReq, 'ran overridden abort function');
+      assert.equal(error.code, REQUEST_ERRORS.FAILURE, 'request failed');
+
+      done();
+    });
+  assert.equal(this.requests.length, 2, 'there are two requests');
+
+  keyReq = this.requests.shift();
+  // Typically, an abort will run the error algorithm for an XHR, however, in certain
+  // cases (e.g., if the request is unsent), the error algorithm will not be run and
+  // the request will never "finish." In order to mimic this behavior, override the
+  // default abort function so that it doesn't finish.
+  keyReq.abort = () => {
+    abortedKeyReq = true;
+  };
+  const segmentReq = this.requests.shift();
+
+  assert.equal(keyReq.uri, '0-key.php', 'the first request is for a key');
+  assert.equal(segmentReq.uri, '0-test.ts', 'the second request is for a segment');
+
+  segmentReq.respond(500, null, '');
+});
+
 QUnit.test('the key response is converted to the correct format', function(assert) {
   let keyReq;
   const done = assert.async();


### PR DESCRIPTION
…-segment-request

## Description
When playing content where two requests may be made for a segment (i.e., there's a map tag for a segment, so both the segment and init segment are requested), if there's a request error on one of the requests before the other has started, then it's possible media-segment-request will be stuck forever, and never finish its group of requests.

To see the behavior:

Go to https://videojs.github.io/http-streaming/
Enter the source as: https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd and the mime type as: application/dash+xml
Click play
Open the console and go to the network tab
Click "Offline"
Wait until the network tab starts showing only audio segment requests (m4a)
Uncheck "Offline"

Only the m4a requests will continue loading. Content may continue playback with audio only, and a stuck video frame.

The fix makes it so that both audio segment (m4a) requests, and init and video segment (m4v) requests are continued, and content resumes as expected.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
