### PR TITLE
Fixed sourceBuffer conflict on endOfStream

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -668,6 +668,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * @private
    */
   onEndOfStream() {
+    // Media Source may have been closed
+    if (!this.masterPlaylistLoader_.media() || this.mediaSource.readyState !== 'open' || this.mainSegmentLoader_.sourceUpdater_ && this.mainSegmentLoader_.sourceUpdater_.updating()) {
+      return;
+    }
+
     let isEndOfStream = this.mainSegmentLoader_.ended_;
 
     if (this.mediaTypes_.AUDIO.activePlaylistLoader) {


### PR DESCRIPTION
## Description
On near end of DASH playback, we observed console log errors with DOMException:
```
VIDEOJS: ERROR: DOMException: Failed to execute
'endOfStream' on 'MediaSource': The 'updating' attribute is true on one or
more of this MediaSource's SourceBuffers.
```

## Specific Changes proposed
After checking the specification laid out by W3C:
https://w3c.github.io/media-source/#dom-mediasource-endofstream
I have added checks on

1. If the readyState attribute is not in the "open" state then throw an InvalidStateError exception and abort these steps

2. If the updating attribute equals true on any SourceBuffer in sourceBuffers, then throw an InvalidStateError exception and abort these steps.

on `master-playlist-controller.js:onEndOfStream()` where problem seems lie there.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
