### PR TITLE
feat: expose custom M3U8 mapper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Video.js Compatibility: 6.0, 7.0
       - [smoothQualityChange](#smoothqualitychange)
       - [allowSeeksWithinUnsafeLiveWindow](#allowseekswithinunsafelivewindow)
       - [customTagParsers](#customtagparsers)
+      - [customTagMappers](#customtagmappers)
   - [Runtime Properties](#runtime-properties)
     - [hls.playlists.master](#hlsplaylistsmaster)
     - [hls.playlists.media](#hlsplaylistsmedia)
@@ -400,6 +401,12 @@ The property defaults to `false`.
 * can be used as a source option
 
 With `customTagParsers` you can pass an array of custom m3u8 tag parser objects. See https://github.com/videojs/m3u8-parser#custom-parsers
+
+##### customTagMappers
+* Type: `Array`
+* can be used as a source option
+
+Similar to `customTagParsers`, with `customTagMappers` you can pass an array of custom m3u8 tag mapper objects. See https://github.com/videojs/m3u8-parser#custom-parsers
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,11 @@
         "video.js": "^6.8.0 || ^7.0.0"
       },
       "dependencies": {
+        "m3u8-parser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
+          "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
+        },
         "mpd-parser": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.6.1.tgz",
@@ -6217,9 +6222,12 @@
       "dev": true
     },
     "m3u8-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
-      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.3.0.tgz",
+      "integrity": "sha512-bVbjuBMoVIgFL1vpXVIxjeaoB5TPDJRb0m5qiTdM738SGqv/LAmsnVVPlKjM4fulm/rr1XZsKM+owHm+zvqxYA==",
+      "requires": {
+        "global": "^4.3.2"
+      }
     },
     "magic-string": {
       "version": "0.22.5",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "aes-decrypter": "3.0.0",
     "global": "^4.3.0",
-    "m3u8-parser": "4.2.0",
+    "m3u8-parser": "4.3.0",
     "mpd-parser": "0.7.0",
     "mux.js": "5.0.1",
     "url-toolkit": "^2.1.3",

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -206,6 +206,7 @@ export default class PlaylistLoader extends EventTarget {
     const options = hls.options_;
 
     this.customTagParsers = (options && options.customTagParsers) || [];
+    this.customTagMappers = (options && options.customTagMappers) || [];
 
     if (!this.srcUrl) {
       throw new Error('A non-empty playlist URL is required');
@@ -272,6 +273,9 @@ export default class PlaylistLoader extends EventTarget {
 
     // adding custom tag parsers
     this.customTagParsers.forEach(customParser => parser.addParser(customParser));
+
+    // adding custom tag mappers
+    this.customTagMappers.forEach(mapper => parser.addTagMapper(mapper));
 
     parser.push(xhr.responseText);
     parser.end();
@@ -514,6 +518,9 @@ export default class PlaylistLoader extends EventTarget {
 
       // adding custom tag parsers
       this.customTagParsers.forEach(customParser => parser.addParser(customParser));
+
+      // adding custom tag mappers
+      this.customTagMappers.forEach(mapper => parser.addTagMapper(mapper));
 
       parser.push(req.responseText);
       parser.end();

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -402,6 +402,7 @@ class HlsHandler extends Component {
         this.source_.useBandwidthFromLocalStorage :
         this.options_.useBandwidthFromLocalStorage || false;
     this.options_.customTagParsers = this.options_.customTagParsers || [];
+    this.options_.customTagMappers = this.options_.customTagMappers || [];
 
     if (typeof this.options_.blacklistDuration !== 'number') {
       this.options_.blacklistDuration = 5 * 60;
@@ -439,7 +440,8 @@ class HlsHandler extends Component {
       'limitRenditionByPlayerDimensions',
       'bandwidth',
       'smoothQualityChange',
-      'customTagParsers'
+      'customTagParsers',
+      'customTagMappers'
     ].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -38,6 +38,27 @@ const options = [{
   default: false,
   test: true,
   alt: false
+}, {
+  name: 'useBandwidthFromLocalStorage',
+  default: false,
+  test: true
+}, {
+  name: 'customTagParsers',
+  default: [],
+  test: [{
+    expression: /#PARSER/,
+    customType: 'test',
+    segment: true
+  }]
+}, {
+  name: 'customTagMappers',
+  default: [],
+  test: [{
+    expression: /#MAPPER/,
+    map(line) {
+      return `#FOO`;
+    }
+  }]
 }];
 
 const CONFIG_KEYS = Object.keys(Config);
@@ -270,7 +291,7 @@ options.forEach((opt) => {
 
     let hls = this.player.tech_.hls;
 
-    assert.equal(hls.options_[opt.name],
+    assert.deepEqual(hls.options_[opt.name],
                 opt.default,
                 `${opt.name} should be default`);
   });
@@ -306,7 +327,7 @@ options.forEach((opt) => {
 
     let hls = this.player.tech_.hls;
 
-    assert.equal(hls.options_[opt.name],
+    assert.deepEqual(hls.options_[opt.name],
                 opt.test,
                 `${opt.name} should be equal to sourceHandler Option`);
   });
@@ -325,7 +346,7 @@ options.forEach((opt) => {
 
     let hls = this.player.tech_.hls;
 
-    assert.equal(hls.options_[opt.name],
+    assert.deepEqual(hls.options_[opt.name],
                 opt.test,
                 `${opt.name} should be equal to src option`);
   });
@@ -345,7 +366,7 @@ options.forEach((opt) => {
 
     let hls = this.player.tech_.hls;
 
-    assert.equal(hls.options_[opt.name],
+    assert.deepEqual(hls.options_[opt.name],
                 opt.test,
                 `${opt.name} should be equal to sourchHandler option`);
   });
@@ -366,7 +387,7 @@ options.forEach((opt) => {
 
     let hls = this.player.tech_.hls;
 
-    assert.equal(hls.options_[opt.name],
+    assert.deepEqual(hls.options_[opt.name],
                 opt.test,
                 `${opt.name} should be equal to sourchHandler option`);
   });


### PR DESCRIPTION
## Description
Exposes parser and mapping APIs from the m3u8-parser module.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
  - [x] https://github.com/videojs/m3u8-parser/pull/73
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [x] Reviewed by Two Core Contributors
