### PR TITLE
fix(id3): cuechange event not being triggered on audio-only HLS streams

### DIFF
--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -479,7 +479,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
       sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
       this.concatAndAppendSegments_(sortedSegments.video, this.videoBuffer_);
-      
+
     } else if (this.videoBuffer_ && (this.audioDisabled_ || !this.audioBuffer_)) {
       // The transmuxer did not return any bytes of video, meaning it was all trimmed
       // for gop alignment. Since we have a video buffer and audio is disabled, updateend

--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -490,8 +490,8 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       triggerUpdateend = true;
     }
 
-	  // Add text-track data for all
-	  addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
+    // Add text-track data for all
+    addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
 
     if (!this.audioDisabled_ && this.audioBuffer_) {
       this.concatAndAppendSegments_(sortedSegments.audio, this.audioBuffer_);

--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -490,8 +490,8 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       triggerUpdateend = true;
     }
 
-	//Add text-track data for all
-	addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
+	  // Add text-track data for all
+	  addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
 
     if (!this.audioDisabled_ && this.audioBuffer_) {
       this.concatAndAppendSegments_(sortedSegments.audio, this.audioBuffer_);

--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -479,8 +479,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
       sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
       this.concatAndAppendSegments_(sortedSegments.video, this.videoBuffer_);
-      // TODO: are video tracks the only ones with text tracks?
-      addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
+      
     } else if (this.videoBuffer_ && (this.audioDisabled_ || !this.audioBuffer_)) {
       // The transmuxer did not return any bytes of video, meaning it was all trimmed
       // for gop alignment. Since we have a video buffer and audio is disabled, updateend
@@ -490,6 +489,9 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       // buffer will not be in an updating state.
       triggerUpdateend = true;
     }
+
+	//Add text-track data for all
+	addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
 
     if (!this.audioDisabled_ && this.audioBuffer_) {
       this.concatAndAppendSegments_(sortedSegments.audio, this.audioBuffer_);


### PR DESCRIPTION
This is a proposed fix for https://github.com/videojs/http-streaming/issues/130. Instead of adding text-track data only to video segments, we are now adding to all segments.

One change bringing the addTextTrackData invocation outside of the conditional which checks for video buffer.

Sources:

With audio only
http://li720-23.members.linode.com/hls/audio.m3u8
With video and audio
http://li720-23.members.linode.com/hls/video.m3u8

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
