### PR TITLE
Use exposed transmuxer time modifications for more accurate conversion between stream and player times

### DIFF
--- a/docs/stream-time-from-player-time.md
+++ b/docs/stream-time-from-player-time.md
@@ -1,0 +1,120 @@
+# How to get stream time from player time
+
+## Definitions
+
+NOTE: All times referenced in seconds unless otherwise specified.
+
+*Player Time*: any time that can be gotten/set from player.currentTime() (e.g., any time within player.seekable().start(0) to player.seekable().end(0))
+*Stream Time*: any time set within one of the stream's segments used by video frames (e.g., dts, pts, base media decode time), natively uses clock values, but referenced in seconds throughout the document
+*Program Time*: any time referencing the real world (e.g., EXT-X-PROGRAM-DATE-TIME)
+*Start of Segment*: the pts (presentation timestamp) value of the first frame in a segment
+
+## Overview
+
+In order to convert from a *player time* to a *stream time*, two things are required:
+
+1. An anchor point must be chosen to match up a *player time* and a *stream time*
+1. The offset must be determined between the *player time* and the *stream time* at that point
+
+Two anchor points that are usable are the time since the start of a new timeline (e.g., the time since the last discontinuity or start of the stream), and the start of a segment. Because each segment is tagged with its *program time*, using the segment start as the anchor point is the easiest solution, since it's the closest point to the time to convert, and it doesn't require us to track time changes across multiple segments.
+
+To make use of the segment start, and to calculate the offset between the two, a few properties are needed:
+
+1. The start of the segment before transmuxing
+1. Time changes made to the segment during transmuxing
+1. The start of the segment after transmuxing
+
+While the start of the segment before and after transmuxing is trivial to retrieve, getting the time changes made during transmuxing is more complicated, as we must account for any trimming, prepending, and gap filling made during the transmux stage. However, the required use-case only requires determining the position of a video frame, allowing us to ignore any changes made to the audio timeline (because VHS uses video as the timeline of truth), and allowing us to ignore a couple of the video changes made.
+
+What follows are the changes made to a video stream by the transmuxer that could modify the timeline, and if they must be accounted for in the conversion:
+
+* Keyframe Pulling
+  * Used when: the segment doesn't start with a keyframe.
+  * Impact: the keyframe with the lowest dts value in the segment is "pulled" back to the first dts value in the segment, and all frames in-between are dropped.
+  * Need to account in time conversion? No. If a keyframe is pulled, and frames before it are dropped, then the segment will maintain the same segment duration, and the viewer is only seeing the keyframe during that period.
+* GOP Fusion
+  * Used when: the segment doesn't start with a keyframe.
+  * Impact: if GOPs were saved from previous segment appends, the last GOP will be prepended to the segment.
+  * Need to account in time conversion? Yes. The segment is artificially extended, so while it shouldn't impact the stream time itself (since it will overlap with content already appended), it will impact the post transmux start of segment.
+* GOPS to Align With
+  * Used when: switching renditions, or appending segments with overlapping GOPs (intersecting time ranges).
+  * Impact: GOPs in the segment will be dropped until there are no overlapping GOPs with previous segments.
+  * Need to account in time conversion? No. So long as we aren't switching renditions, and the content is sane enough to not contain overlapping GOPs, this should not have a meaningful impact.
+
+Among the changes, with only GOP Fusion having an impact, the task becomes simpler. Instead of accounting for any changes to the video stream, only those from GOP Fusion should be accounted for. Since GOP fusion will potentially only prepend frames to the segment, we just need the number of seconds prepended to the segment when offsetting the time. As such, we can add the following properties to each segment:
+
+```
+segment: {
+  ...
+  videoTimingInfo: {
+    // start of segment (stream time)
+    originalStart
+    // number of seconds prepended by GOP fusion
+    transmuxerPrependedSeconds
+    // start of transmuxed segment (player time)
+    transmuxedStart
+  }
+}
+```
+
+## The Formula
+
+With the properties listed above, calculating a *stream time* from a *player time* is given as follows:
+
+```
+const playerTimeToStreamTime = (playerTime, segment) => {
+  const originalStart = segment.videoTimingInfo.originalStart;
+  const transmuxerPrependedSeconds = segment.videoTimingInfo.transmuxerPrependedSeconds;
+  const transmuxedStart = segment.videoTimingInfo.transmuxedStart;
+
+  // get the proper start of new content (not prepended old content) from the segment, in player time
+  const startOfSegment = transmuxedStart + prependedSeconds;
+  const offsetFromSegmentStart = playerTime - startOfSegment;
+
+  return originalStart + offsetFromSegmentStart;
+};
+```
+
+The *stream time* can be converted to *program time* by taking the EXT-X-PROGRAM-DATE-TIME tagged on the segment and adding *stream time* - segment.videoTimingInfo.originalStart.
+
+## Examples
+
+```
+// Stream Times:
+//   segment1: 30.1 => 32.1
+//   segment2: 32.1 => 34.1
+//   segment3: 34.1 => 36.1
+//
+// Player Times:
+//   segment1: 0 => 2
+//   segment2: 2 => 4
+//   segment3: 4 => 6
+
+const segment2 = {
+  videoTimingInfo: {
+    originalStart: 32.1,
+    transmuxerPrependedSeconds: 0.3,
+    transmuxedStart: 1.7
+  }
+};
+playerTimeToStreamTime(2.5, segment2);
+// startOfSegment = 1.7 + 0.3 = 2
+// offsetFromSegmentStart = 2.5 - 2 = 0.5
+// return 32.1 + 0.5 = 32.6
+
+const segment3 = {
+  videoTimingInfo: {
+    originalStart: 34.1,
+    transmuxerPrependedSeconds: 0.2,
+    transmuxedStart: 3.8
+  }
+};
+playerTimeToStreamTime(4, segment3);
+// startOfSegment = 3.8 + 0.2 = 4
+// offsetFromSegmentStart = 4 - 4 = 0
+// return 34.1 + 0 = 34.1
+```
+
+## Transmux Before Append Changes
+
+Even though segment timing values are retained for transmux before append, the formula does not need to change, as all that matters for calculation is the offset from the transmuxed segment start, which can then be applied to the stream time start of segment, or the program time start of segment.

--- a/src/mse/transmuxer-worker.js
+++ b/src/mse/transmuxer-worker.js
@@ -66,10 +66,10 @@ const wireTransmuxerEvents = function(self, transmuxer) {
     });
   });
 
-  transmuxer.on('videoTimingInfo', function(videoTimingInfo) {
+  transmuxer.on('videoSegmentTimingInfo', function(videoSegmentTimingInfo) {
     self.postMessage({
-      action: 'videoTimingInfo',
-      videoTimingInfo
+      action: 'videoSegmentTimingInfo',
+      videoSegmentTimingInfo
     });
   });
 };

--- a/src/mse/transmuxer-worker.js
+++ b/src/mse/transmuxer-worker.js
@@ -65,6 +65,13 @@ const wireTransmuxerEvents = function(self, transmuxer) {
       gopInfo
     });
   });
+
+  transmuxer.on('videoTimingInfo', function(videoTimingInfo) {
+    self.postMessage({
+      action: 'videoTimingInfo',
+      videoTimingInfo
+    });
+  });
 };
 
 /**

--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -102,8 +102,8 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         return this.appendGopInfo_(event);
       }
 
-      if (event.data.action === 'videoTimingInfo') {
-        return this.videoTimingInfo_(event.data.videoTimingInfo);
+      if (event.data.action === 'videoSegmentTimingInfo') {
+        return this.videoSegmentTimingInfo_(event.data.videoSegmentTimingInfo);
       }
     };
 
@@ -218,7 +218,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     return;
   }
 
-  videoTimingInfo_(timingInfo) {
+  videoSegmentTimingInfo_(timingInfo) {
     const timingInfoInSeconds = {
       start: {
         decode: timingInfo.start.dts / ONE_SECOND_IN_TS,
@@ -230,12 +230,15 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       }
     };
 
-    if (timingInfo.prependedGopDuration) {
-      timingInfoInSeconds.prependedGopDuration =
-          timingInfo.prependedGopDuration / ONE_SECOND_IN_TS;
+    if (timingInfo.prependedContentDuration) {
+      timingInfoInSeconds.prependedContentDuration =
+          timingInfo.prependedContentDuration / ONE_SECOND_IN_TS;
     }
 
-    this.trigger({ type: 'videoTimingInfo', videoTimingInfo: timingInfoInSeconds });
+    this.trigger({
+      type: 'videoSegmentTimingInfo',
+      videoSegmentTimingInfo: timingInfoInSeconds
+    });
   }
 
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1171,6 +1171,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     const segment = segmentInfo.segment;
     const timingInfo = this.syncController_.probeSegmentInfo(segmentInfo);
 
+    if (timingInfo && typeof timingInfo.videoPresentationStart !== 'undefined') {
+      segment.videoTimingInfo = {
+        originalPresentationStart: timingInfo.videoPresentationStart
+      };
+    }
+
     // When we have our first timing info, determine what media types this loader is
     // dealing with. Although we're maintaining extra state, it helps to preserve the
     // separation of segment loader from the actual source buffers.
@@ -1247,7 +1253,26 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.logger_(segmentInfoString(segmentInfo));
 
     this.sourceUpdater_.appendBuffer(segmentInfo.bytes,
-                                     this.handleUpdateEnd_.bind(this));
+                                     this.handleUpdateEnd_.bind(this),
+                                     this.handleVideoTimingInfo_.bind(this));
+  }
+
+  handleVideoTimingInfo_(event) {
+    if (!this.pendingSegment_) {
+      return;
+    }
+
+    const segment =
+      this.pendingSegment_.playlist.segments[this.pendingSegment_.mediaIndex];
+
+    if (!segment.videoTimingInfo) {
+      segment.videoTimingInfo = {};
+    }
+
+    segment.videoTimingInfo.transmuxerPrependedSeconds =
+      event.videoTimingInfo.prependedGopDuration || 0;
+    segment.videoTimingInfo.transmuxedPresentationStart =
+      event.videoTimingInfo.start.presentation;
   }
 
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1256,11 +1256,11 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.sourceUpdater_.appendBuffer({
       bytes: segmentInfo.bytes,
-      videoTimingInfoCallback: this.handleVideoTimingInfo_.bind(this)
+      videoSegmentTimingInfoCallback: this.handleVideoSegmentTimingInfo_.bind(this)
     }, this.handleUpdateEnd_.bind(this));
   }
 
-  handleVideoTimingInfo_(event) {
+  handleVideoSegmentTimingInfo_(event) {
     if (!this.pendingSegment_) {
       return;
     }
@@ -1273,11 +1273,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     segment.videoTimingInfo.transmuxerPrependedSeconds =
-      event.videoTimingInfo.prependedGopDuration || 0;
+      event.videoSegmentTimingInfo.prependedContentDuration || 0;
     segment.videoTimingInfo.transmuxedPresentationStart =
-      event.videoTimingInfo.start.presentation;
+      event.videoSegmentTimingInfo.start.presentation;
     segment.videoTimingInfo.transmuxedPresentationEnd =
-      event.videoTimingInfo.end.presentation;
+      event.videoSegmentTimingInfo.end.presentation;
   }
 
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1237,7 +1237,9 @@ export default class SegmentLoader extends videojs.EventTarget {
           this.activeInitSegmentId_ !== initId) {
         const initSegment = this.initSegment(segment.map);
 
-        this.sourceUpdater_.appendBuffer(initSegment.bytes, () => {
+        this.sourceUpdater_.appendBuffer({
+          bytes: initSegment.bytes
+        }, () => {
           this.activeInitSegmentId_ = initId;
         });
       }
@@ -1252,9 +1254,10 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.logger_(segmentInfoString(segmentInfo));
 
-    this.sourceUpdater_.appendBuffer(segmentInfo.bytes,
-                                     this.handleUpdateEnd_.bind(this),
-                                     this.handleVideoTimingInfo_.bind(this));
+    this.sourceUpdater_.appendBuffer({
+      bytes: segmentInfo.bytes,
+      videoTimingInfoCallback: this.handleVideoTimingInfo_.bind(this)
+    }, this.handleUpdateEnd_.bind(this));
   }
 
   handleVideoTimingInfo_(event) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1276,6 +1276,8 @@ export default class SegmentLoader extends videojs.EventTarget {
       event.videoTimingInfo.prependedGopDuration || 0;
     segment.videoTimingInfo.transmuxedPresentationStart =
       event.videoTimingInfo.start.presentation;
+    segment.videoTimingInfo.transmuxedPresentationEnd =
+      event.videoTimingInfo.end.presentation;
   }
 
   /**

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -107,11 +107,15 @@ export default class SourceUpdater {
    * @param {Function} done the function to call when done
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-appendBuffer-void-ArrayBuffer-data
    */
-  appendBuffer(bytes, done) {
+  appendBuffer(bytes, done, videoTimingInfoCallback) {
     this.processedAppend_ = true;
     this.queueCallback_(() => {
+      this.sourceBuffer_.addEventListener('videoTimingInfo', videoTimingInfoCallback);
       this.sourceBuffer_.appendBuffer(bytes);
-    }, done);
+    }, () => {
+      this.sourceBuffer_.removeEventListener('videoTimingInfo', videoTimingInfoCallback);
+      done();
+    });
   }
 
   /**

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -107,13 +107,19 @@ export default class SourceUpdater {
    * @param {Function} done the function to call when done
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-appendBuffer-void-ArrayBuffer-data
    */
-  appendBuffer(bytes, done, videoTimingInfoCallback) {
+  appendBuffer(config, done) {
     this.processedAppend_ = true;
     this.queueCallback_(() => {
-      this.sourceBuffer_.addEventListener('videoTimingInfo', videoTimingInfoCallback);
-      this.sourceBuffer_.appendBuffer(bytes);
+      if (config.videoTimingInfoCallback) {
+        this.sourceBuffer_.addEventListener(
+          'videoTimingInfo', config.videoTimingInfoCallback);
+      }
+      this.sourceBuffer_.appendBuffer(config.bytes);
     }, () => {
-      this.sourceBuffer_.removeEventListener('videoTimingInfo', videoTimingInfoCallback);
+      if (config.videoTimingInfoCallback) {
+        this.sourceBuffer_.removeEventListener(
+          'videoTimingInfo', config.videoTimingInfoCallback);
+      }
       done();
     });
   }

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -120,7 +120,9 @@ export default class SourceUpdater {
         this.sourceBuffer_.removeEventListener(
           'videoTimingInfo', config.videoTimingInfoCallback);
       }
-      done();
+      if (done) {
+        done();
+      }
     });
   }
 

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -110,15 +110,15 @@ export default class SourceUpdater {
   appendBuffer(config, done) {
     this.processedAppend_ = true;
     this.queueCallback_(() => {
-      if (config.videoTimingInfoCallback) {
+      if (config.videoSegmentTimingInfoCallback) {
         this.sourceBuffer_.addEventListener(
-          'videoTimingInfo', config.videoTimingInfoCallback);
+          'videoSegmentTimingInfo', config.videoSegmentTimingInfoCallback);
       }
       this.sourceBuffer_.appendBuffer(config.bytes);
     }, () => {
-      if (config.videoTimingInfoCallback) {
+      if (config.videoSegmentTimingInfoCallback) {
         this.sourceBuffer_.removeEventListener(
-          'videoTimingInfo', config.videoTimingInfoCallback);
+          'videoSegmentTimingInfo', config.videoSegmentTimingInfoCallback);
       }
       if (done) {
         done();

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -464,12 +464,18 @@ export default class SyncController extends videojs.EventTarget {
       segmentEndTime = timeInfo.audio[1].dtsTime;
     }
 
-    return {
+    const probedInfo = {
       start: segmentStartTime,
       end: segmentEndTime,
       containsVideo: timeInfo.video && timeInfo.video.length === 2,
       containsAudio: timeInfo.audio && timeInfo.audio.length === 2
     };
+
+    if (timeInfo.video && timeInfo.video.length === 2) {
+      probedInfo.videoPresentationStart = timeInfo.video[0].ptsTime;
+    }
+
+    return probedInfo;
   }
 
   timestampOffsetForTimeline(timeline) {

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -352,7 +352,10 @@ export const seekToStreamTime = ({
     segment.dateTimeObject,
     streamTime
   );
-  // TODO account for prepended content
+
+  // Since the segment.start value is determined from the buffered end or ending time
+  // of the prior segment, the seekToTime doesn't need to account for any transmuxer
+  // modifications.
   const seekToTime = segment.start + mediaOffset;
   const seekedCallback = () => {
     return callback(null, tech.currentTime());

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -55,7 +55,8 @@ export const actualSegmentVideoDuration = (videoTimingInfo) => {
 };
 
 /**
- * Finds a segment that contains the stream time give as an ISO-8601 string.
+ * Finds a segment that contains the time requested given as an ISO-8601 string. The
+ * returned segment might be an estimate or an accurate match.
  *
  * @param {String} streamTime The ISO-8601 streamTime to find a match for
  * @param {Object} playlist A playlist object to search within

--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -30,7 +30,9 @@ QUnit.test('runs a callback when the source buffer is created', function(assert)
   let updater = new SourceUpdater(this.mediaSource, 'video/mp2t');
   let sourceBuffer;
 
-  updater.appendBuffer(new Uint8Array([0, 1, 2]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0, 1, 2])
+  });
 
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
@@ -50,7 +52,9 @@ function(assert) {
 
   let updater = new SourceUpdater(this.mediaSource, 'video/mp2t', sourceBufferEmitter);
 
-  updater.appendBuffer(new Uint8Array([0, 1, 2]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0, 1, 2])
+  });
 
   sourceBuffer = this.mediaSource.sourceBuffers[1];
   assert.equal(sourceBuffer.updates_.length, 1, 'called the source buffer once');
@@ -66,7 +70,9 @@ function(assert) {
     new SourceUpdater(this.mediaSource, 'video/mp2t', '', sourceBufferEmitter);
   let sourceBuffer;
 
-  updater.appendBuffer(new Uint8Array([0, 1, 2]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0, 1, 2])
+  });
 
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
@@ -88,10 +94,14 @@ QUnit.test('runs the completion callback when updateend fires', function(assert)
 
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
-  updater.appendBuffer(new Uint8Array([0, 1, 2]), function() {
+  updater.appendBuffer({
+    bytes: new Uint8Array([0, 1, 2])
+  }, function() {
     updateends++;
   });
-  updater.appendBuffer(new Uint8Array([2, 3, 4]), function() {
+  updater.appendBuffer({
+    bytes: new Uint8Array([2, 3, 4])
+  }, function() {
     throw new Error('Wrong completion callback invoked!');
   });
 
@@ -104,11 +114,15 @@ QUnit.test('runs the next callback after updateend fires', function(assert) {
   let updater = new SourceUpdater(this.mediaSource, 'video/mp2t');
   let sourceBuffer;
 
-  updater.appendBuffer(new Uint8Array([0, 1, 2]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0, 1, 2])
+  });
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
 
-  updater.appendBuffer(new Uint8Array([2, 3, 4]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([2, 3, 4])
+  });
   assert.equal(sourceBuffer.updates_.length, 1, 'delayed the update');
 
   sourceBuffer.trigger('updateend');
@@ -121,12 +135,18 @@ QUnit.test('runs only one callback at a time', function(assert) {
   let updater = new SourceUpdater(this.mediaSource, 'video/mp2t');
   let sourceBuffer;
 
-  updater.appendBuffer(new Uint8Array([0]));
-  updater.appendBuffer(new Uint8Array([1]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0])
+  });
+  updater.appendBuffer({
+    bytes: new Uint8Array([1])
+  });
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
 
-  updater.appendBuffer(new Uint8Array([2]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([2])
+  });
   assert.equal(sourceBuffer.updates_.length, 1, 'queued some updates');
   assert.deepEqual(sourceBuffer.updates_[0].append, new Uint8Array([0]),
                   'ran the first update');
@@ -136,7 +156,9 @@ QUnit.test('runs only one callback at a time', function(assert) {
   assert.deepEqual(sourceBuffer.updates_[1].append, new Uint8Array([1]),
                   'ran the second update');
 
-  updater.appendBuffer(new Uint8Array([3]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([3])
+  });
   sourceBuffer.trigger('updateend');
   assert.equal(sourceBuffer.updates_.length, 3, 'queued the updates');
   assert.deepEqual(sourceBuffer.updates_[2].append, new Uint8Array([2]),
@@ -154,7 +176,9 @@ QUnit.test('runs updates immediately if possible', function(assert) {
 
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
-  updater.appendBuffer(new Uint8Array([0]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0])
+  });
   assert.equal(sourceBuffer.updates_.length, 1, 'ran an update');
   assert.deepEqual(sourceBuffer.updates_[0].append, new Uint8Array([0]),
                   'appended the bytes');
@@ -170,7 +194,9 @@ QUnit.test('supports abort', function(assert) {
                0,
                'abort not queued before source buffers are appended to');
 
-  updater.appendBuffer(new Uint8Array([0]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0])
+  });
 
   updater.abort();
 
@@ -201,7 +227,9 @@ QUnit.test('supports removeBuffer', function(assert) {
                0,
                'remove not queued before sourceBuffers are appended to');
 
-  updater.appendBuffer(new Uint8Array([0]));
+  updater.appendBuffer({
+    bytes: new Uint8Array([0])
+  });
 
   updater.remove(1, 14);
 
@@ -222,7 +250,9 @@ QUnit.test('supports timestampOffset', function(assert) {
   assert.equal(updater.timestampOffset(), 21, 'reflects changes immediately');
   assert.equal(sourceBuffer.timestampOffset, 21, 'applied the update');
 
-  updater.appendBuffer(new Uint8Array(2));
+  updater.appendBuffer({
+    bytes: new Uint8Array(2)
+  });
   updater.timestampOffset(14);
   assert.equal(updater.timestampOffset(), 14, 'reflects changes immediately');
   assert.equal(sourceBuffer.timestampOffset, 21, 'queues application after updates');

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -42,9 +42,9 @@ class MockSourceBuffer extends videojs.EventTarget {
     });
   }
 
-  appendBuffer(bytes) {
+  appendBuffer(config) {
     this.updates_.push({
-      append: bytes
+      append: config
     });
     this.updating = true;
   }

--- a/test/util/time.test.js
+++ b/test/util/time.test.js
@@ -1021,12 +1021,24 @@ QUnit.test('vod: seeks and returns player time seeked to if buffered', function(
           dateTimeString: '2018-10-12T22:33:49.037+00:00',
           dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
           duration: 1,
-          start: 0
+          start: 0,
+          videoTimingInfo: {
+            originalPresentationStart: 2,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 0,
+            transmuxedPresentationEnd: 1
+          }
         }, {
           dateTimeString: '2018-10-12T22:33:50.037+00:00',
           dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 1,
-          start: 1
+          start: 1,
+          videoTimingInfo: {
+            originalPresentationStart: 1,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 1,
+            transmuxedPresentationEnd: 2
+          }
         }
       ],
       targetDuration: 1,
@@ -1042,6 +1054,74 @@ QUnit.test('vod: seeks and returns player time seeked to if buffered', function(
         newTime,
         1,
         'player time that has been seeked to is returned'
+      );
+      done();
+    }
+  });
+});
+
+QUnit.test('vod: does not account for prepended content duration', function(assert) {
+  let currentTime = 0;
+  const done = assert.async();
+  const handlers = {};
+  const tech = videojs.mergeOptions(this.tech, {
+    one(e, handler) {
+      handlers[e] = handler;
+    },
+    currentTime(ct) {
+      if (ct && handlers.seeked) {
+        currentTime = ct;
+        return handlers.seeked(ct);
+      }
+
+      return currentTime;
+    }
+  });
+  const seekTo = (t) => {
+    tech.currentTime(t);
+  };
+
+  seekToStreamTime({
+    streamTime: '2018-10-12T22:33:51.037+00:00',
+    playlist: {
+      segments: [
+        {
+          dateTimeString: '2018-10-12T22:33:48.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:48.037+00:00'),
+          duration: 2,
+          start: 0,
+          videoTimingInfo: {
+            originalPresentationStart: 0,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 0,
+            transmuxedPresentationEnd: 2
+          }
+        }, {
+          dateTimeString: '2018-10-12T22:33:50.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
+          duration: 2,
+          start: 2,
+          videoTimingInfo: {
+            originalPresentationStart: 2,
+            transmuxerPrependedSeconds: 1,
+            transmuxedPresentationStart: 1,
+            transmuxedPresentationEnd: 4
+          }
+        }
+      ],
+      targetDuration: 1,
+      resolvedUri: 'test',
+      endList: true
+    },
+    seekTo,
+    // tech that hasn't started
+    tech,
+    callback: (err, newTime) => {
+      assert.notOk(err, 'no errors returned');
+      assert.equal(
+        newTime,
+        3,
+        'did not offset seek time by transmuxer modifications'
       );
       done();
     }
@@ -1077,12 +1157,24 @@ QUnit.test('live: seeks and returns player time seeked to if buffered', function
           dateTimeString: '2018-10-12T22:33:49.037+00:00',
           dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
           duration: 1,
-          start: 0
+          start: 0,
+          videoTimingInfo: {
+            originalPresentationStart: 0,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 0,
+            transmuxedPresentationEnd: 1
+          }
         }, {
           dateTimeString: '2018-10-12T22:33:50.037+00:00',
           dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 1,
-          start: 1
+          start: 1,
+          videoTimingInfo: {
+            originalPresentationStart: 1,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 1,
+            transmuxedPresentationEnd: 2
+          }
         }
       ],
       targetDuration: 1,
@@ -1132,12 +1224,24 @@ QUnit.test('setting pauseAfterSeek to false seeks without pausing', function(ass
           dateTimeString: '2018-10-12T22:33:49.037+00:00',
           dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
           duration: 1,
-          start: 0
+          start: 0,
+          videoTimingInfo: {
+            originalPresentationStart: 0,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 0,
+            transmuxedPresentationEnd: 1
+          }
         }, {
           dateTimeString: '2018-10-12T22:33:50.037+00:00',
           dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 1,
-          start: 1
+          start: 1,
+          videoTimingInfo: {
+            originalPresentationStart: 1,
+            transmuxerPrependedSeconds: 0,
+            transmuxedPresentationStart: 1,
+            transmuxedPresentationEnd: 2
+          }
         }
       ],
       targetDuration: 1,

--- a/test/util/time.test.js
+++ b/test/util/time.test.js
@@ -6,7 +6,8 @@ import {
   verifyProgramDateTimeTags,
   findSegmentForPlayerTime,
   findSegmentForStreamTime,
-  getOffsetFromTimestamp
+  getOffsetFromTimestamp,
+  originalSegmentVideoDuration
 } from '../../src/util/time.js';
 
 QUnit.module('Time');
@@ -501,6 +502,33 @@ QUnit.test('getOffsetFromTimestamp will calculate second differences in timestam
     getOffsetFromTimestamp('2018-11-10T19:38:57.158Z', '2018-11-10T19:38:56.158Z'),
     -1,
     'negative offset returned if streamTime is before comparison timestamp'
+  );
+});
+
+QUnit.test(
+'originalSegmentVideoDuration uses transmuxed end and start to determine duration',
+function(assert) {
+  assert.equal(
+    originalSegmentVideoDuration({
+      transmuxedPresentationEnd: 11,
+      transmuxedPresentationStart: 4,
+      transmuxerPrependedSeconds: 0
+    }),
+    7,
+    'determined original segment video duration'
+  );
+});
+
+QUnit.test('originalSegmentVideoDuration accounts for prepended content',
+function(assert) {
+  assert.equal(
+    originalSegmentVideoDuration({
+      transmuxedPresentationEnd: 11,
+      transmuxedPresentationStart: 4,
+      transmuxerPrependedSeconds: 3
+    }),
+    4,
+    'determined original segment video duration'
   );
 });
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -3267,8 +3267,8 @@ QUnit.test('convertToStreamTime will return stream time if buffered', function(a
   // since we don't run through the transmuxer, we have to manually trigger the timing
   // info callback
   videoBuffer.trigger({
-    type: 'videoTimingInfo',
-    videoTimingInfo: {
+    type: 'videoSegmentTimingInfo',
+    videoSegmentTimingInfo: {
       prependedGopDuration: 0,
       start: {
         presentation: 0

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -3261,10 +3261,27 @@ QUnit.test('convertToStreamTime will return stream time if buffered', function(a
   // ts
   this.standardXHRResponse(this.requests[2], muxedSegment());
 
+  const videoBuffer =
+    this.player.vhs.masterPlaylistController_.mediaSource.sourceBuffers[0];
+
+  // since we don't run through the transmuxer, we have to manually trigger the timing
+  // info callback
+  videoBuffer.trigger({
+    type: 'videoTimingInfo',
+    videoTimingInfo: {
+      prependedGopDuration: 0,
+      start: {
+        presentation: 0
+      },
+      end: {
+        presentation: 1
+      }
+    }
+  });
+
   // source buffer is mocked, so must manually trigger the video buffer
   // video buffer is the first buffer created
-  this.player.vhs.masterPlaylistController_
-    .mediaSource.sourceBuffers[0].trigger('updateend');
+  videoBuffer.trigger('updateend');
   this.clock.tick(1);
 
   // ts


### PR DESCRIPTION
NOTE: In progress. This is still being developed, but wanted to put it up for feedback and review.

Requires mux.js master (not yet versioned)

## Description
In order to more accurately convert between player times and stream times, the modifications done to a segment's timing values by the transmuxer must be exposed and used. In addition

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
