### PR TITLE
[Bugfix] m3u8 playlist is not updating when only endList changes

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -97,6 +97,7 @@ export const updateMaster = (master, media) => {
   if (playlist.segments &&
       media.segments &&
       playlist.segments.length === media.segments.length &&
+      playlist.endList === media.endList &&
       playlist.mediaSequence === media.mediaSequence) {
     return null;
   }


### PR DESCRIPTION
Porting the pull request to new http-streaming after the old repo was archieved:
https://github.com/videojs/videojs-contrib-hls/pull/1425/

It's a one-line-fix.

## Description
See https://github.com/videojs/http-streaming/issues/345

Possibly related issues:
https://github.com/videojs/videojs-contrib-hls/issues/442
https://github.com/videojs/videojs-contrib-hls/issues/550
https://github.com/videojs/videojs-contrib-hls/issues/555
https://github.com/videojs/videojs-contrib-hls/issues/111

## Specific Changes proposed
This updates the logic for deciding whether a playlist has changed to check the endList property as well.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
