### PR TITLE
fix: prevents captions parsing twice

### DIFF
--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -335,6 +335,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
       }
 
       parser.parse(mapData);
+      parser.flush();
+      return;
     }
 
     let segmentData = segmentInfo.bytes;


### PR DESCRIPTION
## Description
A proposed fix for #374 

## Specific Changes proposed
When a segment map is presented try to parse it and ignore parsing segmentInfo bytes to avoid duplications. 

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
