### PR TITLE
fix: Prevent infinite buffering at the start of looped video on edge

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -378,7 +378,7 @@ class HlsHandler extends Component {
 
     // Handle seeking when looping - middleware doesn't handle this seek event from the tech
     this.on(this.tech_, 'seeking', function() {
-      if (this.tech_.seeking() && this.tech_.currentTime() === 0 && this.tech_.player_.loop()) {
+      if (this.tech_.currentTime() === 0 && this.tech_.player_.loop()) {
         this.setCurrentTime(0);
       }
     });


### PR DESCRIPTION
### Problem
Right now Edge will sometimes buffer indefinitely once a video that is set to loop moves back to `currentTime` 0. 

After investigating this it appears that Edge does not set `tech.seeking()` to `true` during a `seeking` event for looping back to `currentTime` 0. Normal `seeking` events do set `tech.seeking()` to true, as expected. 

### Solution

I don't think that we need the extra check for `seeking` on the `tech` at the start of the if statement. If we just had a `seeking` event it should be fairly evident that we are seeking. I also think that the other two checks (for currentTime, and loop) should be enough to have this only happen when a video is looping.