### PR TITLE
test: fix intermittent Firefox loop test failures

### DIFF
--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -184,7 +184,10 @@ QUnit.test('loops', function(assert) {
         done();
       });
     });
-    player.currentTime(player.duration());
+
+    // Firefox sometimes won't loop if seeking directly to the duration, or to too close
+    // to the duration (e.g., 10ms from duration). 100ms seems to work.
+    player.currentTime(player.duration() - 0.1);
   });
   player.play();
 });


### PR DESCRIPTION
Firefox won't loop if seeking directly to the duration, or to too close
to the duration. 100ms from the duration seems to work.