### PR TITLE
fix: Fix video playback freezes caused by not using tech current time

### DIFF
--- a/src/middleware-set-current-time.js
+++ b/src/middleware-set-current-time.js
@@ -28,7 +28,7 @@ videojs.use('*', (player) => {
     play() {
       if (player.vhs &&
           player.currentSource().src === player.vhs.source_.src) {
-        player.vhs.setCurrentTime(player.currentTime());
+        player.vhs.setCurrentTime(player.tech_.currentTime());
       }
     }
   };


### PR DESCRIPTION
This bug is somewhat hard to reproduce as it only happens when another middleware reports a `currentTime` that is not the same as what vhs suggests. 