### PR TITLE
Implement handleManifestRedirects option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,16 @@ is set to `true`.
 See html5rocks's [article](http://www.html5rocks.com/en/tutorials/cors/)
 for more info.
 
+##### handleManifestRedirects
+* Type: `boolean`
+* Default: `false`
+* can be used as a source option
+* can be used as an initialization option
+
+When the `handleManifestRedirects` property is set to `true`, manifest requests
+which are redirected will have their URL updated to the new URL for future
+requests.
+
 ##### useCueTags
 * Type: `boolean`
 * can be used as an initialization option

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -1051,6 +1051,68 @@ QUnit.test('recognizes domain-relative URLs', function(assert) {
               'resolved segment URI');
 });
 
+QUnit.test('recognizes redirect, when manifest requested', function(assert) {
+  this.fakeHls.options_ = { handleManifestRedirects: true };
+
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+
+  loader.load();
+
+  const manifestRequest = this.requests.shift();
+
+  manifestRequest.responseURL = window.location.protocol + '//' +
+                                'foo-bar.com/manifest/media.m3u8';
+  manifestRequest.respond(200, null,
+                          '#EXTM3U\n' +
+                          '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
+                          '/media.m3u8\n');
+  assert.equal(loader.master.playlists[0].resolvedUri,
+              window.location.protocol + '//' +
+              'foo-bar.com/media.m3u8',
+              'resolved media URI');
+
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXTINF:10,\n' +
+                                '/00001.ts\n' +
+                                '#EXT-X-ENDLIST\n');
+  assert.equal(loader.media().segments[0].resolvedUri,
+              window.location.protocol + '//' +
+              'foo-bar.com/00001.ts',
+              'resolved segment URI');
+});
+
+QUnit.test('recognizes redirect, when media requested', function(assert) {
+  this.fakeHls.options_ = { handleManifestRedirects: true };
+
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+
+  loader.load();
+
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
+                                '/media.m3u8\n');
+  assert.equal(loader.master.playlists[0].resolvedUri,
+              window.location.protocol + '//' +
+              window.location.host + '/media.m3u8',
+              'resolved media URI');
+
+  const mediaRequest = this.requests.shift();
+
+  mediaRequest.responseURL = window.location.protocol + '//' +
+                             'foo-bar.com/media.m3u8';
+  mediaRequest.respond(200, null,
+                       '#EXTM3U\n' +
+                       '#EXTINF:10,\n' +
+                       '/00001.ts\n' +
+                       '#EXT-X-ENDLIST\n');
+  assert.equal(loader.media().segments[0].resolvedUri,
+              window.location.protocol + '//' +
+              'foo-bar.com/00001.ts',
+              'resolved segment URI');
+});
+
 QUnit.test('recognizes key URLs relative to master and playlist', function(assert) {
   let loader = new PlaylistLoader('/video/media-encrypted.m3u8', this.fakeHls);
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1684,6 +1684,26 @@ QUnit.test('the withCredentials option overrides the global default', function(a
   videojs.options.hls = hlsOptions;
 });
 
+QUnit.test('if handleManifestRedirects global option is used, it should be passed to PlaylistLoader', function(assert) {
+  let hlsOptions = videojs.options.hls;
+
+  this.player.dispose();
+  videojs.options.hls = {
+    handleManifestRedirects: true
+  };
+  this.player = createPlayer();
+  this.player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  assert.ok(this.player.tech_.hls.masterPlaylistController_.masterPlaylistLoader_.handleManifestRedirects);
+
+  videojs.options.hls = hlsOptions;
+});
+
 QUnit.test('playlist blacklisting duration is set through options', function(assert) {
   let hlsOptions = videojs.options.hls;
   let url;


### PR DESCRIPTION
## Description
This PR implements the `handleManifestRedirects` option that is also supported by the `videojs-contrib-hls` plugin. In fact, the implementation is also literally copy-pasted from there (the only thing that really changed is how the option itself is passed).

This resolves #290.

## Specific Changes proposed
Adds the `handleManifestRedirects` option and its implementation.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
