### PR TITLE
fix: only fire seekablechange on a change

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -922,6 +922,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
       }
     }
 
+    let oldEnd;
+    let oldStart;
+
+    if (this.seekable_ && this.seekable_.length) {
+      oldEnd = this.seekable_.end(0);
+      oldStart = this.seekable_.start(0);
+    }
+
     if (!audioSeekable) {
       // seekable has been calculated based on buffering video data so it
       // can be returned directly
@@ -937,6 +945,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
         (audioSeekable.end(0) < mainSeekable.end(0)) ? audioSeekable.end(0) :
                                                        mainSeekable.end(0)
       ]]);
+    }
+
+    // seekable is the same as last time
+    if (this.seekable_ && this.seekable_.length) {
+      if (this.seekable_.end(0) === oldEnd && this.seekable_.start(0) === oldStart) {
+        return;
+      }
     }
 
     this.logger_(`seekable updated [${Ranges.printableRange(this.seekable_)}]`);


### PR DESCRIPTION
## Description
A lot of the time we call `seekablechange` and log `seekable` changes when seekable is the same as it previously was.