### PR TITLE
Fix/never calling eos

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -688,6 +688,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
 
+    this.logger_(`calling mediaSource.endOfStream()`);
     // on chrome calling endOfStream can sometimes cause an exception,
     // even when the media source is in a valid state.
     try {
@@ -955,6 +956,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       // on firefox setting the duration may sometimes cause an exception
       // even if the media source is open and source buffers are not
       // updating, something about the media source being in an invalid state.
+      this.logger_(`Setting duration from ${this.mediaSource.duration} => ${newDuration}`);
       try {
         this.mediaSource.duration = newDuration;
       } catch (e) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -665,9 +665,11 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    let isEndOfStream = detectEndOfStream(this.playlist_,
-                                          this.mediaSource_,
-                                          segmentInfo.mediaIndex);
+    let isEndOfStream = detectEndOfStream(
+      this.playlist_,
+      this.mediaSource_,
+      segmentInfo.mediaIndex
+    ) && !this.sourceUpdater_.updating();
 
     if (isEndOfStream) {
       this.endOfStream();
@@ -1333,9 +1335,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     // any time an update finishes and the last segment is in the
     // buffer, end the stream. this ensures the "ended" event will
     // fire if playback reaches that point.
-    const isEndOfStream = detectEndOfStream(segmentInfo.playlist,
-                                            this.mediaSource_,
-                                            segmentInfo.mediaIndex + 1);
+    const isEndOfStream = detectEndOfStream(
+      segmentInfo.playlist,
+      this.mediaSource_,
+      segmentInfo.mediaIndex + 1
+    ) && !this.sourceUpdater_.updating();
 
     if (isEndOfStream) {
       this.endOfStream();

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -445,9 +445,17 @@ export default class SegmentLoader extends videojs.EventTarget {
       };
     }
 
-    const oldId = oldPlaylist ? oldPlaylist.id : null;
+    let oldId = null;
 
-    this.logger_(`playlist update [${oldId} => ${newPlaylist.id}]`);
+    if (oldPlaylist) {
+      if (oldPlaylist.id) {
+        oldId = oldPlaylist.id;
+      } else if (oldPlaylist.uri) {
+        oldId = oldPlaylist.uri;
+      }
+    }
+
+    this.logger_(`playlist update [${oldId} => ${newPlaylist.id || newPlaylist.uri}]`);
 
     // in VOD, this is always a rendition switch (or we updated our syncInfo above)
     // in LIVE, we always want to update with new playlists (including refreshes)

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -673,13 +673,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    let isEndOfStream = detectEndOfStream(
-      this.playlist_,
-      this.mediaSource_,
-      segmentInfo.mediaIndex
-    ) && !this.sourceUpdater_.updating();
-
-    if (isEndOfStream) {
+    if (this.isEndOfStream_(segmentInfo.mediaIndex)) {
       this.endOfStream();
       return;
     }
@@ -706,6 +700,21 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     this.loadSegment_(segmentInfo);
+  }
+
+  /**
+   * Determines if this segment loader is at the end of it's stream.
+   *
+   * @param {Number} mediaIndex the index of segment we last appended
+   * @param {Object} [playlist=this.playlist_] a media playlist object
+   * @returns {Boolean} true if at end of stream, false otherwise.
+   */
+  isEndOfStream_(mediaIndex, playlist = this.playlist_) {
+    return detectEndOfStream(
+      playlist,
+      this.mediaSource_,
+      mediaIndex
+    ) && !this.sourceUpdater_.updating();
   }
 
   /**
@@ -1343,13 +1352,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // any time an update finishes and the last segment is in the
     // buffer, end the stream. this ensures the "ended" event will
     // fire if playback reaches that point.
-    const isEndOfStream = detectEndOfStream(
-      segmentInfo.playlist,
-      this.mediaSource_,
-      segmentInfo.mediaIndex + 1
-    ) && !this.sourceUpdater_.updating();
-
-    if (isEndOfStream) {
+    if (this.isEndOfStream_(segmentInfo.mediaIndex + 1, segmentInfo.playlist)) {
       this.endOfStream();
     }
 

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -160,7 +160,10 @@ export default class SourceUpdater {
    * @return {Boolean} the updating status of the SourceBuffer
    */
   updating() {
-    return !this.sourceBuffer_ || this.sourceBuffer_.updating || this.pendingCallback_;
+    // we are updating if the sourcebuffer is updating or
+    return !this.sourceBuffer_ || this.sourceBuffer_.updating ||
+      // if we have a pending callback that is not our internal noop
+      (!!this.pendingCallback_ && this.pendingCallback_ !== noop);
   }
 
   /**

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -615,6 +615,48 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
       assert.equal(endOfStreams, 1, 'triggered ended');
     });
 
+    QUnit.test('endOfStream does not happen while sourceUpdater is updating', function(assert) {
+      let endOfStreams = 0;
+      let bandwidthupdates = 0;
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered_ = () => buffered;
+
+      loader.playlist(playlistWithDuration(20));
+      loader.mimeType(this.mimeType);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.mediaSource_ = {
+        readyState: 'open',
+        sourceBuffers: this.mediaSource.sourceBuffers
+      };
+
+      loader.on('ended', () => endOfStreams++);
+
+      loader.on('bandwidthupdate', () => {
+        bandwidthupdates++;
+        // Simulate a rendition switch
+        loader.resetEverything();
+      });
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(10);
+
+      loader.sourceUpdater_.updating = () => true;
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+
+      this.updateend();
+
+      assert.equal(bandwidthupdates, 0, 'did not trigger bandwidthupdate');
+      assert.equal(endOfStreams, 0, 'did not trigger trigger ended');
+    });
+
     QUnit.test('live playlists do not trigger ended', function(assert) {
       let endOfStreams = 0;
       let playlist;


### PR DESCRIPTION
## Description
Trigger `ended` on segment loaders while the underlying sourcebuffers were updating was incorrect. This caused some videos to never call `endOfStream` and hang at the end of the video.