### PR TITLE
fix: expose `custom` segment property in the segment metadata track

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1413,6 +1413,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
+      custom: segment.custom,
       dateTimeObject: segment.dateTimeObject,
       dateTimeString: segment.dateTimeString,
       bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -436,6 +436,8 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
                   'segment-metadata track empty when no segments appended');
 
         // Start appending some segments
+        // Add parsed custom tag data to the segment
+        playlist.segments[0].custom = { data: true };
         probeResponse = { start: 0, end: 9.5 };
         this.requests[0].response = new Uint8Array(10).buffer;
         this.requests.shift().respond(200, null, '');
@@ -452,7 +454,8 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           codecs: 'mp4a.40.5,avc1.42001e',
           byteLength: 10,
           dateTimeObject: undefined,
-          dateTimeString: undefined
+          dateTimeString: undefined,
+          custom: { data: true }
         };
 
         assert.equal(track.cues.length, 1, 'one cue added for segment');
@@ -475,7 +478,8 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           codecs: 'mp4a.40.5,avc1.42001e',
           byteLength: 10,
           dateTimeObject: undefined,
-          dateTimeString: undefined
+          dateTimeString: undefined,
+          custom: undefined
         };
 
         assert.equal(track.cues.length, 2, 'one cue added for segment');
@@ -498,7 +502,8 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           codecs: 'mp4a.40.5,avc1.42001e',
           byteLength: 10,
           dateTimeObject: undefined,
-          dateTimeString: undefined
+          dateTimeString: undefined,
+          custom: undefined
         };
 
         assert.equal(track.cues.length, 3, 'one cue added for segment');
@@ -523,7 +528,8 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           codecs: 'mp4a.40.5,avc1.42001e',
           byteLength: 10,
           dateTimeObject: undefined,
-          dateTimeString: undefined
+          dateTimeString: undefined,
+          custom: undefined
         };
 
         assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');


### PR DESCRIPTION
## Description
Exposes the missing `custom` segment property in the segment metadata track, this property is present on the segment object parsed by VHS.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
