### PR TITLE
fix(id3): ignore unsupported id3 frames

### DIFF
--- a/src/mse/add-text-track-data.js
+++ b/src/mse/add-text-track-data.js
@@ -81,6 +81,14 @@ export const addTextTrackData = function(sourceHandler, captionArray, metadataAr
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;
 
+      // if time isn't a finite number between 0 and Infinity, like NaN,
+      // ignore this bit of metadata.
+      // This likely occurs when you have an non-timed ID3 tag like TIT2,
+      // which is the "Title/Songname/Content description" frame
+      if (typeof time !== 'number' || window.isNaN(time) || time < 0 || !(time < Infinity)) {
+        return;
+      }
+
       metadata.frames.forEach(function(frame) {
         let cue = new Cue(
           time,


### PR DESCRIPTION
When we get an unsupported id3 frame, we don't parse its time. This ends
up coming back to us as NaN in the timing for the frame. Instead of
trying to create a cue for this frame, ignore it whenever the time isn't
a number or when it isn't finite.

Fixes videojs/video.js#5823