### PR TITLE
Fix: On dispose, don't call abort on SourceBuffer until after remove() has finished

### DIFF
--- a/src/mse/virtual-source-buffer.js
+++ b/src/mse/virtual-source-buffer.js
@@ -311,7 +311,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
             if (t === 'audio' && this.audioDisabled_) {
               return true;
             }
-            // if the other type if updating we don't trigger
+            // if the other type is updating we don't trigger
             if (type !== t &&
                 this[`${t}Buffer_`] &&
                 this[`${t}Buffer_`].updating) {

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -71,6 +71,7 @@ export default class SourceUpdater {
       let pendingCallback = this.pendingCallback_;
 
       this.pendingCallback_ = null;
+      this.sourceBuffer_.removing = false;
 
       this.logger_(`buffered [${printableRange(this.buffered())}]`);
 
@@ -149,6 +150,7 @@ export default class SourceUpdater {
     if (this.processedAppend_) {
       this.queueCallback_(() => {
         this.logger_(`remove [${start} => ${end}]`);
+        this.sourceBuffer_.removing = true;
         this.sourceBuffer_.remove(start, end);
       }, done);
     }
@@ -208,9 +210,18 @@ export default class SourceUpdater {
    * dispose of the source updater and the underlying sourceBuffer
    */
   dispose() {
+    const disposeFn = () => {
+      if (this.sourceBuffer_ && this.mediaSource.readyState === 'open') {
+        this.sourceBuffer_.abort();
+      }
+      this.sourceBuffer_.removeEventListener('updateend', disposeFn);
+    };
+
     this.sourceBuffer_.removeEventListener('updateend', this.onUpdateendCallback_);
-    if (this.sourceBuffer_ && this.mediaSource.readyState === 'open') {
-      this.sourceBuffer_.abort();
+    if (this.sourceBuffer_.removing) {
+      this.sourceBuffer_.addEventListener('updateend', disposeFn);
+    } else {
+      disposeFn();
     }
   }
 }


### PR DESCRIPTION
## Description
Per the MSE spec, [calling `abort()` during a `remove()` will throw an `InvalidStateError`](https://www.w3.org/TR/media-source/#dom-sourcebuffer-abort). During `dispose()` of the `SourceUpdater`, we call `this.sourceBuffer_.abort()` without waiting for the pending operation to finish, even if that operation is a `remove`. Thus, we can get an `InvalidStateError` on `dispose`.

## Specific Changes proposed
Track whether we're in the process of removal. If `dispose` happens before we finish the `remove`, add the dispose function as a handler for `updateend`.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
