### PR TITLE
feat: add option to cache encrpytion keys in the player

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Video.js Compatibility: 6.0, 7.0
       - [Source](#source)
     - [List](#list)
       - [withCredentials](#withcredentials)
+      - [handleManifestRedirects](#handlemanifestredirects)
       - [useCueTags](#usecuetags)
       - [overrideNative](#overridenative)
       - [blacklistDuration](#blacklistduration)
@@ -51,6 +52,7 @@ Video.js Compatibility: 6.0, 7.0
       - [allowSeeksWithinUnsafeLiveWindow](#allowseekswithinunsafelivewindow)
       - [customTagParsers](#customtagparsers)
       - [customTagMappers](#customtagmappers)
+      - [cacheEncryptionKeys](#cacheencryptionkeys)
   - [Runtime Properties](#runtime-properties)
     - [hls.playlists.master](#hlsplaylistsmaster)
     - [hls.playlists.media](#hlsplaylistsmedia)
@@ -417,6 +419,13 @@ With `customTagParsers` you can pass an array of custom m3u8 tag parser objects.
 * can be used as a source option
 
 Similar to `customTagParsers`, with `customTagMappers` you can pass an array of custom m3u8 tag mapper objects. See https://github.com/videojs/m3u8-parser#custom-parsers
+
+##### cacheEncryptionKeys
+* Type: `boolean`
+* can be used as an initialization option
+
+This option forces the player to cache AES-128 encryption keys internally instead of requesting the key alongside every segment request.
+This option defaults to `false`.
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Similar to `customTagParsers`, with `customTagMappers` you can pass an array of 
 
 ##### cacheEncryptionKeys
 * Type: `boolean`
+* can be used as a source option
 * can be used as an initialization option
 
 This option forces the player to cache AES-128 encryption keys internally instead of requesting the key alongside every segment request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3436,8 +3436,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -3667,7 +3666,6 @@
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -3735,8 +3733,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -3775,8 +3772,7 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -3920,14 +3916,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4209,7 +4203,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }

--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -76,6 +76,13 @@ export const initSegmentId = function(initSegment) {
 };
 
 /**
+ *
+ */
+export const segmentKeyId = function(key) {
+  return key.resolvedUri;
+};
+
+/**
  * utils to help dump binary data to the console
  */
 export const hexDump = (data) => {

--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -76,7 +76,7 @@ export const initSegmentId = function(initSegment) {
 };
 
 /**
- *
+ * Returns a unique string identifier for a media segment key.
  */
 export const segmentKeyId = function(key) {
   return key.resolvedUri;

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -64,7 +64,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       blacklistDuration,
       enableLowInitialPlaylist,
       sourceType,
-      seekTo
+      seekTo,
+      cacheEncryptionKeys
     } = options;
 
     if (!url) {
@@ -125,7 +126,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       syncController: this.syncController_,
       decrypter: this.decrypter_,
       sourceType: this.sourceType_,
-      inbandTextTracks: this.inbandTextTracks_
+      inbandTextTracks: this.inbandTextTracks_,
+      cacheEncryptionKeys
     };
 
     this.masterPlaylistLoader_ = this.sourceType_ === 'dash' ?

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -434,7 +434,7 @@ export const mediaSegmentRequest = (xhr,
   const finishProcessingFn = waitForCompletion(activeXhrs, decryptionWorker, doneFn);
 
   // optionally, request the decryption key
-  if (segment.key && ! segment.key.bytes) {
+  if (segment.key && !segment.key.bytes) {
     const keyRequestOptions = videojs.mergeOptions(xhrOptions, {
       uri: segment.key.resolvedUri,
       responseType: 'arraybuffer'

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -285,16 +285,18 @@ const decryptSegment = (decrypter, segment, doneFn) => {
 
   decrypter.addEventListener('message', decryptionHandler);
 
+  const keyBytes = segment.key.bytes.slice();
+
   // this is an encrypted segment
   // incrementally decrypt the segment
   decrypter.postMessage(createTransferableMessage({
     source: segment.requestId,
     encrypted: segment.encryptedBytes,
-    key: segment.key.bytes,
+    key: keyBytes,
     iv: segment.key.iv
   }), [
     segment.encryptedBytes.buffer,
-    segment.key.bytes.buffer
+    keyBytes.buffer
   ]);
 };
 
@@ -432,7 +434,7 @@ export const mediaSegmentRequest = (xhr,
   const finishProcessingFn = waitForCompletion(activeXhrs, decryptionWorker, doneFn);
 
   // optionally, request the decryption key
-  if (segment.key) {
+  if (segment.key && ! segment.key.bytes) {
     const keyRequestOptions = videojs.mergeOptions(xhrOptions, {
       uri: segment.key.resolvedUri,
       responseType: 'arraybuffer'

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -372,23 +372,31 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @return {Object}
    *         Key object for desired key
    */
-   segmentKey(key, set = false) {
-     if (!key) {
-       return null;
-     }
+  segmentKey(key, set = false) {
+    if (!key) {
+      return null;
+    }
 
-     const id = segmentKeyId(key);
-     let storedKey = this.keyCache_[id];
+    const id = segmentKeyId(key);
+    let storedKey = this.keyCache_[id];
 
-     if (this.cacheEncryptionKeys_ && set && !storedKey && key.bytes) {
-       this.keyCache_[id] = storedKey = {
-         resolvedUri: key.resolvedUri,
-         bytes: key.bytes
-       };
-     }
+    if (this.cacheEncryptionKeys_ && set && !storedKey && key.bytes) {
+      this.keyCache_[id] = storedKey = {
+        resolvedUri: key.resolvedUri,
+        bytes: key.bytes
+      };
+    }
 
-     return storedKey || { resolvedUri: key.resolvedUri };
-   }
+    const result = {
+      resolvedUri: (storedKey || key).resolvedUri
+    };
+
+    if (storedKey) {
+      result.bytes = storedKey.bytes;
+    }
+
+    return result;
+  }
 
   /**
    * Returns true if all configuration required for loading is present, otherwise false.

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -347,8 +347,6 @@ export default class SegmentLoader extends videojs.EventTarget {
     const id = initSegmentId(map);
     let storedMap = this.initSegments_[id];
 
-    // TODO: We should use the HTTP Expires header to invalidate our cache per
-    // https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-6.2.3
     if (set && !storedMap && map.bytes) {
       this.initSegments_[id] = storedMap = {
         resolvedUri: map.resolvedUri,
@@ -380,6 +378,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     const id = segmentKeyId(key);
     let storedKey = this.keyCache_[id];
 
+    // TODO: We should use the HTTP Expires header to invalidate our cache per
+    // https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-6.2.3
     if (this.cacheEncryptionKeys_ && set && !storedKey && key.bytes) {
       this.keyCache_[id] = storedKey = {
         resolvedUri: key.resolvedUri,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1188,9 +1188,6 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (simpleSegment.map) {
       segmentInfo.segment.map.bytes = simpleSegment.map.bytes;
     }
-    // if (simpleSegment.key) {
-    //   segmentInfo.segment.key.bytes = simpleSegment.key.bytes;
-    // }
 
     segmentInfo.endOfAllRequests = simpleSegment.endOfAllRequests;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -347,6 +347,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     const id = initSegmentId(map);
     let storedMap = this.initSegments_[id];
 
+    // TODO: We should use the HTTP Expires header to invalidate our cache per
+    // https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-6.2.3
     if (set && !storedMap && map.bytes) {
       this.initSegments_[id] = storedMap = {
         resolvedUri: map.resolvedUri,

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -444,7 +444,8 @@ class HlsHandler extends Component {
       'smoothQualityChange',
       'customTagParsers',
       'customTagMappers',
-      'handleManifestRedirects'
+      'handleManifestRedirects',
+      'cacheEncryptionKeys'
     ].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -404,6 +404,7 @@ class HlsHandler extends Component {
         this.options_.useBandwidthFromLocalStorage || false;
     this.options_.customTagParsers = this.options_.customTagParsers || [];
     this.options_.customTagMappers = this.options_.customTagMappers || [];
+    this.options_.cacheEncryptionKeys = this.options_.cacheEncryptionKeys || false;
 
     if (typeof this.options_.blacklistDuration !== 'number') {
       this.options_.blacklistDuration = 5 * 60;

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -59,6 +59,10 @@ const options = [{
       return `#FOO`;
     }
   }]
+}, {
+  name: 'cacheEncryptionKeys',
+  default: false,
+  test: true
 }];
 
 const CONFIG_KEYS = Object.keys(Config);

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -161,6 +161,41 @@ QUnit.test('creates appropriate PlaylistLoader for sourceType', function(assert)
             'created a dash playlist loader');
 });
 
+QUnit.test('passes options to SegmentLoader', function(assert) {
+  const options = {
+    url: 'test',
+    tech: this.player.tech_
+  };
+
+  let controller = new MasterPlaylistController(options);
+
+  assert.notOk(controller.mainSegmentLoader_.bandwidth, "bandwidth won't be set by default");
+  assert.notOk(controller.mainSegmentLoader_.sourceType_, "sourceType won't be set by default");
+  assert.notOk(controller.mainSegmentLoader_.cacheEncryptionKeys_, "cacheEncryptionKeys won't be set by default");
+
+  controller = new MasterPlaylistController(Object.assign({
+    bandwidth: 3,
+    cacheEncryptionKeys: true,
+    sourceType: 'fake-type'
+  }, options));
+
+  assert.strictEqual(
+    controller.mainSegmentLoader_.bandwidth,
+    3,
+    'bandwidth will be set'
+  );
+  assert.strictEqual(
+    controller.mainSegmentLoader_.sourceType_,
+    'fake-type',
+    'sourceType will be set'
+  );
+  assert.strictEqual(
+    controller.mainSegmentLoader_.cacheEncryptionKeys_,
+    true,
+    'cacheEncryptionKeys will be set'
+  );
+});
+
 QUnit.test('resets SegmentLoader when seeking out of buffer',
   function(assert) {
     let resets = 0;

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -358,18 +358,22 @@ export const standardXHRResponse = function(request, data) {
     contentType = 'video/MP2T';
   } else if (/\.mpd/.test(request.url)) {
     contentType = 'application/dash+xml';
+  } else if (request.responseType === 'arraybuffer') {
+    contentType = 'binary/octet-stream';
   }
 
   if (!data) {
     data = testDataManifests[manifestName];
   }
 
+  const isTypedBuffer = data instanceof Uint8Array || data instanceof Uint32Array;
+
   request.response =
     // if segment data was passed, use that, otherwise use a placeholder
-    data instanceof Uint8Array ? data.buffer : new Uint8Array(1024).buffer;
+    isTypedBuffer ? data.buffer : new Uint8Array(1024).buffer;
   request.respond(200,
                   { 'Content-Type': contentType },
-                  data instanceof Uint8Array ? '' : data);
+                  isTypedBuffer ? '' : data);
 };
 
 export const playlistWithDuration = function(time, conf) {


### PR DESCRIPTION
## Description
Adds an option to force the player to cache encryption keys instead of requesting for every segment. Defaults to `false` for backwards compatibility.
Addressess #140 

todo/future enhancement: Use HTTP Expires header to expire our internal cache per https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-6.2.3