### PR TITLE
fix: run callbacks after setting timestampOffset

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -177,6 +177,7 @@ export default class SourceUpdater {
     if (typeof offset !== 'undefined') {
       this.queueCallback_(() => {
         this.sourceBuffer_.timestampOffset = offset;
+        this.runCallback_();
       });
       this.timestampOffset_ = offset;
     }

--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -131,6 +131,24 @@ QUnit.test('runs the next callback after updateend fires', function(assert) {
                   'appended the bytes');
 });
 
+QUnit.test('runs the next callback after calling timestampOffset', function(assert) {
+  let updater = new SourceUpdater(this.mediaSource, 'video/mp2t');
+  let sourceBuffer;
+
+  updater.timestampOffset(10);
+  updater.appendBuffer({
+    bytes: new Uint8Array([0, 1, 2])
+  }, () => {});
+
+  this.mediaSource.trigger('sourceopen');
+  sourceBuffer = this.mediaSource.sourceBuffers[0];
+
+  assert.equal(sourceBuffer.timestampOffset, 10, 'offset correctly set');
+  assert.equal(sourceBuffer.updates_.length, 1, 'updated once');
+  assert.deepEqual(sourceBuffer.updates_[0].append, new Uint8Array([0, 1, 2]),
+                  'appended the bytes');
+});
+
 QUnit.test('runs only one callback at a time', function(assert) {
   let updater = new SourceUpdater(this.mediaSource, 'video/mp2t');
   let sourceBuffer;


### PR DESCRIPTION
## Description
Long story short, I hit a condition where non-muxed HLS wouldn't start playing sometimes. This is because it's possible to end up in a condition where one `SourceUpdater` gets both a `timestampOffset` and an `appendBuffer` call before the other `SourceBuffer` is added to the `MediaSource`. Since [`timestampOffset` queues a callback](https://github.com/videojs/http-streaming/blob/faf1198b9cbaddc89857cf19895d3c185708cc96/src/source-updater.js#L178-L180), but does not trigger an `updateend` on the `SourceBuffer`, the already-queued `appendBuffer` call is never processed, and thus a `SegmentLoader` ends up waiting forever.

For easy reproduction of the problem, you can simply delay the creation of the audio `SourceBuffer`, like so:
```diff
diff --git i/src/source-updater.js w/src/source-updater.js
index b89993d..f0e8c4b 100644
--- i/src/source-updater.js
+++ w/src/source-updater.js
@@ -35,7 +35,13 @@ export default class SourceUpdater {
       mediaSource.addEventListener(
         'sourceopen', this.createSourceBuffer_.bind(this, mimeType, sourceBufferEmitter));
     } else {
-      this.createSourceBuffer_(mimeType, sourceBufferEmitter);
+      if (mimeType === 'audio/mp2t; codecs="mp4a.40.2"') {
+        setTimeout(() => {
+          this.createSourceBuffer_(mimeType, sourceBufferEmitter);
+        }, 2000);
+      } else {
+        this.createSourceBuffer_(mimeType, sourceBufferEmitter);
+      }
     }
   }

```

## Specific Changes proposed
Simply call `this.runCallback_()` in the queued callback so that any other queued callbacks are run. I'm not sure if this is bad form; perhaps `this.runCallback_()` should be inside a `setTimeout()`?

Note: I'm adding the fix on a separate commit so you can see the change from fail -> pass.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
