### PR TITLE
WIP: fix: a/v sync

### DIFF
--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -504,7 +504,7 @@ export default class SyncController extends videojs.EventTarget {
     let segment = segmentInfo.segment;
     let mappingObj = this.timelines[segmentInfo.timeline];
 
-    if (segmentInfo.timestampOffset !== null) {
+    if (!mappingObj && segmentInfo.startOfSegment !== null) {
       mappingObj = {
         time: segmentInfo.startOfSegment,
         mapping: segmentInfo.startOfSegment - timingInfo.start


### PR DESCRIPTION
## Description
This PR attempts to fix A/V offset that can occur in both TS and fMP4 sources. In short, it aligns DTS by using a "global" timestamp offset per timeline.

Not pictured: something that will ensure you seek into the buffer for live feeds. We may seek into a region that has only video or only audio buffered, and there's currently nothing in the code that ensures we end up within a buffered region. 

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
