### PR TITLE
feature: expose abortEarlyBlacklistDuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Video.js Compatibility: 6.0, 7.0
       - [useCueTags](#usecuetags)
       - [overrideNative](#overridenative)
       - [blacklistDuration](#blacklistduration)
+      - [abortEarlyBlacklistDuration](#abortearlyblacklistduration)
       - [bandwidth](#bandwidth)
       - [useBandwidthFromLocalStorage](#usebandwidthfromlocalstorage)
       - [enableLowInitialPlaylist](#enablelowinitialplaylist)
@@ -337,10 +338,18 @@ player.src({
 * Type: `number`
 * can be used as an initialization option
 
-When the `blacklistDuration` property is set to a time duration in seconds,
-if a playlist is blacklisted, it will be blacklisted for a period of that
-customized duration. This enables the blacklist duration to be configured
-by the user.
+A playlist will be blacklisted for `blacklistDuration` seconds if it is live
+and no longer updating, if an error was encountered when downloading it, or
+if an error was encountered when downloading one of its media segments. This
+setting is `300` by default.
+
+##### abortEarlyBlacklistDuration
+* Type: `number`
+* can be used as an initialization option
+
+A playlist will be blacklisted for `abortEarlyBlacklistDuration` seconds if
+one of its segments is being downloaded but won't finish before the buffer
+runs out. This setting is `120` by default.
 
 ##### bandwidth
 * Type: `number`

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -21,8 +21,6 @@ import {
 import { createMediaTypes, setupMediaGroups } from './media-groups';
 import logger from './util/logger';
 
-const ABORT_EARLY_BLACKLIST_SECONDS = 60 * 2;
-
 let Hls;
 
 // SegmentLoader stats that need to have each loader's
@@ -62,6 +60,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       externHls,
       useCueTags,
       blacklistDuration,
+      abortEarlyBlacklistDuration,
       enableLowInitialPlaylist,
       sourceType,
       seekTo,
@@ -81,6 +80,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.sourceType_ = sourceType;
     this.useCueTags_ = useCueTags;
     this.blacklistDuration = blacklistDuration;
+    this.abortEarlyBlacklistDuration = abortEarlyBlacklistDuration;
     this.enableLowInitialPlaylist = enableLowInitialPlaylist;
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
@@ -469,7 +469,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.blacklistCurrentPlaylist({
         message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +
           'request without rebuffering.'
-      }, ABORT_EARLY_BLACKLIST_SECONDS);
+      }, this.abortEarlyBlacklistDuration);
     });
 
     this.mainSegmentLoader_.on('reseteverything', () => {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -410,6 +410,10 @@ class HlsHandler extends Component {
       this.options_.blacklistDuration = 5 * 60;
     }
 
+    if (typeof this.options_.abortEarlyBlacklistDuration !== 'number') {
+      this.options_.abortEarlyBlacklistDuration = 2 * 60;
+    }
+
     if (typeof this.options_.bandwidth !== 'number') {
       if (this.options_.useBandwidthFromLocalStorage) {
         const storedObject = getVhsLocalStorage();


### PR DESCRIPTION
## Description
The duration for which a playlist is blacklisted when one of its segments can't finish in time is currently hard-coded. This PR exposes that duration as a setting.

I've also re-written the description for `blacklistDuration` to describe when that setting is used, so it is clear what cases each setting affects.

## Specific Changes proposed
Expose `abortEarlyBlacklistDuration` as an initialization setting.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
