### PR TITLE
fix: change rollup config so that npm run watch works

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -31,6 +31,20 @@ const umdPlugins = [
   babel(),
 ];
 
+const externals = [
+  'aes-decrypter',
+  'global/document',
+  'global/window',
+  'm3u8-parser',
+  'mpd-parser',
+  'mux.js/lib/mp4',
+  'mux.js/lib/mp4/probe',
+  'mux.js/lib/tools/mp4-inspector',
+  'mux.js/lib/tools/ts-inspector.js',
+  'url-toolkit',
+  'video.js'
+];
+
 const onwarn = (warning) => {
   if (warning.code === 'UNUSED_EXTERNAL_IMPORT' ||
       warning.code === 'UNRESOLVED_IMPORT') {
@@ -101,6 +115,7 @@ export default [
       format: 'cjs',
       banner
     }],
+    external: externals,
     onwarn
   }, {
     input: 'src/videojs-http-streaming.js',
@@ -117,6 +132,7 @@ export default [
       format: 'es',
       banner
     }],
+    external: externals,
     onwarn
   }
 ];


### PR DESCRIPTION
## Description
I was annoyed with `npm run watch` not working properly, so I decided to try to fix it. I don't know if this is the right approach, but I did what video.js is doing with adding modules into the `external` config key.

With this + videojs/video.js#5966, you can change a file in VHS and it will be compiled into video.js. It takes a bit to compile, but I found that I would sometimes get some weird behaviour if I was loading both `video.js` and `videojs-http-streaming.js`.

## Specific Changes proposed
Added the modules that caused compilation failure to the `external` config key for CommonJS and ES output.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
