### PR TITLE
fix: do not always set ended_ to false on sourceopen

### DIFF
--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -28,6 +28,7 @@ QUnit.module('Playback', {
     let done = assert.async();
     let video = document.createElement('video-js');
 
+    videojs.log.level('debug');
     video.style = 'display: none;';
 
     video.width = 600;
@@ -192,10 +193,7 @@ QUnit.test('DASH sidx', function(assert) {
   });
 });
 
-// This is a potentially existing issue where a combination of things
-// results in no ended event. We should fix this and start running this
-// test with 100% pass rate after that.
-QUnit.skip('DASH sidx with alt audio should end', function(assert) {
+QUnit.test('DASH sidx with alt audio should end', function(assert) {
 
   let done = assert.async();
   let player = this.player;

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -891,45 +891,6 @@ QUnit.module('SegmentLoader', function(hooks) {
       });
     });
 
-    QUnit.test('endOfStream does not happen while sourceUpdater is updating', function(assert) {
-      let endOfStreams = 0;
-      let bandwidthupdates = 0;
-
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
-
-        loader.on('ended', () => endOfStreams++);
-
-        loader.on('bandwidthupdate', () => {
-          bandwidthupdates++;
-          // Simulate a rendition switch
-          loader.resetEverything();
-        });
-
-        loader.playlist(playlistWithDuration(20));
-        loader.load();
-        this.clock.tick(1);
-
-        standardXHRResponse(this.requests.shift(), muxedSegment());
-        return new Promise((resolve, reject) => {
-          loader.one('appended', resolve);
-          loader.one('error', reject);
-        });
-      }).then(() => {
-        this.clock.tick(10);
-
-        loader.sourceUpdater_.updating = () => true;
-        standardXHRResponse(this.requests.shift(), muxedSegment());
-
-        return new Promise((resolve, reject) => {
-          loader.one('appended', resolve);
-          loader.one('error', reject);
-        });
-      }).then(() => {
-        assert.equal(bandwidthupdates, 1, 'triggered bandwidthupdate');
-        assert.equal(endOfStreams, 0, 'triggered ended');
-      });
-    });
-
     QUnit.test('live playlists do not trigger ended', function(assert) {
       let endOfStreams = 0;
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -630,16 +630,10 @@ function(assert) {
   });
   openMediaSource(this.player, this.clock);
 
-  this.player.tech_.hls.masterPlaylistController_.mediaSource.endOfStream = (type) => {
-    endOfStreams.push(type);
-    throw new Error();
-  };
+  this.player.tech_.hls.masterPlaylistController_.mediaSource.readyState = 'closed';
 
   this.player.on('error', () => {
     const error = this.player.error();
-
-    assert.equal(endOfStreams.length, 1, 'one endOfStream called');
-    assert.equal(endOfStreams[0], 'network', 'endOfStream called with network');
 
     assert.equal(error.code, 2, 'error has correct code');
     assert.equal(error.message,


### PR DESCRIPTION
## Description
Currently the way `endOfStream` works in the tba branch:

1. Does not make much sense as most `sourceBuffer` and `mediaSource` operations go through the `sourceUpdater` now
2. `endOfStream` isn't called correctly whenever a rendition switch or audio switch happens at the end of a stream.

This full request fixes that.
