### PR TITLE
fix: Prevent double 608 captions on rendition change

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -690,6 +690,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.metadataQueue_.id3 = [];
     this.metadataQueue_.caption = [];
     this.abort();
+
+    if (this.captionParser_) {
+      this.captionParser_.clearParsedCaptions();
+    }
   }
 
   /**
@@ -1212,7 +1216,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
   }
 
-  handleCaptions_(simpleSegment, captions) {
+  handleCaptions_(simpleSegment, captionData) {
     if (this.checkForAbort_(simpleSegment.requestId) ||
       this.abortRequestEarly_(simpleSegment.stats)) {
       return;
@@ -1220,7 +1224,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // This could only happen with fmp4 segments, but
     // should still not happen in general
-    if (captions.length === 0) {
+    if (captionData.length === 0) {
       this.logger_('SegmentLoader received no captions from a caption event');
       return;
     }
@@ -1231,7 +1235,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // can be adjusted by the timestamp offset
     if (!segmentInfo.hasAppendedData_) {
       this.metadataQueue_.caption.push(
-        this.handleCaptions_.bind(this, simpleSegment, captions));
+        this.handleCaptions_.bind(this, simpleSegment, captionData));
       return;
     }
 
@@ -1239,14 +1243,39 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.sourceUpdater_.audioTimestampOffset() :
       this.sourceUpdater_.videoTimestampOffset();
 
-    captions.forEach((caption) => {
-      createCaptionsTrackIfNotExists(
-        this.inbandTextTracks_, this.hls_.tech_, caption.stream);
-      addCaptionData({
-        captionArray: [caption],
-        inbandTextTracks: this.inbandTextTracks_,
-        timestampOffset
-      });
+    const tracks = {};
+
+    // get total start/end and captions for each track/stream
+    captionData.forEach((caption) => {
+      // caption.stream is actually a track name...
+      // set to the existing values in tracks or default values
+      tracks[caption.stream] = tracks[caption.stream] || {
+        startTime: Infinity,
+        captions: [],
+        endTime: 0
+      };
+
+      const track = tracks[caption.stream];
+
+      track.startTime = Math.min(track.startTime, (caption.startTime + timestampOffset));
+      track.endTime = Math.max(track.endTime, (caption.endTime + timestampOffset));
+      track.captions.push(caption);
+    });
+
+    Object.keys(tracks).forEach((trackName) => {
+      const {startTime, endTime, captions} = tracks[trackName];
+      const inbandTextTracks = this.inbandTextTracks_;
+
+      this.logger_(`adding cues from ${startTime} -> ${endTime} for ${trackName}`);
+
+      createCaptionsTrackIfNotExists(inbandTextTracks, this.hls_.tech_, trackName);
+      // clear out any cues that start and end at the same time period for the same track.
+      // We do this because a rendition change that also changes the timescale for captions
+      // will result in captions being re-parsed for certain segments. If we add them again
+      // without clearing we will have two of the same captions visible.
+      removeCuesFromTrack(startTime, endTime, inbandTextTracks[trackName]);
+
+      addCaptionData({captionArray: captions, inbandTextTracks, timestampOffset});
     });
 
     // Reset stored captions since we added parsed

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1243,27 +1243,29 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.sourceUpdater_.audioTimestampOffset() :
       this.sourceUpdater_.videoTimestampOffset();
 
-    const tracks = {};
+    const captionTracks = {};
 
     // get total start/end and captions for each track/stream
     captionData.forEach((caption) => {
       // caption.stream is actually a track name...
       // set to the existing values in tracks or default values
-      tracks[caption.stream] = tracks[caption.stream] || {
+      captionTracks[caption.stream] = captionTracks[caption.stream] || {
+        // Infinity, as any other value will be less than this
         startTime: Infinity,
         captions: [],
+        // 0 as an other value will be more than this
         endTime: 0
       };
 
-      const track = tracks[caption.stream];
+      const captionTrack = captionTracks[caption.stream];
 
-      track.startTime = Math.min(track.startTime, (caption.startTime + timestampOffset));
-      track.endTime = Math.max(track.endTime, (caption.endTime + timestampOffset));
-      track.captions.push(caption);
+      captionTrack.startTime = Math.min(captionTrack.startTime, (caption.startTime + timestampOffset));
+      captionTrack.endTime = Math.max(captionTrack.endTime, (caption.endTime + timestampOffset));
+      captionTrack.captions.push(caption);
     });
 
-    Object.keys(tracks).forEach((trackName) => {
-      const {startTime, endTime, captions} = tracks[trackName];
+    Object.keys(captionTracks).forEach((trackName) => {
+      const {startTime, endTime, captions} = captionTracks[trackName];
       const inbandTextTracks = this.inbandTextTracks_;
 
       this.logger_(`adding cues from ${startTime} -> ${endTime} for ${trackName}`);

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -32,6 +32,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.mediaSource_ = null;
 
     this.subtitlesTrack_ = null;
+
+    this.loaderType_ = 'subtitle';
   }
 
   createTransmuxer_() {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1856,7 +1856,7 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
         loader.fillBuffer_();
         assert.ok(this.inbandTextTracks.CC1, 'text track created');
         assert.equal(this.inbandTextTracks.CC1.cues.length, 1, 'cue added');
-        assert.equal(mockCaptionParserClearParsedCaptions.callCount, 1, 'captions cleared after adding to text track');
+        assert.equal(mockCaptionParserClearParsedCaptions.callCount, 3, 'captions cleared after adding to text track');
         loader.pendingSegment_ = originalPendingSegment;
 
         // Dispose the loader


### PR DESCRIPTION
608 captions can currently "multiply", ie The same cue and text for a different rendition is added and both the caption from the old rendition and the new rendition are shown at the same time. This happens because:

1. We switch renditions segments are downloaded and parsed for captions.
2. We add the cues for those captions to our tracks.
3. If we already had similar cues from the previous rendition, we don't do anything about it. This causes duplicated captions!

The Fix:
Before adding caption cues to a track, we remove any existing caption cues at those times. 
