### PR TITLE
fix: prioritize playlist codecs over mux.js codecs, so encrypted content doesn't fail

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1173,14 +1173,20 @@ export class MasterPlaylistController extends videojs.EventTarget {
     const playlistCodecs = codecsForPlaylist(this.masterPlaylistLoader_.master, media);
     const codecs = {};
 
+    // priorty of codecs: playlist -> mux.js parsed codecs -> default
     if (mainStartingMedia.hasAudio || hasAltAudio) {
-      codecs.audio = mainStartingMedia.audioCodec || (audioStartingMedia || {}).audioCodec ||
-        translateLegacyCodec(playlistCodecs.audio) || DEFAULT_AUDIO_CODEC;
+      codecs.audio =
+        translateLegacyCodec(playlistCodecs.audio) ||
+        mainStartingMedia.audioCodec ||
+        (audioStartingMedia || {}).audioCodec ||
+        DEFAULT_AUDIO_CODEC;
     }
 
     if (mainStartingMedia.hasVideo) {
-      codecs.video = mainStartingMedia.videoCodec ||
-        translateLegacyCodec(playlistCodecs.video) || DEFAULT_VIDEO_CODEC;
+      codecs.video =
+        translateLegacyCodec(playlistCodecs.video) ||
+        mainStartingMedia.videoCodec ||
+        DEFAULT_VIDEO_CODEC;
     }
 
     if (!codecs.video && !codecs.audio) {

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -355,11 +355,15 @@ const handleSegmentBytes = ({
       hasAudio: !!tracks.audio
     };
 
-    if (tracks.audio && tracks.audio.codec) {
+    // if we have a audio track, with a codec that is not set to
+    // encrypted audio
+    if (tracks.audio && tracks.audio.codec && tracks.audio.codec !== 'enca') {
       trackInfo.audioCodec = tracks.audio.codec;
     }
 
-    if (tracks.video && tracks.video.codec) {
+    // if we have a video track, with a codec that is not set to
+    // encrypted video
+    if (tracks.video && tracks.video.codec && tracks.audio.codec !== 'encv') {
       trackInfo.videoCodec = tracks.video.codec;
     }
 

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -363,7 +363,7 @@ const handleSegmentBytes = ({
 
     // if we have a video track, with a codec that is not set to
     // encrypted video
-    if (tracks.video && tracks.video.codec && tracks.audio.codec !== 'encv') {
+    if (tracks.video && tracks.video.codec && tracks.video.codec !== 'encv') {
       trackInfo.videoCodec = tracks.video.codec;
     }
 

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -363,14 +363,9 @@ const handleSegmentBytes = ({
       trackInfo.videoCodec = tracks.video.codec;
     }
 
-    // if an init segment has both audio and video is muxed
-    // set hasAudio to false and merge the audio codec info.
     if (tracks.video && tracks.audio) {
+      trackInfo.isMuxed = true;
       trackInfo.hasAudio = false;
-      if (trackInfo.audioCodec) {
-        trackInfo.videoCodec += `,${trackInfo.audioCodec}`;
-        delete trackInfo.audioCodec;
-      }
     }
 
     // since we don't support appending fmp4 data on progress, we know we have the full

--- a/src/util/codecs.js
+++ b/src/util/codecs.js
@@ -97,7 +97,6 @@ const getCodecs = function(media) {
   if (mediaAttributes.CODECS) {
     return parseCodecs(mediaAttributes.CODECS);
   }
-  return defaultCodecs;
 };
 
 const audioProfileFromDefault = (master, audioGroupId) => {
@@ -166,7 +165,7 @@ export const isMuxed = (master, media) => {
  */
 export const codecsForPlaylist = function(master, media) {
   const mediaAttributes = media.attributes || {};
-  const codecInfo = getCodecs(media);
+  const codecInfo = getCodecs(media) || {};
 
   // HLS with multiple-audio tracks must always get an audio codec.
   // Put another way, there is no way to have a video-only multiple-audio HLS!
@@ -177,23 +176,16 @@ export const codecsForPlaylist = function(master, media) {
       // video are always separate (and separately specified).
       codecInfo.audioProfile = audioProfileFromDefault(master, mediaAttributes.AUDIO);
     }
-
-    if (!codecInfo.audioProfile) {
-      videojs.log.warn(
-        'Multiple audio tracks present but no audio codec string is specified. ' +
-        'Attempting to use the default audio codec (mp4a.40.2)');
-      codecInfo.audioProfile = defaultCodecs.audioProfile;
-    }
   }
 
   const codecs = {};
 
   if (codecInfo.videoCodec) {
-    codecs.video = `${codecInfo.videoCodec}${codecInfo.videoObjectTypeIndicator}`;
+    codecs.video = translateLegacyCodec(`${codecInfo.videoCodec}${codecInfo.videoObjectTypeIndicator}`);
   }
 
   if (codecInfo.audioProfile) {
-    codecs.audio = `mp4a.40.${codecInfo.audioProfile}`;
+    codecs.audio = translateLegacyCodec(`mp4a.40.${codecInfo.audioProfile}`);
   }
 
   return codecs;

--- a/src/util/codecs.js
+++ b/src/util/codecs.js
@@ -3,16 +3,7 @@
  * codec strings, or translating codec strings into objects that can be examined.
  */
 
-import videojs from 'video.js';
 import {findBox} from 'mux.js/lib/mp4/probe';
-
-// Default codec parameters if none were provided for video and/or audio
-const defaultCodecs = {
-  videoCodec: 'avc1',
-  videoObjectTypeIndicator: '.4d400d',
-  // AAC-LC
-  audioProfile: '2'
-};
 
 export const translateLegacyCodec = function(codec) {
   if (!codec) {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2550,7 +2550,9 @@ QUnit.test('parses codec from muxed fmp4 init segment', function(assert) {
     assert.deepEqual(loader.startingMedia_, {
       hasAudio: false,
       hasVideo: true,
-      videoCodec: 'avc1.42c00d,mp4a.40.2'
+      videoCodec: 'avc1.42c00d',
+      audioCodec: 'mp4a.40.2',
+      isMuxed: true
     }, 'starting media as expected');
   });
 });

--- a/test/util/codecs.test.js
+++ b/test/util/codecs.test.js
@@ -67,10 +67,7 @@ const testMimeTypes = function(assert, isFMP4) {
       hasAudioCodec: false,
       isFMP4
     })),
-    {
-      audio: 'mp4a.40.2',
-      video: 'avc1.4d400d'
-    },
+    {},
     'no MAAT, codecs: none');
 
   assert.deepEqual(
@@ -122,10 +119,7 @@ const testMimeTypes = function(assert, isFMP4) {
       hasAudioCodec: false,
       isFMP4
     })),
-    {
-      audio: 'mp4a.40.2',
-      video: 'avc1.4d400d'
-    },
+    {},
     'MAAT, demuxed, codecs: none');
 
   assert.deepEqual(
@@ -137,7 +131,6 @@ const testMimeTypes = function(assert, isFMP4) {
       isFMP4
     })),
     {
-      audio: 'mp4a.40.2',
       video: 'avc1.deadbeef'
     },
     'MAAT, demuxed, codecs: video');
@@ -178,10 +171,7 @@ const testMimeTypes = function(assert, isFMP4) {
       hasAudioCodec: false,
       isFMP4
     })),
-    {
-      audio: 'mp4a.40.2',
-      video: 'avc1.4d400d'
-    },
+    {},
     'MAAT, muxed, codecs: none');
 
   assert.deepEqual(
@@ -193,7 +183,6 @@ const testMimeTypes = function(assert, isFMP4) {
       isFMP4
     })),
     {
-      audio: 'mp4a.40.2',
       video: 'avc1.deadbeef'
     },
     'MAAT, muxed, codecs: video');
@@ -330,7 +319,6 @@ function(assert) {
   assert.deepEqual(
     codecsForPlaylist(master, media),
     {
-      audio: 'mp4a.40.2',
       video: 'avc1.deadbeef'
     },
     'uses default audio codec');


### PR DESCRIPTION
fix: prioritize playlist codecs over mux.js codecs, so encrypted content doesn't fail