### PR TITLE
fix: track does not exist race condition

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1396,8 +1396,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // to the initSegment cache
     if (simpleSegment.map) {
       simpleSegment.map = this.initSegmentForMap(simpleSegment.map, true);
-      // move the map bytes onto the segment loader's segment state object
-      segmentInfo.segment.map.bytes = simpleSegment.map.bytes;
+      // move over init segment properties to media request
+      segmentInfo.segment.map = simpleSegment.map;
     }
 
     // if this request included a segment key, save that data in the cache


### PR DESCRIPTION
This contains the change originally from #565 but broken out so that we can talk about it.

Increasing playbackRate showed a race condition where an alt audio track wouldn't have, tracks or timescales set correctly after the first request