### PR TITLE
test: Fix a tests that could fail via a race condition

### DIFF
--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -810,7 +810,7 @@ function(assert) {
 
 QUnit.test('setDuration blocks audio and video queue entries until it finishes',
 function(assert) {
-  const done = assert.async();
+  const done = assert.async(2);
 
   assert.expect(6);
 
@@ -835,6 +835,7 @@ function(assert) {
       this.mediaSource.duration,
       11,
       'video append processed post duration set');
+    done();
   });
   this.sourceUpdater.appendBuffer({type: 'audio', bytes: mp4Audio()}, () => {
     assert.equal(


### PR DESCRIPTION
## Description
Sometimes this test fails on Firefox, because audio is appended to the audio buffer, before video, even though we call appendBuffer on video first. This causes the test to end without running the video appendBuffer callback and we get one less assertion than we expect.
