### PR TITLE
test: Make custom assertion functions instead of adding to QUnit

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -5,7 +5,6 @@ const worker = require('@gkatsev/rollup-plugin-bundle-worker');
 // for options
 const options = {
   input: 'src/videojs-http-streaming.js',
-  testInput: ['test/custom-assertions.js', 'test/**/*.test.js'],
   distName: 'videojs-http-streaming',
   externals(defaults) {
     return Object.assign(defaults, {

--- a/test/custom-assertions.js
+++ b/test/custom-assertions.js
@@ -4,12 +4,12 @@ import { timeRangesToArray } from '../src/ranges';
 // 1%
 const BANDWIDTH_TOLERANCE = 0.01;
 
-QUnit.assert.timeRangesEqual = function(timeRange1, timeRange2, message) {
-  this.deepEqual(timeRangesToArray(timeRange1), timeRangesToArray(timeRange2), message);
+export const timeRangesEqual = function(timeRange1, timeRange2, message) {
+  QUnit.assert.deepEqual(timeRangesToArray(timeRange1), timeRangesToArray(timeRange2), message);
 };
 
-QUnit.assert.bandwidthWithinTolerance = function(actual, expected, message) {
-  this.ok(
+export const bandwidthWithinTolerance = function(actual, expected, message) {
+  QUnit.assert.ok(
     Math.abs(actual - expected) < (expected * BANDWIDTH_TOLERANCE),
     `${message}: expected ${actual} to be within ${BANDWIDTH_TOLERANCE} of ${expected}`
   );

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -35,6 +35,10 @@ import {
   mp4AudioInit as mp4AudioInitSegment,
   mp4Audio as mp4AudioSegment
 } from './dist/test-segments';
+import {
+  timeRangesEqual,
+  bandwidthWithinTolerance
+} from './custom-assertions.js';
 
 QUnit.module('MasterPlaylistController', {
   beforeEach(assert) {
@@ -1876,7 +1880,7 @@ QUnit.test('does not get stuck in a loop due to inconsistent network/caching', f
     segmentRequest = this.requests[0];
 
     // walking forwards, still need two segments before trying to change rendition
-    assert.bandwidthWithinTolerance(segmentLoader.bandwidth, 80000, 'bandwidth is correct');
+    bandwidthWithinTolerance(segmentLoader.bandwidth, 80000, 'bandwidth is correct');
     assert.equal(mediaChanges.length, 2, 'did not change media');
     assert.equal(
       segmentRequest.uri.substring(segmentRequest.uri.length - 4),
@@ -1896,7 +1900,7 @@ QUnit.test('does not get stuck in a loop due to inconsistent network/caching', f
   }).then(() => {
     // Media may be changed, but it should be changed to the same media. In the future, this
     // can safely not be changed.
-    assert.bandwidthWithinTolerance(segmentLoader.bandwidth, 88000, 'bandwidth is correct');
+    bandwidthWithinTolerance(segmentLoader.bandwidth, 88000, 'bandwidth is correct');
     assert.equal(mediaChanges.length, 3, 'changed media');
     assert.equal(mediaChanges[2].uri, 'media.m3u8', 'media remains unchanged');
 
@@ -2105,11 +2109,11 @@ QUnit.test(
       return videojs.createTimeRanges(audioTimeRanges);
     };
 
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when main empty');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when main empty');
     mainTimeRanges = [[0, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 10]]), 'main when no audio');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 10]]), 'main when no audio');
 
     mpc.mediaTypes_.AUDIO.activePlaylistLoader = {
       media: () => audioMedia,
@@ -2120,45 +2124,45 @@ QUnit.test(
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
 
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when both empty');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when both empty');
     mainTimeRanges = [[0, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when audio empty');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when audio empty');
     mainTimeRanges = [];
     audioTimeRanges = [[0, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when main empty');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges(), 'empty when main empty');
     mainTimeRanges = [[0, 10]];
     audioTimeRanges = [[0, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 10]]), 'ranges equal');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 10]]), 'ranges equal');
     mainTimeRanges = [[5, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[5, 10]]), 'main later start');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[5, 10]]), 'main later start');
     mainTimeRanges = [[0, 10]];
     audioTimeRanges = [[5, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[5, 10]]), 'audio later start');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[5, 10]]), 'audio later start');
     mainTimeRanges = [[0, 9]];
     audioTimeRanges = [[0, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 9]]), 'main earlier end');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 9]]), 'main earlier end');
     mainTimeRanges = [[0, 10]];
     audioTimeRanges = [[0, 9]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 9]]), 'audio earlier end');
+    timeRangesEqual(mpc.seekable(), videojs.createTimeRanges([[0, 9]]), 'audio earlier end');
     mainTimeRanges = [[1, 10]];
     audioTimeRanges = [[0, 9]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(
+    timeRangesEqual(
       mpc.seekable(),
       videojs.createTimeRanges([[1, 9]]),
       'main later start, audio earlier end'
@@ -2167,7 +2171,7 @@ QUnit.test(
     audioTimeRanges = [[1, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(
+    timeRangesEqual(
       mpc.seekable(),
       videojs.createTimeRanges([[1, 9]]),
       'audio later start, main earlier end'
@@ -2175,7 +2179,7 @@ QUnit.test(
     mainTimeRanges = [[2, 9]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(
+    timeRangesEqual(
       mpc.seekable(),
       videojs.createTimeRanges([[2, 9]]),
       'main later start, main earlier end'
@@ -2184,7 +2188,7 @@ QUnit.test(
     audioTimeRanges = [[2, 9]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(
+    timeRangesEqual(
       mpc.seekable(),
       videojs.createTimeRanges([[2, 9]]),
       'audio later start, audio earlier end'
@@ -2193,7 +2197,7 @@ QUnit.test(
     audioTimeRanges = [[11, 20]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(
+    timeRangesEqual(
       mpc.seekable(),
       videojs.createTimeRanges([[1, 10]]),
       'no intersection, audio later'
@@ -2202,7 +2206,7 @@ QUnit.test(
     audioTimeRanges = [[1, 10]];
     mpc.seekable_ = videojs.createTimeRanges();
     mpc.onSyncInfoUpdate_();
-    assert.timeRangesEqual(
+    timeRangesEqual(
       mpc.seekable(),
       videojs.createTimeRanges([[11, 20]]),
       'no intersection, main later'

--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -4,6 +4,7 @@ import QUnit from 'qunit';
 import videojs from 'video.js';
 import SourceUpdater from '../src/source-updater';
 import { mp4Video, mp4Audio } from './dist/test-segments';
+import { timeRangesEqual } from './custom-assertions.js';
 
 QUnit.module('Source Updater', {
   beforeEach() {
@@ -299,7 +300,7 @@ QUnit.test('buffered returns intersection of audio and video buffers', function(
     buffered: videojs.createTimeRanges([[1.25, 1.5], [5.1, 6.1], [10.5, 10.9]])
   };
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     this.sourceUpdater.buffered(),
     videojs.createTimeRanges([[1.25, 1.5], [5.5, 5.6], [10.5, 10.9]]),
     'buffered is intersection'

--- a/test/util/buffer.test.js
+++ b/test/util/buffer.test.js
@@ -1,13 +1,14 @@
 import videojs from 'video.js';
 import QUnit from 'qunit';
 import { buffered } from '../../src/util/buffer';
+import {timeRangesEqual} from '../custom-assertions.js';
 
 QUnit.module('buffer');
 
 QUnit.test('buffered returns video buffered when no audio', function(assert) {
   const videoBuffered = videojs.createTimeRanges([[0, 1], [2, 3]]);
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered({ buffered: videoBuffered }, null, false),
     videoBuffered,
     'returns video buffered'
@@ -18,7 +19,7 @@ QUnit.test('buffered returns video buffered when audio disabled', function(asser
   const videoBuffered = videojs.createTimeRanges([[0, 1], [2, 3]]);
   const audioBuffered = videojs.createTimeRanges([[4, 5], [6, 7]]);
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered({ buffered: videoBuffered }, { buffered: audioBuffered }, true),
     videoBuffered,
     'returns video buffered'
@@ -28,7 +29,7 @@ QUnit.test('buffered returns video buffered when audio disabled', function(asser
 QUnit.test('buffered returns audio buffered when no video', function(assert) {
   const audioBuffered = videojs.createTimeRanges([[4, 5], [6, 7]]);
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered(null, { buffered: audioBuffered }, false),
     audioBuffered,
     'returns audio buffered'
@@ -39,7 +40,7 @@ QUnit.test('buffered returns intersection of audio and video buffers', function(
   const videoBuffered = videojs.createTimeRanges([[0, 5], [12, 100]]);
   const audioBuffered = videojs.createTimeRanges([[4, 5], [10, 101]]);
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered({ buffered: videoBuffered }, { buffered: audioBuffered }, false),
     videojs.createTimeRanges([[4, 5], [12, 100]]),
     'returns intersection'
@@ -47,7 +48,7 @@ QUnit.test('buffered returns intersection of audio and video buffers', function(
 });
 
 QUnit.test('buffered returns empty when no audio or video buffers', function(assert) {
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered(null, null, false),
     videojs.createTimeRanges(),
     'returns empty'
@@ -60,7 +61,7 @@ QUnit.test(
     const videoBuffered = videojs.createTimeRanges();
     const audioBuffered = videojs.createTimeRanges();
 
-    assert.timeRangesEqual(
+    timeRangesEqual(
       buffered({ buffered: videoBuffered }, { buffered: audioBuffered }, false),
       videojs.createTimeRanges(),
       'returns empty'
@@ -72,7 +73,7 @@ QUnit.test('buffered returns empty when audio buffer empty', function(assert) {
   const videoBuffered = videojs.createTimeRanges([[0, 1], [2, 3]]);
   const audioBuffered = videojs.createTimeRanges();
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered({ buffered: videoBuffered }, { buffered: audioBuffered }, false),
     videojs.createTimeRanges(),
     'returns empty'
@@ -83,7 +84,7 @@ QUnit.test('buffered returns empty when video buffer empty', function(assert) {
   const videoBuffered = videojs.createTimeRanges();
   const audioBuffered = videojs.createTimeRanges([[0, 1], [2, 3]]);
 
-  assert.timeRangesEqual(
+  timeRangesEqual(
     buffered({ buffered: videoBuffered }, { buffered: audioBuffered }, false),
     videojs.createTimeRanges(),
     'returns empty'


### PR DESCRIPTION
## Description
As the commit message says, we currently modify the assertion prototype. Initially this caused a lot of confusion for me because QUnit has nothing in the docs about the assertions we were using. I think adding to the prototype of a library is a bad practice.