### PR TITLE
chore: do not lint deploy dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ignore": [
       "dist",
       "docs",
+      "deploy",
       "test/dist",
       "utils",
       "src/*.worker.js"


### PR DESCRIPTION
## Description
When testing the netlify script @gkatsev found that we try to lint the deploy dir, which we should not do.