### PR TITLE
Added attribute NAME from playlist to Representation object

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ignore": [
       "dist",
       "docs",
+      "deploy",
       "test/dist",
       "utils",
       "src/*.worker.js"

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -64,6 +64,10 @@ class Representation {
       this.height = resolution.height;
     }
 
+    if (playlist.attributes.NAME) {
+      this.name = playlist.attributes.NAME;
+    }
+
     this.bandwidth = playlist.attributes.BANDWIDTH;
 
     // The id is simply the ordinality of the media playlist


### PR DESCRIPTION
## Description
Working with a playlist like this one
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=6758400,NAME="Source"
hls_000s_test_source/index.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3379200,NAME="High"
hls_000s_test_high/index.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=732160,NAME="Medium"
hls_000s_test_mid/index.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=337920,NAME="Low"
hls_000s_test_low/index.m3u8
```
I couldn't create a list for quality selection based on NAME attribute because the Representation object does not use this attribute.

## Specific Changes proposed
Add this attribute to Representation object.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
