### PR TITLE
fix: check loader type properly

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -269,9 +269,13 @@ const transmuxAndNotify = ({
       });
       trackInfoFn = null;
 
-      audioStartFn(probeResult.audioStart);
+      if (probeResult.hasAudio) {
+        audioStartFn(probeResult.audioStart);
+      }
+      if (probeResult.hasVideo) {
+        videoStartFn(probeResult.videoStart);
+      }
       audioStartFn = null;
-      videoStartFn(probeResult.videoStart);
       videoStartFn = null;
     }
   }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -659,6 +659,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     };
     this.resetLoader();
     this.remove(0, this.duration_(), done);
+
     // clears fmp4 captions
     if (this.captionParser_) {
       this.captionParser_.clearAllCaptions();
@@ -848,7 +849,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return false;
     }
 
-    if (this.loaderType === 'main' &&
+    if (this.loaderType_ === 'main' &&
         segmentInfo.startOfSegment < this.sourceUpdater_.videoTimestampOffset()) {
       return true;
     }
@@ -1557,7 +1558,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     const videoSegmentTimingInfoCallback =
       this.handleVideoSegmentTimingInfo_.bind(this, segmentInfo.requestId);
 
-    this.sourceUpdater_.appendBuffer({type, bytes, videoSegmentTimingInfoCallback}, (error) => {
+    this.sourceUpdater_.appendBuffer({segmentInfo, type, bytes, videoSegmentTimingInfoCallback}, (error) => {
       if (error) {
         this.error(`appenderror for ${type} append with ${bytes.length} bytes`);
         // If an append errors, we can't recover.

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -274,7 +274,7 @@ export default class SourceUpdater extends videojs.EventTarget {
    */
   appendBuffer({segmentInfo, type, bytes, videoSegmentTimingInfoCallback}, doneFn) {
     this.processedAppend_ = true;
-    const originalAction = actions.appendBuffer(bytes, segmentInfo);
+    const originalAction = actions.appendBuffer(bytes, segmentInfo || {mediaIndex: -1});
     const originalDoneFn = doneFn;
     let action = originalAction;
 

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -105,7 +105,7 @@ const actions = {
   appendBuffer: (bytes, segmentInfo) => (type, sourceUpdater) => {
     const sourceBuffer = sourceUpdater[`${type}Buffer`];
 
-    sourceUpdater.logger_(`Appending ${bytes.length} to ${type}Buffer`);
+    sourceUpdater.logger_(`Appending segment ${segmentInfo.mediaIndex}'s ${bytes.length} bytes to ${type}Buffer`);
 
     sourceBuffer.appendBuffer(bytes);
   },

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -102,7 +102,7 @@ const shiftQueue = (type, sourceUpdater) => {
 };
 
 const actions = {
-  appendBuffer: (bytes) => (type, sourceUpdater) => {
+  appendBuffer: (bytes, segmentInfo) => (type, sourceUpdater) => {
     const sourceBuffer = sourceUpdater[`${type}Buffer`];
 
     sourceUpdater.logger_(`Appending ${bytes.length} to ${type}Buffer`);
@@ -272,9 +272,9 @@ export default class SourceUpdater extends videojs.EventTarget {
    * @param {Function} done the function to call when done
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-appendBuffer-void-ArrayBuffer-data
    */
-  appendBuffer({type, bytes, videoSegmentTimingInfoCallback}, doneFn) {
+  appendBuffer({segmentInfo, type, bytes, videoSegmentTimingInfoCallback}, doneFn) {
     this.processedAppend_ = true;
-    const originalAction = actions.appendBuffer(bytes);
+    const originalAction = actions.appendBuffer(bytes, segmentInfo);
     const originalDoneFn = doneFn;
     let action = originalAction;
 


### PR DESCRIPTION
In the segment loader, we checked for `this.loaderType` but should be checking against `this.loaderType_`.
In addition, this passes the segmentInfo to the appendBuffer action, so we can have a more meaningful debug log.
Also, don't log audio buffer or video buffer data if they don't exist.