### PR TITLE
fix: improve timestampOffset calculation to avoid gaps

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1284,6 +1284,17 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (segmentInfo.timestampOffset !== null &&
         segmentInfo.timestampOffset !== this.sourceUpdater_.timestampOffset()) {
+      const buffered = this.buffered_();
+
+      // Update the timestampOffset with more accurate timing info from the
+      // current buffered range and results of the probe, if it is available
+      if (buffered.length && timingInfo.segmentTimestampInfo) {
+        const ptsStartTime = timingInfo.segmentTimestampInfo[0].ptsTime;
+        const dtsStartTime = timingInfo.segmentTimestampInfo[0].dtsTime;
+
+        segmentInfo.timestampOffset = buffered.end(buffered.length - 1) - (ptsStartTime - dtsStartTime);
+      }
+
       this.sourceUpdater_.timestampOffset(segmentInfo.timestampOffset);
       // fired when a timestamp offset is set in HLS (can also identify discontinuities)
       this.trigger('timestampoffset');

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1288,7 +1288,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       // Update the timestampOffset with more accurate timing info from the
       // current buffered range and results of the probe, if it is available
-      if (buffered.length && timingInfo.segmentTimestampInfo) {
+      if (buffered.length && timingInfo && timingInfo.segmentTimestampInfo) {
         const ptsStartTime = timingInfo.segmentTimestampInfo[0].ptsTime;
         const dtsStartTime = timingInfo.segmentTimestampInfo[0].dtsTime;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -822,11 +822,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (mediaIndex !== null) {
       let segment = playlist.segments[mediaIndex];
 
-      if (segment && segment.end) {
-        startOfSegment = segment.end;
-      } else {
-        startOfSegment = lastBufferedEnd;
-      }
+      startOfSegment = lastBufferedEnd;
+
       return this.generateSegmentInfo_(playlist, mediaIndex + 1, startOfSegment, false);
     }
 
@@ -1284,15 +1281,15 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (segmentInfo.timestampOffset !== null &&
         segmentInfo.timestampOffset !== this.sourceUpdater_.timestampOffset()) {
-      const buffered = this.buffered_();
 
-      // Update the timestampOffset with more accurate timing info from the
-      // current buffered range and results of the probe, if it is available
-      if (buffered.length && timingInfo && timingInfo.segmentTimestampInfo) {
+      // Subtract any difference between the PTS and DTS times of the first frame
+      // from the timeStampOffset (which currently equals the buffered.end) to prevent
+      // creating any gaps in the buffer
+      if (timingInfo && timingInfo.segmentTimestampInfo) {
         const ptsStartTime = timingInfo.segmentTimestampInfo[0].ptsTime;
         const dtsStartTime = timingInfo.segmentTimestampInfo[0].dtsTime;
 
-        segmentInfo.timestampOffset = buffered.end(buffered.length - 1) - (ptsStartTime - dtsStartTime);
+        segmentInfo.timestampOffset -= ptsStartTime - dtsStartTime;
       }
 
       this.sourceUpdater_.timestampOffset(segmentInfo.timestampOffset);

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -449,6 +449,7 @@ export default class SyncController extends videojs.EventTarget {
     let timeInfo = tsprobe(segmentInfo.bytes, this.inspectCache_);
     let segmentStartTime;
     let segmentEndTime;
+    let segmentTimestampInfo;
 
     if (!timeInfo) {
       return null;
@@ -458,13 +459,16 @@ export default class SyncController extends videojs.EventTarget {
       this.inspectCache_ = timeInfo.video[1].dts;
       segmentStartTime = timeInfo.video[0].dtsTime;
       segmentEndTime = timeInfo.video[1].dtsTime;
+      segmentTimestampInfo = timeInfo.video;
     } else if (timeInfo.audio && timeInfo.audio.length === 2) {
       this.inspectCache_ = timeInfo.audio[1].dts;
       segmentStartTime = timeInfo.audio[0].dtsTime;
       segmentEndTime = timeInfo.audio[1].dtsTime;
+      segmentTimestampInfo = timeInfo.audio;
     }
 
     const probedInfo = {
+      segmentTimestampInfo,
       start: segmentStartTime,
       end: segmentEndTime,
       containsVideo: timeInfo.video && timeInfo.video.length === 2,


### PR DESCRIPTION
## Description
Currently, the value for `timestampOffset` comes from `segment.end`, which is set from the DTS values returned by the tsprobe. This is not the correct value to use for the `timestampOffset`, and can result in missing frames or gaps between segments.

## Specific Changes proposed
The TBA/LHLS branch (now #master) improves upon the current calculation of the `timestampOffset` by using the buffered end value instead of `segment.end`. However, this can still result in gaps in some cases if there is a difference between the pts time and dts time of the first frame that exceeds an internal browser threshold (in Chrome this threshold seems to be right around .08). The way to address that is to factor in the difference between the pts start time and dts start time of the first frame: `timestampOffset = buffered.end - (ptsTime - dtsTime)`.

**Note:** This change will also need to be re-implemented in `master` on top of the TBA/LHLS changes at some point.
