### PR TITLE
Allow VP9 and AV1 codecs through in VHS

### DIFF
--- a/src/util/codecs.js
+++ b/src/util/codecs.js
@@ -44,7 +44,7 @@ export const parseCodecs = function(codecs = '') {
   result.codecCount = result.codecCount || 2;
 
   // parse the video codec
-  const parsed = (/(^|\s|,)+(avc[13])([^ ,]*)/i).exec(codecs);
+  const parsed = (/(^|\s|,)+(avc[13]|vp09|av01)([^ ,]*)/i).exec(codecs);
 
   if (parsed) {
     result.videoCodec = parsed[2];


### PR DESCRIPTION
Allow VP9 and AV1 via MSE streaming formats

## Description

The video codec strings for anything but h.264 were being ignored, leading to creation of a SourceBuffer with no codec string in its type when playing HLS containing AV1 video codec in fMP4 segments. Chrome wouldn't allow using such buffers and threw an error, but works with this change in to pass through the codec string. Firefox seemed to let them through either way.

I have some very experimental AV1-in-HLS sample streams up at https://media-streaming.wmflabs.org/clean/av1-hls/

## Specific Changes proposed

Codec string extraction now checks for VP9 and AV1 codec string prefixes ('vp09' and 'av01') as well as 'avc1' for h.264

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
