### PR TITLE
fix: Use pts value for timingInfo probes (#616/#660 from 1.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6626,9 +6626,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.2.0.tgz",
-      "integrity": "sha512-5P57+6jRqf2Jt8Qk1zHjR5Fei09RmDDuKOaaYKUTTSoi937hyxMerEsp8615N3OspQVCFRJwtGmvyT6sFmXdAA=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.5.0.tgz",
+      "integrity": "sha512-Rwai9Jm/RXbIW40389Td7SqQ+mhiPEDYRjNiN+5QAAhS/X9na/iPUooy0GT2VEHYpw6aTO6laKjjoHZqe12E0g=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6825,17 +6825,20 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -6845,12 +6848,14 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -6864,7 +6869,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -6872,22 +6878,26 @@
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6895,17 +6905,20 @@
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -6913,7 +6926,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -6922,7 +6936,8 @@
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -6931,7 +6946,8 @@
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -6939,17 +6955,20 @@
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6957,7 +6976,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -6965,12 +6985,14 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -6980,17 +7002,20 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -6998,37 +7023,44 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -7036,17 +7068,20 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -7056,7 +7091,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7064,12 +7100,14 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -7077,12 +7115,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -7091,17 +7131,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "10.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
             "cliui": "^3.2.0",
@@ -7120,12 +7163,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
@@ -7135,7 +7180,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -7147,7 +7193,8 @@
             },
             "string-width": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
@@ -7156,12 +7203,14 @@
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                   "dev": true
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
@@ -7173,7 +7222,8 @@
         },
         "yargs-parser": {
           "version": "8.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -7181,7 +7231,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,17 +14,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-      "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.2.tgz",
+      "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helpers": "^7.6.0",
-        "@babel/parser": "^7.6.0",
+        "@babel/generator": "^7.6.2",
+        "@babel/helpers": "^7.6.2",
+        "@babel/parser": "^7.6.2",
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
         "@babel/types": "^7.6.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
@@ -36,9 +36,9 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-          "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+          "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
           "dev": true
         },
         "debug": {
@@ -71,16 +71,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-      "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
+      "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.6.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "source-map": {
@@ -284,13 +283,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
-      "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
         "@babel/types": "^7.6.0"
       }
     },
@@ -343,9 +342,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-      "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+      "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -363,14 +362,14 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-      "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+      "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.5.4"
+        "regexpu-core": "^4.6.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -448,9 +447,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz",
-      "integrity": "sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.2.tgz",
+      "integrity": "sha512-zZT8ivau9LOQQaOGC7bQLQOT4XPkPXgN2ERfUgk1X8ql+mVkLc4E8eKk+FO3o0154kxzqenWCorfmEXpEZcrSQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -492,14 +491,14 @@
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-      "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+      "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.5.4"
+        "regexpu-core": "^4.6.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -603,12 +602,12 @@
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz",
-      "integrity": "sha512-jem7uytlmrRl3iCAuQyw8BpB4c4LWvSpvIeXKpMb+7j84lkx4m4mYr5ErAcmN5KM7B6BqrAvRGjBIbbzqCczew==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.2.tgz",
+      "integrity": "sha512-xBdB+XOs+lgbZc2/4F5BVDVcDNS4tcSKQc96KmlqLEAwz6tpYPEvPdmDfvVG0Ssn8lAhronaRs6Z6KSexIpK5g==",
       "dev": true,
       "requires": {
-        "regexp-tree": "^0.1.13"
+        "regexpu-core": "^4.6.0"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -678,9 +677,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
-      "integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+      "integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -707,9 +706,9 @@
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-      "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+      "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -745,20 +744,20 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-      "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+      "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.5.4"
+        "regexpu-core": "^4.6.0"
       }
     },
     "@babel/preset-env": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
-      "integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.2.tgz",
+      "integrity": "sha512-Ru7+mfzy9M1/YTEtlDS8CD45jd22ngb9tXnn64DvQK3ooyqSw9K4K9DUWmYknTTVk4TqygL9dqCrZgm1HMea/Q==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -766,9 +765,9 @@
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
         "@babel/plugin-proposal-dynamic-import": "^7.5.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
         "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
@@ -777,11 +776,11 @@
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
         "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.6.0",
+        "@babel/plugin-transform-block-scoping": "^7.6.2",
         "@babel/plugin-transform-classes": "^7.5.5",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
         "@babel/plugin-transform-destructuring": "^7.6.0",
-        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.6.2",
         "@babel/plugin-transform-duplicate-keys": "^7.5.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
         "@babel/plugin-transform-for-of": "^7.4.4",
@@ -792,7 +791,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.6.0",
         "@babel/plugin-transform-modules-systemjs": "^7.5.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.2",
         "@babel/plugin-transform-new-target": "^7.4.4",
         "@babel/plugin-transform-object-super": "^7.5.5",
         "@babel/plugin-transform-parameters": "^7.4.4",
@@ -800,11 +799,11 @@
         "@babel/plugin-transform-regenerator": "^7.4.5",
         "@babel/plugin-transform-reserved-words": "^7.2.0",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-        "@babel/plugin-transform-spread": "^7.2.0",
+        "@babel/plugin-transform-spread": "^7.6.2",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
         "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.4.4",
+        "@babel/plugin-transform-unicode-regex": "^7.6.2",
         "@babel/types": "^7.6.0",
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
@@ -822,9 +821,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -841,24 +840,24 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-          "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+          "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
           "dev": true
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-      "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
+      "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
+        "@babel/generator": "^7.6.2",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.0",
+        "@babel/parser": "^7.6.2",
         "@babel/types": "^7.6.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -866,9 +865,9 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-          "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+          "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
           "dev": true
         },
         "debug": {
@@ -942,9 +941,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+      "version": "12.7.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1071,9 +1070,9 @@
       }
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1176,9 +1175,9 @@
       "dev": true
     },
     "anymatch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-      "integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -1613,9 +1612,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.44",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
-      "integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ==",
+      "version": "1.6.47",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.47.tgz",
+      "integrity": "sha512-9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg==",
       "dev": true
     },
     "binary": {
@@ -1856,9 +1855,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+      "version": "1.0.30000999",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
+      "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
       "dev": true
     },
     "caporal": {
@@ -1950,19 +1949,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-      "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.1.tgz",
+      "integrity": "sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==",
       "dev": true,
       "requires": {
-        "anymatch": "^3.0.1",
-        "braces": "^3.0.2",
-        "fsevents": "^2.0.6",
-        "glob-parent": "^5.0.0",
-        "is-binary-path": "^2.1.0",
-        "is-glob": "^4.0.1",
-        "normalize-path": "^3.0.0",
-        "readdirp": "^3.1.1"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.0",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.1.3"
       },
       "dependencies": {
         "braces": {
@@ -2142,15 +2141,15 @@
       "dev": true
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
     },
     "comment-parser": {
       "version": "0.5.5",
@@ -2355,9 +2354,9 @@
       }
     },
     "conventional-changelog-eslint": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.2.tgz",
-      "integrity": "sha512-Yi7tOnxjZLXlCYBHArbIAm8vZ68QUSygFS7PgumPRiEk+9NPUeucy5Wg9AAyKoBprSV3o6P7Oghh4IZSLtKCvQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.4.tgz",
+      "integrity": "sha512-CPwTUENzhLGl3auunrJxiIEWncAGaby7gOFCdj2gslIuOFJ0KPJVOUhRz4Da/I53sdo/7UncUJkiLg94jEsjxg==",
       "dev": true,
       "requires": {
         "q": "^1.5.1"
@@ -2437,9 +2436,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
-      "integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
+      "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -2915,9 +2914,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.254.tgz",
-      "integrity": "sha512-7I5/OkgR6JKy6RFLJeru0kc0RMmmMu1UnkHBKInFKRrg1/4EQKIqOaUqITSww/SZ1LqWwp1qc/LLoIGy449eYw==",
+      "version": "1.3.277",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
+      "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
       "dev": true
     },
     "elegant-spinner": {
@@ -2939,9 +2938,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -3043,9 +3042,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -3055,8 +3054,8 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-check": {
@@ -3496,9 +3495,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
       "dev": true
     },
     "execa": {
@@ -3916,9 +3915,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-      "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.0.tgz",
+      "integrity": "sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==",
       "dev": true,
       "optional": true
     },
@@ -3970,9 +3969,9 @@
       }
     },
     "get-own-enumerable-property-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+      "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
       "dev": true
     },
     "get-pkg-repo": {
@@ -4332,9 +4331,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -4416,9 +4415,9 @@
       }
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4552,9 +4551,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "htmlparser2": {
@@ -4625,12 +4624,12 @@
       }
     },
     "http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
+        "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
       }
@@ -5196,9 +5195,9 @@
       "dev": true
     },
     "is-reference": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
-      "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
+      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
@@ -5272,9 +5271,9 @@
       "dev": true
     },
     "is-wsl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz",
-      "integrity": "sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
       "dev": true
     },
     "isarray": {
@@ -5539,9 +5538,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -5904,9 +5903,9 @@
       "dev": true
     },
     "karma-safari-applescript-launcher": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/karma-safari-applescript-launcher/-/karma-safari-applescript-launcher-0.1.1.tgz",
-      "integrity": "sha512-QVwXLtDnDbuKiupIZGCD56AUmGHUtDFoe80eMNf+dfZMJ7n4T1lNYr3wVjwuvB0vQaFV1/qdtqaZxmTMQ3VASQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-safari-applescript-launcher/-/karma-safari-applescript-launcher-0.1.0.tgz",
+      "integrity": "sha512-BAg8Q+VFgb8G9IajAYWvFSmvCYBr/RwqwZBRs6jbyaoIrHdi5boPgjz92c+y95zcKtsOqg8hncelsuuU6pA4hw==",
       "dev": true,
       "requires": {
         "run-applescript": "^3.2.0"
@@ -6333,12 +6332,24 @@
         "@babel/runtime": "^7.5.5",
         "@videojs/vhs-utils": "^1.1.0",
         "global": "^4.3.2"
+      },
+      "dependencies": {
+        "@videojs/vhs-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-1.1.0.tgz",
+          "integrity": "sha512-J+1rLDj3iA1qejmCU3b+UOdTpT9w00XaxyJis+JUfTOZ5o5t8BHa5Uhmk8pXDNsjSJNJyMMgtJ6+z8g/Fxsuzg==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "global": "^4.3.2",
+            "url-toolkit": "^2.1.6"
+          }
+        }
       }
     },
     "magic-string": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
-      "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
+      "integrity": "sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==",
       "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
@@ -6611,6 +6622,18 @@
         "@videojs/vhs-utils": "^1.1.0",
         "global": "^4.3.2",
         "xmldom": "^0.1.27"
+      },
+      "dependencies": {
+        "@videojs/vhs-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-1.1.0.tgz",
+          "integrity": "sha512-J+1rLDj3iA1qejmCU3b+UOdTpT9w00XaxyJis+JUfTOZ5o5t8BHa5Uhmk8pXDNsjSJNJyMMgtJ6+z8g/Fxsuzg==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "global": "^4.3.2",
+            "url-toolkit": "^2.1.6"
+          }
+        }
       }
     },
     "ms": {
@@ -6626,9 +6649,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.5.0.tgz",
-      "integrity": "sha512-Rwai9Jm/RXbIW40389Td7SqQ+mhiPEDYRjNiN+5QAAhS/X9na/iPUooy0GT2VEHYpw6aTO6laKjjoHZqe12E0g=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.5.1.tgz",
+      "integrity": "sha512-5VmmjADBqS4++8pTI6poSRJ+chHdaoI4XErcQPM5w4QfwaDl+FQlSI0iOgWbYDn6CBCbDRKaSCcEiN2K5aHNGQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6674,26 +6697,18 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.30",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.30.tgz",
-      "integrity": "sha512-BHcr1g6NeUH12IL+X3Flvs4IOnl1TL0JczUhEZjDE+FXXPQcVCNr8NEPb01zqGxzhTpdyJL5GXemaCW7aw6Khw==",
+      "version": "1.1.35",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+      "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^6.3.0"
       }
     },
     "node-watch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.0.tgz",
-      "integrity": "sha512-XAgTL05z75ptd7JSVejH1a2Dm1zmXYhuDr9l230Qk6Z7/7GPcnAs/UyJJ4ggsXSvWil8iOzwQLW0zuGUvHpG8g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.1.tgz",
+      "integrity": "sha512-gwQiR7weFRV8mAtT0x0kXkZ18dfRLB45xH7q0hCOVQMLfLb2f1ZaSvR57q4/b/Vj6B0RwMNJYbvb69e1yM7qEA==",
       "dev": true
     },
     "nomnom": {
@@ -6825,20 +6840,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -6848,14 +6860,12 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -6869,8 +6879,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -6878,26 +6887,22 @@
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "bundled": true,
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6905,20 +6910,17 @@
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -6926,8 +6928,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -6936,8 +6937,7 @@
         },
         "lru-cache": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -6946,8 +6946,7 @@
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -6955,20 +6954,17 @@
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+          "bundled": true,
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6976,8 +6972,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -6985,14 +6980,12 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -7002,20 +6995,17 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+          "bundled": true,
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -7023,44 +7013,37 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -7068,20 +7051,17 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -7091,8 +7071,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7100,14 +7079,12 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "which": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -7115,14 +7092,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -7131,20 +7106,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^3.2.0",
@@ -7163,14 +7135,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
@@ -7180,8 +7150,7 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -7193,8 +7162,7 @@
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
@@ -7203,14 +7171,12 @@
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
@@ -7222,8 +7188,7 @@
         },
         "yargs-parser": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -7231,8 +7196,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             }
           }
@@ -7924,15 +7888,15 @@
       "dev": true
     },
     "qunit": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.9.2.tgz",
-      "integrity": "sha512-wTOYHnioWHcx5wa85Wl15IE7D6zTZe2CQlsodS14yj7s2FZ3MviRnQluspBZsueIDEO7doiuzKlv05yfky1R7w==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.9.3.tgz",
+      "integrity": "sha512-RH4VYSaVsNRDthMFFboTJAJ8q4kJM5LvOqWponKUYPEAeOcmc/YFV1QsZ7ikknA3TjqliWFJYEV63vvVXaALmQ==",
       "dev": true,
       "requires": {
         "commander": "2.12.2",
         "js-reporters": "1.2.1",
         "minimatch": "3.0.4",
-        "node-watch": "0.6.0",
+        "node-watch": "0.6.1",
         "resolve": "1.9.0"
       },
       "dependencies": {
@@ -8004,9 +7968,9 @@
       }
     },
     "readdirp": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-      "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.3.tgz",
+      "integrity": "sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==",
       "dev": true,
       "requires": {
         "picomatch": "^2.0.4"
@@ -8070,12 +8034,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexp-tree": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
-      "integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
-      "dev": true
-    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -8083,9 +8041,9 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
@@ -8257,14 +8215,14 @@
       }
     },
     "rollup": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.2.tgz",
-      "integrity": "sha512-sCAHlcQ/PExU5t/kRwkEWHdhGmQrZ2IgdQzbjPVNfhWbKHMMZGYqkASVTpQqRPLtQKg15xzEscc+BnIK/TE7/Q==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.23.1.tgz",
+      "integrity": "sha512-95C1GZQpr/NIA0kMUQmSjuMDQ45oZfPgDBcN0yZwBG7Kee//m7H68vgIyg+SPuyrTZ5PrXfyLK80OzXeKG5dAA==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "^12.7.4",
-        "acorn": "^7.0.0"
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
       }
     },
     "rollup-plugin-babel": {
@@ -8332,9 +8290,9 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.1.tgz",
-      "integrity": "sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
+      "integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -8345,9 +8303,9 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-      "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
@@ -9356,9 +9314,9 @@
       }
     },
     "terser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.1.tgz",
-      "integrity": "sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.8.tgz",
+      "integrity": "sha512-otmIRlRVmLChAWsnSFNO0Bfk6YySuBp6G9qrHiJwlLDd4mxe2ta4sjI7TzIR+W1nBMjilzrMcPOz9pSusgx3hQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -9560,14 +9518,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
+      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "ultron": {
@@ -9934,9 +9901,9 @@
       }
     },
     "videojs-contrib-eme": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-3.5.4.tgz",
-      "integrity": "sha512-nwkff6x09NbaPgpk60J53hytPcBdrxa8culSG7EW43tIoU72bDnNrxLIYxEpU9Hp36cx/EuUcEcgfrIuv7agiw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-3.5.0.tgz",
+      "integrity": "sha512-MJNKvvYMNugVXwEw8X5ylgpGvVdXKW4NzCv5xyPOg3oE/Z5pjOZakLxmRfXMmnigCsu8qctODnBCWX5UcOT47A==",
       "dev": true,
       "requires": {
         "global": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "global": "^4.3.2",
     "m3u8-parser": "4.4.2",
     "mpd-parser": "0.9.0",
-    "mux.js": "5.2.0",
+    "mux.js": "5.5.0",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "global": "^4.3.2",
     "m3u8-parser": "4.4.2",
     "mpd-parser": "0.9.0",
-    "mux.js": "5.5.0",
+    "mux.js": "5.5.1",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -386,7 +386,7 @@ const handleSegmentBytes = ({
     trackInfoFn(segment, trackInfo);
     // the probe doesn't provide the segment end time, so only callback with the start
     // (the end time can be roughly calculated by the receiver using the duration)
-    const timingInfo = mp4probe.startTime(segment.map.timescales, bytesAsUint8Array);
+    const timingInfo = mp4probe.compositionStartTime(segment.map.timescales, bytesAsUint8Array);
 
     if (trackInfo.hasAudio) {
       timingInfoFn(segment, 'audio', 'start', timingInfo);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1432,7 +1432,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       if (useVideoTimingInfo) {
         firstVideoFrameTimeForData = this.handlePartialData_ ?
-          result.videoFrameDtsTime : segmentInfo.videoTimingInfo.start;
+          result.videoFramePtsTime : segmentInfo.videoTimingInfo.start;
       }
 
       // Segment loader knows more about segment timing than the transmuxer (in certain

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1555,7 +1555,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       segments
     });
 
-    this.sourceUpdater_.appendBuffer({type, bytes}, (error) => {
+    this.sourceUpdater_.appendBuffer({segmentInfo, type, bytes}, (error) => {
       if (error) {
         this.error(`appenderror for ${type} append with ${bytes.length} bytes`);
         // If an append errors, we can't recover.

--- a/src/segment-transmuxer.js
+++ b/src/segment-transmuxer.js
@@ -8,7 +8,8 @@ export const handleData_ = (event, transmuxedData, callback) => {
     captions,
     captionStreams,
     metadata,
-    videoFrameDtsTime
+    videoFrameDtsTime,
+    videoFramePtsTime
   } = event.data.segment;
 
   transmuxedData.buffer.push({
@@ -37,8 +38,12 @@ export const handleData_ = (event, transmuxedData, callback) => {
     )
   };
 
-  if (videoFrameDtsTime) {
+  if (typeof videoFrameDtsTime !== 'undefined') {
     result.videoFrameDtsTime = videoFrameDtsTime;
+  }
+
+  if (typeof videoFramePtsTime !== 'undefined') {
+    result.videoFramePtsTime = videoFramePtsTime;
   }
 
   callback(result);

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -164,6 +164,10 @@ const wirePartialTransmuxerEvents = function(self, transmuxer) {
       segment.videoFrameDtsTime = videoTsToSeconds(event.data.videoFrameDts);
     }
 
+    if (typeof event.data.videoFramePts !== 'undefined') {
+      segment.videoFramePtsTime = videoTsToSeconds(event.data.videoFramePts);
+    }
+
     self.postMessage({
       action: 'data',
       segment

--- a/src/util/segment.js
+++ b/src/util/segment.js
@@ -40,10 +40,10 @@ export const probeTsSegment = (bytes, baseStartTime) => {
   };
 
   if (result.hasVideo) {
-    result.videoStart = timeInfo.video[0].dtsTime;
+    result.videoStart = timeInfo.video[0].ptsTime;
   }
   if (result.hasAudio) {
-    result.audioStart = timeInfo.audio[0].dtsTime;
+    result.audioStart = timeInfo.audio[0].ptsTime;
   }
 
   return result;

--- a/src/util/segment.js
+++ b/src/util/segment.js
@@ -1,21 +1,5 @@
-import mp4probe from 'mux.js/lib/mp4/probe';
 import tsInspector from 'mux.js/lib/tools/ts-inspector.js';
 import { ONE_SECOND_IN_TS } from 'mux.js/lib/utils/clock';
-
-/**
- * Probe an fmp4 segment to determine the start of the segment in it's internal
- * "media time".
- *
- * @private
- * @param {Uint8Array} segmentBytes - segment bytes
- * @param {Uint8Array} mapBytes - map bytes
- * @return {Object} The start and end time of the current segment in "media time"
- */
-export const probeMp4StartTime = (segmentBytes, mapBytes) => {
-  const timescales = mp4probe.timescale(mapBytes);
-
-  return mp4probe.startTime(timescales, segmentBytes);
-};
 
 /**
  * Probe an mpeg2-ts segment to determine the start time of the segment in it's

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -20,6 +20,7 @@ import {
 } from './loader-common.js';
 import {
   muxed as muxedSegment,
+  oneSecond as oneSecondSegment,
   audio as audioSegment,
   video as videoSegment,
   mp4Video as mp4VideoSegment,
@@ -423,7 +424,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           this.currentTime = 210;
         });
 
-        standardXHRResponse(this.requests.shift(), muxedSegment());
+        standardXHRResponse(this.requests.shift(), oneSecondSegment());
         // the appended event will not fire, as segment-loader will realize that its guess
         // was off and will reset everything to load at the new point, therefore, wait for
         // the syncinfoupdate event rather than the appended event
@@ -630,7 +631,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
         assert.notOk(playlist.segments[0].end, 'does not start with duration');
 
-        standardXHRResponse(this.requests.shift(), muxedSegment());
+        standardXHRResponse(this.requests.shift(), oneSecondSegment());
 
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
@@ -986,7 +987,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         );
 
         // wrap up the first request to set mediaIndex and start normal live streaming
-        standardXHRResponse(this.requests.shift(), muxedSegment());
+        standardXHRResponse(this.requests.shift(), oneSecondSegment());
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1020,7 +1021,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           loader.one('error', reject);
         });
       }).then(() => {
-        assert.equal(playlistUpdated.segments[0].start, 0, 'set start on segment of new playlist');
+        assert.equal(playlistUpdated.segments[0].start, 0.11072222222222239, 'set start on segment of new playlist');
         assert.ok(playlistUpdated.segments[0].end, 'set end on segment of new playlist');
         assert.notOk(playlist.segments[1].start, 'did not set start on segment of old playlist');
         assert.notOk(playlist.segments[1].end, 'did not set end on segment of old playlist');
@@ -1048,7 +1049,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         );
 
         // wrap up the first request to set mediaIndex and start normal live streaming
-        standardXHRResponse(this.requests.shift(), muxedSegment());
+        standardXHRResponse(this.requests.shift(), oneSecondSegment());
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1082,7 +1083,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           loader.one('error', reject);
         });
       }).then(() => {
-        assert.equal(playlist.segments[1].start, 0, 'set start on segment of old playlist');
+        assert.equal(playlist.segments[1].start, 0.11072222222222239, 'set start on segment of old playlist');
         assert.ok(playlist.segments[1].end, 'set end on segment of old playlist');
         assert.notOk(
           playlistUpdated.segments[0].start,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1373,7 +1373,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           loader.one('error', reject);
         });
       }).then(() => {
-        assert.deepEqual(loader.error_, 'appenderror for video append with 2944 bytes', 'loader triggered and saved the appenderror');
+        assert.deepEqual(loader.error_, 'appenderror for video append with 2960 bytes', 'loader triggered and saved the appenderror');
       });
     });
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -192,7 +192,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     let loader;
 
     nestedHooks.beforeEach(function(assert) {
-      this.startTime = sinon.stub(mp4probe, 'startTime');
+      this.compositionStartTime = sinon.stub(mp4probe, 'compositionStartTime');
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'main',
         segmentMetadataTrack: this.segmentMetadataTrack
@@ -200,7 +200,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     nestedHooks.afterEach(function(assert) {
-      this.startTime.restore();
+      this.compositionStartTime.restore();
       loader.dispose();
     });
 
@@ -252,7 +252,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         loader.playlist(playlist);
         loader.load();
 
-        this.startTime.returns(11);
+        this.compositionStartTime.returns(11);
 
         this.clock.tick(100);
         // init


### PR DESCRIPTION
## Description
~~**I am not sure if this is correct or not, and will need feedback. This does fix the issue from #616 though**~~

#616 and #660 but for master. Since we already set `timestampOffset` to `bufferedEnd` in master all that was needed here was to change the `start` times that we probe for so that they use `ptsTime`. When trying to minus dtsTime and ptsTime as seen in #616 playback never works. After setting it to just use the `ptsTime` value everything works.  From my testing `ptsTime` works **a lot more consistently** then `dtsTime` 

Depends on https://github.com/videojs/mux.js/pull/300