### PR TITLE
perf: better mux.js imports, save 15492 bytes gzipped, ~17.5% decrease in size

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -11,7 +11,7 @@ import TransmuxWorker from 'worker!./transmuxer-worker.worker.js';
 import segmentTransmuxer from './segment-transmuxer';
 import { TIME_FUDGE_FACTOR, timeUntilRebuffer as timeUntilRebuffer_ } from './ranges';
 import { minRebufferMaxBandwidthSelector } from './playlist-selectors';
-import { CaptionParser } from 'mux.js/lib/mp4';
+import CaptionParser from 'mux.js/lib/mp4/caption-parser';
 import logger from './util/logger';
 import { concatSegments } from './util/segment';
 import {

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -14,8 +14,8 @@
  * message-based interface to a Transmuxer object.
  */
 
-import fullMux from 'mux.js/lib/mp4/transmuxer';
-import partialMux from 'mux.js/lib/partial/transmuxer';
+import {Transmuxer as FullMux} from 'mux.js/lib/mp4/transmuxer';
+import PartialMux from 'mux.js/lib/partial/transmuxer';
 import {
   secondsToVideoTs,
   videoTsToSeconds
@@ -260,8 +260,8 @@ class MessageHandlers {
       this.transmuxer.dispose();
     }
     this.transmuxer = this.options.handlePartialData ?
-      new partialMux.Transmuxer(this.options) :
-      new fullMux.Transmuxer(this.options);
+      new PartialMux(this.options) :
+      new FullMux(this.options);
 
     if (this.options.handlePartialData) {
       wirePartialTransmuxerEvents(this.self, this.transmuxer);

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -14,8 +14,8 @@
  * message-based interface to a Transmuxer object.
  */
 
-import fullMux from 'mux.js/lib/mp4';
-import partialMux from 'mux.js/lib/partial';
+import fullMux from 'mux.js/lib/mp4/transmuxer';
+import partialMux from 'mux.js/lib/partial/transmuxer';
 import {
   secondsToVideoTs,
   videoTsToSeconds

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -9,6 +9,7 @@ import window from 'global/window';
 import PlaylistLoader from './playlist-loader';
 import Playlist from './playlist';
 import xhrFactory from './xhr';
+import { Decrypter, AsyncStream, decrypt } from 'aes-decrypter';
 import * as utils from './bin-utils';
 import {
   getProgramTime,
@@ -34,6 +35,9 @@ import './middleware-set-current-time';
 const Hls = {
   PlaylistLoader,
   Playlist,
+  Decrypter,
+  AsyncStream,
+  decrypt,
   utils,
 
   STANDARD_PLAYLIST_SELECTOR: lastBandwidthSelector,

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -9,7 +9,6 @@ import window from 'global/window';
 import PlaylistLoader from './playlist-loader';
 import Playlist from './playlist';
 import xhrFactory from './xhr';
-import { Decrypter, AsyncStream, decrypt } from 'aes-decrypter';
 import * as utils from './bin-utils';
 import {
   getProgramTime,
@@ -35,9 +34,6 @@ import './middleware-set-current-time';
 const Hls = {
   PlaylistLoader,
   Playlist,
-  Decrypter,
-  AsyncStream,
-  decrypt,
   utils,
 
   STANDARD_PLAYLIST_SELECTOR: lastBandwidthSelector,


### PR DESCRIPTION
gzipped size goes from 
`89525` -> `74033`,  `15492 bytes gzipped` or a ~17.5% decrease 

~~Due to dropping the main export of ` Decrypter,	AsyncStream,	 decrypt` this will probably have to be a major version, but I think it is warranted~~ EDIT: this part was removed, and an issue has been filed #627