### PR TITLE
feat: setup EME key systems for HLS as well as DASH 

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -162,12 +162,14 @@ const emeKeySystems = (keySystemOptions, mainSegmentLoader, audioSegmentLoader) 
   // 'video/mp4; codecs="avc1"' and 'audio/mp4; codecs="mp4"')
   } else {
     const parsedMimeType = parseContentType(mainSegmentLoader.mimeType_);
-    const codecs = parsedMimeType.parameters.codecs.split(',').map(codec => codec.trim());
+    const codecs = parsedMimeType.parameters.codecs.split(',');
 
     let audioCodec;
     let videoCodec;
 
     codecs.forEach(codec => {
+      codec = codec.trim();
+
       if (isAudioCodec(codec)) {
         audioCodec = codec;
       } else if (isVideoCodec(codec)) {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -179,15 +179,9 @@ const emeKeySystems = (keySystemOptions, mainSegmentLoader, audioSegmentLoader) 
       }
     });
 
-    if (!videoCodec || !audioCodec) {
-      videojs.log.warn('Insufficient codec information in the manifest.' +
-        ' There may be problems playing encrypted content');
-    }
-
     videoMimeAndCodec = `video/${subtype}; codecs="${videoCodec}"`;
     audioMimeAndCodec = `audio/${subtype}; codecs="${audioCodec}"`;
   }
-
 
   // upsert the content types based on the selected playlist
   const keySystemContentTypes = {};


### PR DESCRIPTION
## Description
Currently, VHS augments the EME key systems of DASH sources with DRM-related information from the manifest. In order to support Widevine HLS content, we will need to expand this key system handling to work for HLS content as well. Since the existing logic is based on the assumption that we are dealing with DASH, and thus unmuxed video and audio, some tweaks are needed in order to account for the fact that HLS can be either muxed or unmuxed.

## Specific Changes proposed
- get video and audio mimeTypes and codecs from `mainSegmentLoader.mimeType_` and `audioSegmentLoader.mimeType_` instead of playlist attributes, since we already do some of the [work needed](https://github.com/videojs/http-streaming/blob/1.x/src/master-playlist-controller.js#L1094) to format those strings for EME when we initially setup the source buffers. The one exception to that is muxed HLS, where some string manipulation is still required to parse out the individual codecs from a comma-delimited list.
- test changes
  - segment loader mocking needed to be added to account for changes to the `emeKeySystems()` function
  - added `openMediaSource()` call to one eme integration test so segment loader mimeTypes will be set
- created player for HLS Integration tests since this new code path for HLS requires a player to exist
