### PR TITLE
perf: Switch to two passes in terser save 903 gz bytes

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -1,5 +1,6 @@
 const generate = require('videojs-generate-rollup-config');
 const worker = require('@gkatsev/rollup-plugin-bundle-worker');
+const {terser} = require('rollup-plugin-terser');
 
 // see https://github.com/videojs/videojs-generate-rollup-config
 // for options
@@ -35,7 +36,8 @@ const options = {
   },
   primedPlugins(defaults) {
     return Object.assign(defaults, {
-      worker: worker()
+      worker: worker(),
+      uglify: terser({output: {comments: 'some'}, compress: {passes: 2}})
     });
   },
   babel(defaults) {


### PR DESCRIPTION
## Description
`89525` -> to `88623` no noticeable increase in minify time.

passes are not an unsafe transformation either. 
