### PR TITLE
perf: save 1157b gzip by using module mux.js

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -11,7 +11,7 @@ import {
   forEachMediaGroup
 } from './playlist-loader';
 import { resolveUrl, resolveManifestRedirect } from './resolve-url';
-import mp4Inspector from 'mux.js/lib/tools/mp4-inspector';
+import {parseSidx} from 'mux.js/module/tools/mp4-inspector';
 import { segmentXhrHeaders } from './xhr';
 import window from 'global/window';
 
@@ -275,7 +275,7 @@ export default class DashPlaylistLoader extends EventTarget {
       }
 
       const bytes = new Uint8Array(request.response);
-      const sidx = mp4Inspector.parseSidx(bytes.subarray(8));
+      const sidx = parseSidx(bytes.subarray(8));
 
       return doneFn(master, sidx);
     };

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -4,7 +4,7 @@ import { stringToArrayBuffer } from './util/string-to-array-buffer';
 import { transmux } from './segment-transmuxer';
 import { probeTsSegment } from './util/segment';
 import { isLikelyFmp4Data } from './util/codecs';
-import mp4probe from 'mux.js/lib/mp4/probe';
+import {tracks as mp4Tracks, startTime as mp4StartTime} from 'mux.js/module/mp4/probe';
 import { segmentXhrHeaders } from './xhr';
 
 export const REQUEST_ERRORS = {
@@ -165,7 +165,7 @@ const handleInitSegmentResponse =
 
   segment.map.bytes = new Uint8Array(request.response);
 
-  const tracks = mp4probe.tracks(segment.map.bytes);
+  const tracks = mp4Tracks(segment.map.bytes);
 
   tracks.forEach(function(track) {
     segment.map.tracks = segment.map.tracks || {};
@@ -381,7 +381,7 @@ const handleSegmentBytes = ({
     trackInfoFn(segment, trackInfo);
     // the probe doesn't provide the segment end time, so only callback with the start
     // (the end time can be roughly calculated by the receiver using the duration)
-    const timingInfo = mp4probe.startTime(segment.map.timescales, bytesAsUint8Array);
+    const timingInfo = mp4StartTime(segment.map.timescales, bytesAsUint8Array);
 
     if (trackInfo.hasAudio) {
       timingInfoFn(segment, 'audio', 'start', timingInfo);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -11,7 +11,7 @@ import TransmuxWorker from 'worker!./transmuxer-worker.worker.js';
 import segmentTransmuxer from './segment-transmuxer';
 import { TIME_FUDGE_FACTOR, timeUntilRebuffer as timeUntilRebuffer_ } from './ranges';
 import { minRebufferMaxBandwidthSelector } from './playlist-selectors';
-import { CaptionParser } from 'mux.js/lib/mp4';
+import CaptionParser from 'mux.js/module/mp4/caption-parser';
 import logger from './util/logger';
 import { concatSegments } from './util/segment';
 import {

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -14,12 +14,12 @@
  * message-based interface to a Transmuxer object.
  */
 
-import fullMux from 'mux.js/lib/mp4';
-import partialMux from 'mux.js/lib/partial';
+import {Transmuxer as FullMux} from 'mux.js/module/mp4/transmuxer';
+import PartialMux from 'mux.js/module/partial/transmuxer';
 import {
   secondsToVideoTs,
   videoTsToSeconds
-} from 'mux.js/lib/utils/clock';
+} from 'mux.js/module/utils/clock';
 
 const typeFromStreamString = (streamString) => {
   if (streamString === 'AudioSegmentStream') {
@@ -260,8 +260,8 @@ class MessageHandlers {
       this.transmuxer.dispose();
     }
     this.transmuxer = this.options.handlePartialData ?
-      new partialMux.Transmuxer(this.options) :
-      new fullMux.Transmuxer(this.options);
+      new PartialMux(this.options) :
+      new FullMux(this.options);
 
     if (this.options.handlePartialData) {
       wirePartialTransmuxerEvents(this.self, this.transmuxer);

--- a/src/util/codecs.js
+++ b/src/util/codecs.js
@@ -3,7 +3,7 @@
  * codec strings, or translating codec strings into objects that can be examined.
  */
 
-import {findBox} from 'mux.js/lib/mp4/probe';
+import {findBox} from 'mux.js/module/mp4/probe';
 
 export const translateLegacyCodec = function(codec) {
   if (!codec) {

--- a/src/util/gops.js
+++ b/src/util/gops.js
@@ -1,4 +1,4 @@
-import { ONE_SECOND_IN_TS } from 'mux.js/lib/utils/clock';
+import { ONE_SECOND_IN_TS } from 'mux.js/module/utils/clock';
 
 /**
  * Returns a list of gops in the buffer that have a pts value of 3 seconds or more in

--- a/src/util/segment.js
+++ b/src/util/segment.js
@@ -1,21 +1,5 @@
-import mp4probe from 'mux.js/lib/mp4/probe';
-import tsInspector from 'mux.js/lib/tools/ts-inspector.js';
-import { ONE_SECOND_IN_TS } from 'mux.js/lib/utils/clock';
-
-/**
- * Probe an fmp4 segment to determine the start of the segment in it's internal
- * "media time".
- *
- * @private
- * @param {Uint8Array} segmentBytes - segment bytes
- * @param {Uint8Array} mapBytes - map bytes
- * @return {Object} The start and end time of the current segment in "media time"
- */
-export const probeMp4StartTime = (segmentBytes, mapBytes) => {
-  const timescales = mp4probe.timescale(mapBytes);
-
-  return mp4probe.startTime(timescales, segmentBytes);
-};
+import {inspect as tsInspector} from 'mux.js/module/tools/ts-inspector.js';
+import { ONE_SECOND_IN_TS } from 'mux.js/module/utils/clock';
 
 /**
  * Probe an mpeg2-ts segment to determine the start time of the segment in it's
@@ -27,7 +11,7 @@ export const probeMp4StartTime = (segmentBytes, mapBytes) => {
  *                  whether it contains video and/or audio
  */
 export const probeTsSegment = (bytes, baseStartTime) => {
-  const timeInfo = tsInspector.inspect(bytes, baseStartTime * ONE_SECOND_IN_TS);
+  const timeInfo = tsInspector(bytes, baseStartTime * ONE_SECOND_IN_TS);
 
   if (!timeInfo) {
     return null;

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -8,7 +8,7 @@ import { removeCuesFromTrack } from './util/text-tracks';
 import { initSegmentId } from './bin-utils';
 import { uint8ToUtf8 } from './util/string';
 import { REQUEST_ERRORS } from './media-segment-request';
-import { ONE_SECOND_IN_TS } from 'mux.js/lib/utils/clock';
+import { ONE_SECOND_IN_TS } from 'mux.js/module/utils/clock';
 
 const VTT_LINE_TERMINATORS =
   new Uint8Array('\n\n'.split('').map(char => char.charCodeAt(0)));

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -6,7 +6,7 @@ import {
 } from '../src/segment-loader';
 import segmentTransmuxer from '../src/segment-transmuxer';
 import videojs from 'video.js';
-import mp4probe from 'mux.js/lib/mp4/probe';
+import mp4probe from 'mux.js/module/mp4/probe';
 import {
   playlistWithDuration,
   standardXHRResponse,


### PR DESCRIPTION
## Description
`74033` -> `72876` this includes the optimizations from #626 , so it is `1157b` more than that

Depends on https://github.com/videojs/mux.js/pull/290

