### PR TITLE
fix: add dispose functions and fix memory leaks

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -227,11 +227,14 @@ export default class DashPlaylistLoader extends EventTarget {
   }
 
   dispose() {
+    this.trigger('dispose');
     this.stopRequest();
     this.loadedPlaylists_ = {};
     window.clearTimeout(this.minimumUpdatePeriodTimeout_);
     window.clearTimeout(this.mediaRequest_);
     window.clearTimeout(this.mediaUpdateTimeout);
+
+    this.off();
   }
 
   hasPendingRequest() {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1098,6 +1098,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * that it controls
    */
   dispose() {
+    this.trigger('dispose');
     this.decrypter_.terminate();
     this.masterPlaylistLoader_.dispose();
     this.mainSegmentLoader_.dispose();
@@ -1117,6 +1118,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.audioSegmentLoader_.dispose();
     this.subtitleSegmentLoader_.dispose();
     this.sourceUpdater_.dispose();
+    this.off();
   }
 
   /**
@@ -1327,4 +1329,5 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     return Math.min(initial + currentTime * rate, max);
   }
+
 }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -314,9 +314,12 @@ export default class PlaylistLoader extends EventTarget {
     * Abort any outstanding work and clean up.
     */
   dispose() {
+    this.trigger('dispose');
     this.stopRequest();
     window.clearTimeout(this.mediaUpdateTimeout);
     window.clearTimeout(this.finalRenditionTimeout);
+
+    this.off();
   }
 
   stopRequest() {
@@ -588,4 +591,5 @@ export default class PlaylistLoader extends EventTarget {
       return this.trigger('loadedmetadata');
     });
   }
+
 }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -207,7 +207,8 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.transmuxer_ = this.createTransmuxer_();
 
-    this.syncController_.on('syncinfoupdate', () => this.trigger('syncinfoupdate'));
+    this.triggerSyncInfoUpdate_ = () => this.trigger('syncinfoupdate');
+    this.syncController_.on('syncinfoupdate', this.triggerSyncInfoUpdate_);
 
     this.mediaSource_.addEventListener('sourceopen', () => {
       if (!this.isEndOfStream_()) {
@@ -276,6 +277,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    * dispose of the SegmentLoader and reset to the default state
    */
   dispose() {
+    this.trigger('dispose');
     this.state = 'DISPOSED';
     this.pause();
     this.abort_();
@@ -289,6 +291,16 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (this.captionParser_) {
       this.captionParser_.reset();
     }
+
+    if (this.checkBufferTimeout_) {
+      window.clearTimeout(this.checkBufferTimeout_);
+    }
+
+    if (this.syncController_ && this.triggerSyncInfoUpdate_) {
+      this.syncController_.off('syncinfoupdate', this.triggerSyncInfoUpdate_);
+    }
+
+    this.off();
   }
 
   setAudio(enable) {

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -481,6 +481,7 @@ export default class SourceUpdater extends videojs.EventTarget {
    * dispose of the source updater and the underlying sourceBuffer
    */
   dispose() {
+    this.trigger('dispose');
     const audioDisposeFn = () => {
       if (this.mediaSource.readyState === 'open') {
         // ie 11 likes to throw on abort with InvalidAccessError or InvalidStateError
@@ -534,5 +535,7 @@ export default class SourceUpdater extends videojs.EventTarget {
     this.delayedAudioAppendQueue_.length = 0;
 
     this.mediaSource.removeEventListener('sourceopen', this.sourceopenListener_);
+
+    this.off();
   }
 }

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -490,4 +490,9 @@ export default class SyncController extends videojs.EventTarget {
       }
     }
   }
+
+  dispose() {
+    this.trigger('dispose');
+    this.off();
+  }
 }


### PR DESCRIPTION
## Description
A lot of the classes and major objects extend EventTarget, which has no notion of disposing listeners. We need to trigger dispose on our own and call `off` to remove all listeners on `dispose`. I noticed that we aren't even disposing most objects. 