### PR TITLE
fix: fix anamorphic video with chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,9 +5898,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.2.0.tgz",
-      "integrity": "sha512-5P57+6jRqf2Jt8Qk1zHjR5Fei09RmDDuKOaaYKUTTSoi937hyxMerEsp8615N3OspQVCFRJwtGmvyT6sFmXdAA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.2.1.tgz",
+      "integrity": "sha512-1t2payD3Y8izfZRq7tfUQlhL2fKzjeLr9v1/2qNCTkEQnd9Abtn1JgzsBgGZubEXh6lM5L8B0iLGoWQiukjtbQ=="
     },
     "mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "4.4.0",
     "mpd-parser": "0.8.1",
-    "mux.js": "5.2.0",
+    "mux.js": "5.2.1",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.8.0 || ^7.0.0"
   },


### PR DESCRIPTION
This updates to mux.js 5.2.1 which adds a pasp atom to fix anamorphic videos.

Fixes #312.