### PR TITLE
fix: update timestamp and dont wait for append, for zero length segments

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1948,6 +1948,20 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     segmentInfo.waitingOnAppends = 0;
 
+    // segments with no data
+    if (!segmentInfo.hasAppendedData_) {
+      // override settings for metadata only segments
+      segmentInfo.timestampOffset = segmentInfo.startOfSegment;
+      segmentInfo.timingInfo = {start: 0};
+      segmentInfo.waitingOnAppends++;
+
+      // update the timestampoffset
+      this.updateSourceBufferTimestampOffset_(segmentInfo);
+      // append is "done" instantly with no data.
+      this.checkAppendsDone_(segmentInfo);
+      return;
+    }
+
     // Since source updater could call back synchronously, do the increments first.
     if (waitForVideo) {
       segmentInfo.waitingOnAppends++;

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1957,6 +1957,11 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       // update the timestampoffset
       this.updateSourceBufferTimestampOffset_(segmentInfo);
+
+      // make sure the metadata queue is processed even though we have
+      // no video/audio data.
+      this.processMetadataQueue_();
+
       // append is "done" instantly with no data.
       this.checkAppendsDone_(segmentInfo);
       return;


### PR DESCRIPTION
## Description
Currently master waits for zero length segments to append, and they never will. So playback stalls and the video is assumed to have ended once we reach a zero length segment. Once I fixed that I realized that we have to set timingInfo start to zero for a zero length segment as we won't get a `timinginfo` event from mux.js.
