### PR TITLE
fix: improve timestampOffset calculation for fmp4s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,9 +5898,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.3.0.tgz",
-      "integrity": "sha512-pxvO3GrFwaHC032jGX4yg5W/RopPqOD7Ae82OshrnrML/VUJuE3Z5h9m/Zb43b07bPy/Edc1lCZnHgHu8avgwA=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.3.1.tgz",
+      "integrity": "sha512-HPid4YB13D2/EjEsNRqtJ6bWCWOB3LggVxtHLbbb/zwguGqwrgfnbCRoofwENKc9fkQQurqJ9zEHqRJsOGIfLg=="
     },
     "mz": {
       "version": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,9 +5898,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.3.1.tgz",
-      "integrity": "sha512-HPid4YB13D2/EjEsNRqtJ6bWCWOB3LggVxtHLbbb/zwguGqwrgfnbCRoofwENKc9fkQQurqJ9zEHqRJsOGIfLg=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.4.0.tgz",
+      "integrity": "sha512-UHCJk+Y2ZNU7Wpg+RKDeegr2GKtGjDG1RC+95dVG+OlM2Wz60vpK1LbC3J4D6ehWvtAC8EAaWGzKPzeAiVJxWw=="
     },
     "mz": {
       "version": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,9 +5898,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.2.1.tgz",
-      "integrity": "sha512-1t2payD3Y8izfZRq7tfUQlhL2fKzjeLr9v1/2qNCTkEQnd9Abtn1JgzsBgGZubEXh6lM5L8B0iLGoWQiukjtbQ=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.3.0.tgz",
+      "integrity": "sha512-pxvO3GrFwaHC032jGX4yg5W/RopPqOD7Ae82OshrnrML/VUJuE3Z5h9m/Zb43b07bPy/Edc1lCZnHgHu8avgwA=="
     },
     "mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "4.4.0",
     "mpd-parser": "0.8.1",
-    "mux.js": "5.3.0",
+    "mux.js": "5.3.1",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.8.0 || ^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "4.4.0",
     "mpd-parser": "0.8.1",
-    "mux.js": "5.2.1",
+    "mux.js": "5.3.0",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.8.0 || ^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "4.4.0",
     "mpd-parser": "0.8.1",
-    "mux.js": "5.3.1",
+    "mux.js": "5.4.0",
     "url-toolkit": "^2.1.3",
     "video.js": "^6.8.0 || ^7.0.0"
   },

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -456,6 +456,7 @@ export default class SyncController extends videojs.EventTarget {
     // so we use it here for consistency
     timescale = timescales[trackId] || 90e3;
 
+    // calculate the composition start time, in seconds
     compositionStartTime = (baseMediaDecodeTime + compositionTimeOffset) / timescale;
 
     if (segmentInfo.timestampOffset !== null) {

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -425,14 +425,14 @@ export default class SyncController extends videojs.EventTarget {
    * @return {object} The start and end time of the current segment in "composition time"
    */
   probeMp4Segment_(segmentInfo) {
-    let segment = segmentInfo.segment;
-    let timescales = mp4probe.timescale(segment.map.bytes);
-    let trafBoxes = mp4probe.findBox(segmentInfo.bytes, ['moof', 'traf']);
+    const segment = segmentInfo.segment;
+    // get timescales from init segment
+    const timescales = mp4probe.timescale(segment.map.bytes);
+    // get `traf` boxes from the media segment
+    const trafBoxes = mp4probe.findBox(segmentInfo.bytes, ['moof', 'traf']);
     let baseMediaDecodeTime = 0;
     let compositionTimeOffset = 0;
     let trackId;
-    let timescale;
-    let compositionStartTime;
 
     if (trafBoxes && trafBoxes.length) {
       // The spec states that track run samples contained within a `traf` box are contiguous, but
@@ -451,13 +451,14 @@ export default class SyncController extends videojs.EventTarget {
       }
     }
 
-    // Assume a 90kHz clock if no timescale was specified. This assumption comes from
-    // mux.js (https://github.com/videojs/mux.js/blob/master/lib/mp4/probe.js#L153-L154)
+    // Get timescale for this specific track. Assume a 90kHz clock if no timescale was
+    // specified. This assumption comes from mux.js
+    // (https://github.com/videojs/mux.js/blob/master/lib/mp4/probe.js#L153-L154)
     // so we use it here for consistency
-    timescale = timescales[trackId] || 90e3;
+    const timescale = timescales[trackId] || 90e3;
 
     // calculate the composition start time, in seconds
-    compositionStartTime = (baseMediaDecodeTime + compositionTimeOffset) / timescale;
+    const compositionStartTime = (baseMediaDecodeTime + compositionTimeOffset) / timescale;
 
     if (segmentInfo.timestampOffset !== null) {
       segmentInfo.timestampOffset -= compositionStartTime;

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -4,7 +4,7 @@
 
 import mp4probe from 'mux.js/lib/mp4/probe';
 import tsInspector from 'mux.js/lib/tools/ts-inspector.js';
-import { parseTraf } from 'mux.js/lib/tools/mp4-inspector.js';
+import mp4Inspector from 'mux.js/lib/tools/mp4-inspector.js';
 import { sumDurations } from './playlist';
 import videojs from 'video.js';
 import logger from './util/logger';
@@ -438,7 +438,7 @@ export default class SyncController extends videojs.EventTarget {
       // The spec states that track run samples contained within a `traf` box are contiguous, but
       // it does not explicitly state whether the `traf` boxes themselves are contiguous.
       // We will assume that they are, so we only need the first to calculate start time.
-      const parsedTraf = parseTraf(trafBoxes[0]);
+      const parsedTraf = mp4Inspector.parseTraf(trafBoxes[0]);
 
       for (var i = 0; i < parsedTraf.boxes.length; i++) {
         if (parsedTraf.boxes[i].type === 'tfhd') {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -6,7 +6,6 @@ import {
 } from '../src/segment-loader';
 import videojs from 'video.js';
 import mp4probe from 'mux.js/lib/mp4/probe';
-import mp4Inspector from 'mux.js/lib/tools/mp4-inspector.js';
 import {
   playlistWithDuration,
   MockTextTrack,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -145,6 +145,7 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
 
     nestedHooks.beforeEach(function(assert) {
       this.segmentMetadataTrack = new MockTextTrack();
+      this.compositionStartTime = sinon.stub(mp4probe, 'compositionStartTime');
       this.mimeType = 'video/mp2t';
 
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
@@ -158,6 +159,10 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
           loader.mediaSource_.sourceBuffers[0].trigger('updateend');
         }
       };
+    });
+
+    nestedHooks.afterEach(function(assert) {
+      this.compositionStartTime.restore();
     });
 
     QUnit.test(`load waits until a playlist and mime type are specified to proceed`,
@@ -229,35 +234,7 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
       loader.mimeType(this.mimeType);
       loader.load();
 
-      mp4probe.timescale = function() {
-        return {1: 1};
-      };
-
-      // for testing purposes, just return an array with length > 0
-      mp4probe.findBox = function() {
-        return [1, 2, 3];
-      };
-
-      mp4Inspector.parseTraf = function() {
-        return {
-          boxes: [
-            {
-              type: 'tfhd',
-              trackId: 1
-            },
-            {
-              type: 'tfdt',
-              baseMediaDecodeTime: 0
-            },
-            {
-              type: 'trun',
-              samples: [{
-                compositionTimeOffset: 11
-              }]
-            }
-          ]
-        }
-      };
+      this.compositionStartTime.returns(11);
 
       this.clock.tick(100);
       // init

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -233,7 +233,7 @@ QUnit.module('SegmentLoader: M2TS', function(hooks) {
         return {1: 1};
       };
 
-      // for tersting purposes, just return an array with length > 0
+      // for testing purposes, just return an array with length > 0
       mp4probe.findBox = function() {
         return [1, 2, 3];
       };

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -3,6 +3,8 @@ import {
   default as SyncController,
   syncPointStrategies as strategies } from '../src/sync-controller.js';
 import { playlistWithDuration } from './test-helpers.js';
+import mp4probe from 'mux.js/lib/mp4/probe';
+import mp4Inspector from 'mux.js/lib/tools/mp4-inspector.js';
 
 function getStrategy(name) {
   for (let i = 0; i < strategies.length; i++) {
@@ -524,4 +526,107 @@ QUnit.test('Correctly calculates expired time', function(assert) {
   expired = this.syncController.getExpiredTime(playlist, 50);
 
   assert.equal(expired, 0, 'estimated expired time using segmentSync');
+});
+
+QUnit.test('mp4 probe calculates correct composition start time and timestampOffset', function(assert) {
+  assert.expect(9);
+
+  let segmentInfo = {
+    segment: {
+      map: {
+        bytes: null
+      },
+      duration: 5
+    },
+    timestampOffset: 0,
+    bytes: null
+  };
+
+  mp4probe.timescale = function() {
+    return {
+      1: 1,
+      2: 60
+    };
+  };
+
+  // for testing purposes, just return an array with length > 0 to ensure we follow
+  // the right code path
+  mp4probe.findBox = function() {
+    return [1, 2, 3];
+  };
+
+  mp4Inspector.parseTraf = function() {
+    return {
+      boxes: [
+        {
+          type: 'tfhd',
+          trackId: 1
+        },
+        {
+          type: 'tfdt',
+          baseMediaDecodeTime: 0
+        },
+        {
+          type: 'trun',
+          samples: [{
+            compositionTimeOffset: 11
+          }]
+        }
+      ]
+    }
+  };
+
+  let result = this.syncController.probeMp4Segment_(segmentInfo);
+
+  assert.equal(segmentInfo.timestampOffset, -11, 'mp4 probe adjusts segment\'s timeStampOffset');
+  assert.equal(result.start, 11, 'mp4 probe returns segment\'s compsoition start time');
+  assert.equal(result.end, 16, 'mp4 probe returns segment\'s compsoition end time');
+
+  // what if there is no `traf` box
+  mp4probe.findBox = function() {
+    return [];
+  };
+
+  // reset offset value to 0
+  segmentInfo.timestampOffset = 0;
+
+  result = this.syncController.probeMp4Segment_(segmentInfo);
+
+  assert.equal(segmentInfo.timestampOffset, 0, 'if no traf box, composition start time defaults to 0')
+  assert.equal(result.start, 0, 'if no traf box, start time defaults to 0');
+  assert.equal(result.end, 5, 'if no traf box, segment end defaults to the duration');
+
+  // there is a `traf` box again
+  mp4probe.findBox = function() {
+    return [1, 2, 3];
+  };
+
+  // but what if the `trun` has no samples
+  mp4Inspector.parseTraf = function() {
+    return {
+      boxes: [
+        {
+          type: 'tfhd',
+          trackId: 1
+        },
+        {
+          type: 'tfdt',
+          baseMediaDecodeTime: 2
+        },
+        {
+          type: 'trun',
+          samples: []
+        }
+      ]
+    }
+  };
+
+  // reset offset value to 0
+  segmentInfo.timestampOffset = 0;
+
+  result = this.syncController.probeMp4Segment_(segmentInfo);
+
+  assert.equal(segmentInfo.timestampOffset, -2, 'if no trun samples, calculate composition start from decode start')
+  assert.equal(result.start, 2, 'if no trun samples, start time comes from decode time');
+  assert.equal(result.end, 7, 'if no trun samples, segment end comes from decode time and segment duration');
 });


### PR DESCRIPTION
## Description
Starting in v69, Chrome started rolling out [changes](https://developers.google.com/web/updates/2018/08/chrome-69-media-updates#pts) to report media buffer ranges and durations based on `pts` (presentation timestamp) values instead of `dts` (decode timestamp). Until recently, this project was still expecting the former behavior, setting `timestampOffset` values using dts values. This occasionally conflicted with the new Chrome behavior, resulting in gaps in the buffer that negatively impacted playback. We addressed this issue in #616 for .ts segments, but apparently not fmp4s. This PR achieves the same thing as #616 for fmp4 segments by modifying the `probeMp4Segment_()` function to use "composition time" values instead of decode time. (**Note:** fmp4 timing does not rely on the same concepts of "pts" and "dts" as m2ts timing, instead using "decode time" and "composition time", the latter being a value calculated from the  decode time and a "composition time offset".)

The specific values we need to calculate the composition start time (in seconds) for a given fmp4 segment are: 
- the base media decode time of the fragment
- the composition time offset of the fragment
- the timescale of the media
  - From the ISO BMFF spec:
    > timescale is an integer that specifies the time-scale for this media; this is the number of time units that pass in one second. For example, a time coordinate system that measures time in sixtieths of a second has a time scale of 60.
  - timescale information is contained within the initialization segment, so we also need to get the specific `trackId` of a given media segment in order to associate it with a timescale.

The final calculation is:

`compositionStartTimeInSeconds = (baseMediaDecodeTime + compositionTimeOffset) / timescale`

## Specific Changes proposed
- The mux.js version bump exposes [parseTraf()](https://github.com/videojs/mux.js/commit/7ac044db5aea7bfd976ad357b5f5bc81bd9dbad7) to simplify retrieval of the base media decode time, composition time offset, and track id, since they are all contained within the `traf` box.
- Inside `probeMp4Segment_()`, parse the first `traf` box to get the information we need, then calculate and return the composition start and end times in seconds
  - Unlike `probeTsSegment_()`, the mp4 probe function also has the side effect of setting the `timestampOffset`. We may want to change this in the future so, like the ts probe, it simply returns the timing information and the `timestampOffset` can be set in `handleSegment_()`.
