### PR TITLE
1.x: support multiple stream-inf with same URI

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -471,7 +471,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
         properties.playlists[0].uri = phonyUri;
         properties.playlists[0].id = id;
-        // setup ID and URI references (URI for backwards compatability)
+        // setup ID and URI references (URI for backwards compatibility)
         master.playlists[id] = properties.playlists[0];
         master.playlists[phonyUri] = properties.playlists[0];
       }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -8,7 +8,8 @@ import {
   setupMediaPlaylists,
   resolveMediaGroupUris,
   updateMaster as updatePlaylist,
-  forEachMediaGroup
+  forEachMediaGroup,
+  createPlaylistID
 } from './playlist-loader';
 import { resolveUrl, resolveManifestRedirect } from './resolve-url';
 import mp4Inspector from 'mux.js/lib/tools/mp4-inspector';
@@ -51,13 +52,13 @@ export const updateMaster = (oldMaster, newMaster) => {
   // Then update media group playlists
   forEachMediaGroup(newMaster, (properties, type, group, label) => {
     if (properties.playlists && properties.playlists.length) {
-      const uri = properties.playlists[0].uri;
+      const id = properties.playlists[0].id;
       const playlistUpdate = updatePlaylist(update, properties.playlists[0]);
 
       if (playlistUpdate) {
         update = playlistUpdate;
         // update the playlist reference within media groups
-        update.mediaGroups[type][group][label].playlists[0] = update.playlists[uri];
+        update.mediaGroups[type][group][label].playlists[0] = update.playlists[id];
         noChanges = false;
       }
     }
@@ -105,8 +106,8 @@ const equivalentSidx = (a, b) => {
 export const compareSidxEntry = (playlists, oldSidxMapping) => {
   const newSidxMapping = {};
 
-  for (const uri in playlists) {
-    const playlist = playlists[uri];
+  for (const id in playlists) {
+    const playlist = playlists[id];
     const currentSidxInfo = playlist.sidx;
 
     if (currentSidxInfo) {
@@ -204,7 +205,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
     // live playlist staleness timeout
     this.on('mediaupdatetimeout', () => {
-      this.refreshMedia_(this.media().uri);
+      this.refreshMedia_(this.media().id);
     });
 
     this.state = 'HAVE_NOTHING';
@@ -304,12 +305,12 @@ export default class DashPlaylistLoader extends EventTarget {
       playlist = this.master.playlists[playlist];
     }
 
-    const mediaChange = !this.media_ || playlist.uri !== this.media_.uri;
+    const mediaChange = !this.media_ || playlist.id !== this.media_.id;
 
     // switch to previously loaded playlists immediately
     if (mediaChange &&
-      this.loadedPlaylists_[playlist.uri] &&
-      this.loadedPlaylists_[playlist.uri].endList) {
+      this.loadedPlaylists_[playlist.id] &&
+      this.loadedPlaylists_[playlist.id].endList) {
       this.state = 'HAVE_METADATA';
       this.media_ = playlist;
 
@@ -379,7 +380,7 @@ export default class DashPlaylistLoader extends EventTarget {
         // everything is ready just continue to haveMetadata
         this.haveMetadata({
           startingState,
-          playlist: newMaster.playlists[playlist.uri]
+          playlist: newMaster.playlists[playlist.id]
         });
       })
     );
@@ -387,11 +388,11 @@ export default class DashPlaylistLoader extends EventTarget {
 
   haveMetadata({startingState, playlist}) {
     this.state = 'HAVE_METADATA';
-    this.loadedPlaylists_[playlist.uri] = playlist;
+    this.loadedPlaylists_[playlist.id] = playlist;
     this.mediaRequest_ = null;
 
     // This will trigger loadedplaylist
-    this.refreshMedia_(playlist.uri);
+    this.refreshMedia_(playlist.id);
 
     // fire loadedmetadata the first time a media playlist is loaded
     // to resolve setup of media groups
@@ -459,8 +460,6 @@ export default class DashPlaylistLoader extends EventTarget {
       const phonyUri = `placeholder-uri-${i}`;
 
       master.playlists[i].uri = phonyUri;
-      // set up by URI references
-      master.playlists[phonyUri] = master.playlists[i];
     }
 
     // set up phony URIs for the media group playlists since we won't have external
@@ -468,10 +467,12 @@ export default class DashPlaylistLoader extends EventTarget {
     forEachMediaGroup(master, (properties, mediaType, groupKey, labelKey) => {
       if (properties.playlists && properties.playlists.length) {
         const phonyUri = `placeholder-uri-${mediaType}-${groupKey}-${labelKey}`;
+        const id = createPlaylistID(0, phonyUri);
 
         properties.playlists[0].uri = phonyUri;
+        properties.playlists[0].id = id;
         // setup URI references
-        master.playlists[phonyUri] = properties.playlists[0];
+        master.playlists[id] = properties.playlists[0];
       }
     });
 
@@ -709,7 +710,7 @@ export default class DashPlaylistLoader extends EventTarget {
                 }, this.master.minimumUpdatePeriod);
 
                 // TODO: do we need to reload the current playlist?
-                this.refreshMedia_(this.media().uri);
+                this.refreshMedia_(this.media().id);
 
                 return;
               })
@@ -732,9 +733,9 @@ export default class DashPlaylistLoader extends EventTarget {
    * references. If this is an alternate loader, the updated parsed manifest is retrieved
    * from the master loader.
    */
-  refreshMedia_(mediaUri) {
-    if (!mediaUri) {
-      throw new Error('refreshMedia_ must take a media uri');
+  refreshMedia_(mediaID) {
+    if (!mediaID) {
+      throw new Error('refreshMedia_ must take a media id');
     }
 
     let oldMaster;
@@ -756,9 +757,9 @@ export default class DashPlaylistLoader extends EventTarget {
       } else {
         this.master = updatedMaster;
       }
-      this.media_ = updatedMaster.playlists[mediaUri];
+      this.media_ = updatedMaster.playlists[mediaID];
     } else {
-      this.media_ = newMaster.playlists[mediaUri];
+      this.media_ = newMaster.playlists[mediaID];
       this.trigger('playlistunchanged');
     }
 

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -471,8 +471,9 @@ export default class DashPlaylistLoader extends EventTarget {
 
         properties.playlists[0].uri = phonyUri;
         properties.playlists[0].id = id;
-        // setup URI references
+        // setup ID and URI references (URI for backwards compatability)
         master.playlists[id] = properties.playlists[0];
+        master.playlists[phonyUri] = properties.playlists[0];
       }
     });
 

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -127,6 +127,8 @@ export const updateMaster = (master, media) => {
     }
   }
   result.playlists[media.id] = mergedPlaylist;
+  // URI reference added for backwards compatibility
+  result.playlists[media.uri] = mergedPlaylist;
 
   return result;
 };
@@ -146,6 +148,8 @@ export const setupMediaPlaylists = (master) => {
     playlist.id = createPlaylistID(i, playlist.uri);
 
     master.playlists[playlist.id] = playlist;
+    // URI reference added for backwards compatibility
+    master.playlists[playlist.uri] = playlist;
 
     if (!playlist.attributes) {
       // Although the spec states an #EXT-X-STREAM-INF tag MUST have a
@@ -597,6 +601,9 @@ export default class PlaylistLoader extends EventTarget {
         }]
       };
       this.master.playlists[id] = this.master.playlists[0];
+      // URI reference added for backwards compatibility
+      this.master.playlists[this.srcUrl] = this.master.playlists[0];
+
       this.haveMetadata(req, this.srcUrl, id);
       return this.trigger('loadedmetadata');
     });

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -4,7 +4,8 @@ import { isIncompatible, isEnabled } from './playlist.js';
  * Returns a function that acts as the Enable/disable playlist function.
  *
  * @param {PlaylistLoader} loader - The master playlist loader
- * @param {String} playlistUri - uri of the playlist
+
+ * @param {string} playlistID - id of the playlist
  * @param {Function} changePlaylistFn - A function to be called after a
  * playlist's enabled-state has been changed. Will NOT be called if a
  * playlist's enabled-state is unchanged
@@ -12,8 +13,8 @@ import { isIncompatible, isEnabled } from './playlist.js';
  * or if undefined returns the current enabled-state for the playlist
  * @return {Function} Function for setting/getting enabled
  */
-const enableFunction = (loader, playlistUri, changePlaylistFn) => (enable) => {
-  const playlist = loader.master.playlists[playlistUri];
+const enableFunction = (loader, playlistID, changePlaylistFn) => (enable) => {
+  const playlist = loader.master.playlists[playlistID];
   const incompatible = isIncompatible(playlist);
   const currentlyEnabled = isEnabled(playlist);
 
@@ -72,9 +73,11 @@ class Representation {
 
     // Partially-apply the enableFunction to create a playlist-
     // specific variant
-    this.enabled = enableFunction(hlsHandler.playlists,
-                                  playlist.uri,
-                                  qualityChangeFunction);
+    this.enabled = enableFunction(
+      hlsHandler.playlists,
+      playlist.id,
+      qualityChangeFunction
+    );
   }
 }
 
@@ -93,7 +96,7 @@ let renditionSelectionMixin = function(hlsHandler) {
       .master
       .playlists
       .filter((media) => !isIncompatible(media))
-      .map((e, i) => new Representation(hlsHandler, e, e.uri));
+      .map((e, i) => new Representation(hlsHandler, e, e.id));
   };
 };
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1489,7 +1489,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       byteLength: segmentInfo.byteLength,
       uri: segmentInfo.uri,
       timeline: segmentInfo.timeline,
-      playlist: segmentInfo.playlist.uri,
+      playlist: segmentInfo.playlist.id,
       start,
       end
     };

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -107,7 +107,7 @@ const handleHlsMediaChange = function(qualityLevels, playlistLoader) {
   let selectedIndex = -1;
 
   for (let i = 0; i < qualityLevels.length; i++) {
-    if (qualityLevels[i].id === newPlaylist.uri) {
+    if (qualityLevels[i].id === newPlaylist.id) {
       selectedIndex = i;
       break;
     }

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -45,6 +45,7 @@ QUnit.test('updateMaster: returns falsy when there are no changes', function(ass
       length: 1,
       0: {
         uri: '0',
+        id: '0',
         segments: []
       }
     },
@@ -77,7 +78,7 @@ QUnit.test('updateMaster: updates playlists', function(assert) {
   const master = {
     playlists: {
       length: 1,
-      0: { uri: '0' }
+      0: { uri: '0', id: '0' }
     },
     mediaGroups: {
       AUDIO: {},
@@ -91,6 +92,7 @@ QUnit.test('updateMaster: updates playlists', function(assert) {
     playlists: {
       length: 1,
       0: {
+        id: '0',
         uri: '0',
         segments: []
       }
@@ -109,6 +111,7 @@ QUnit.test('updateMaster: updates playlists', function(assert) {
       playlists: {
         length: 1,
         0: {
+          id: '0',
           uri: '0',
           segments: []
         }
@@ -128,6 +131,7 @@ QUnit.test('updateMaster: updates mediaGroups', function(assert) {
     playlists: {
       length: 1,
       0: {
+        id: '0',
         uri: '0',
         segments: []
       }
@@ -137,6 +141,7 @@ QUnit.test('updateMaster: updates mediaGroups', function(assert) {
         audio: {
           'audio-main': {
             playlists: [{
+              id: '0',
               uri: '0',
               test: 'old text',
               segments: []
@@ -163,6 +168,7 @@ QUnit.test('updateMaster: updates mediaGroups', function(assert) {
         audio: {
           'audio-main': {
             playlists: [{
+              id: '0',
               uri: '0',
               resolvedUri: '0',
               test: 'new text',
@@ -196,6 +202,7 @@ QUnit.test('updateMaster: updates playlists and mediaGroups', function(assert) {
             playlists: [{
               mediaSequence: 0,
               attributes: {},
+              id: 'audio-0-uri',
               uri: 'audio-0-uri',
               resolvedUri: urlTo('audio-0-uri'),
               segments: [{
@@ -213,6 +220,7 @@ QUnit.test('updateMaster: updates playlists and mediaGroups', function(assert) {
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -232,6 +240,7 @@ QUnit.test('updateMaster: updates playlists and mediaGroups', function(assert) {
             playlists: [{
               mediaSequence: 1,
               attributes: {},
+              id: 'audio-0-uri',
               uri: 'audio-0-uri',
               resolvedUri: urlTo('audio-0-uri'),
               segments: [{
@@ -249,6 +258,7 @@ QUnit.test('updateMaster: updates playlists and mediaGroups', function(assert) {
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -274,6 +284,7 @@ QUnit.test('updateMaster: updates playlists and mediaGroups', function(assert) {
               playlists: [{
                 mediaSequence: 1,
                 attributes: {},
+                id: 'audio-0-uri',
                 uri: 'audio-0-uri',
                 resolvedUri: urlTo('audio-0-uri'),
                 segments: [{
@@ -291,6 +302,7 @@ QUnit.test('updateMaster: updates playlists and mediaGroups', function(assert) {
         attributes: {
           BANDWIDTH: 9
         },
+        id: 'playlist-0-uri',
         uri: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
@@ -357,6 +369,7 @@ QUnit.test('compareSidxEntry: will remove non-matching sidxes from a mapping', f
   const playlists = [
     {
       uri: '0',
+      id: '0',
       sidx: {
         byterange: {
           offset: 0,
@@ -410,8 +423,8 @@ QUnit.test('filterChangedSidxMappings: removes change sidx info from mapping', f
     'if no sidx info changed, return the same object'
   );
   const playlists = loader.master.playlists;
-  const oldVideoKey = generateSidxKey(playlists['placeholder-uri-0'].sidx);
-  const oldAudioEnKey = generateSidxKey(playlists['placeholder-uri-AUDIO-audio-en'].sidx);
+  const oldVideoKey = generateSidxKey(playlists['0-placeholder-uri-0'].sidx);
+  const oldAudioEnKey = generateSidxKey(playlists['0-placeholder-uri-AUDIO-audio-en'].sidx);
 
   // should change the video playlist
   masterXml = loader.masterXml_.replace(/(indexRange)=\"\d+-\d+\"/, '$1="201-400"');
@@ -421,7 +434,7 @@ QUnit.test('filterChangedSidxMappings: removes change sidx info from mapping', f
     loader.clientOffset_,
     loader.sidxMapping_
   );
-  const newVideoKey = `${playlists['placeholder-uri-0'].sidx.uri}-201-400`;
+  const newVideoKey = `${playlists['0-placeholder-uri-0'].sidx.uri}-201-400`;
 
   assert.notOk(
     newSidxMapping[oldVideoKey],
@@ -460,6 +473,7 @@ QUnit.test('requestSidx_: creates an XHR request for a sidx range', function(ass
   };
   const playlist = {
     uri: 'fakeplaylist',
+    id: 'fakeplaylist',
     segments: [sidxInfo],
     sidx: sidxInfo
   };
@@ -784,7 +798,7 @@ QUnit.test('media: sets initial media playlist on master loader', function(asser
   );
   assert.deepEqual(
     Object.keys(loader.loadedPlaylists_),
-    [loader.master.playlists[0].uri],
+    [loader.master.playlists[0].id],
     'updated the loadedPlaylists_'
   );
   assert.strictEqual(loader.state, 'HAVE_METADATA', 'state should be HAVE_METADATA');
@@ -825,7 +839,7 @@ QUnit.test('media: sets a playlist from a string reference', function(assert) {
   );
   assert.deepEqual(
     Object.keys(loader.loadedPlaylists_),
-    [loader.master.playlists[0].uri],
+    [loader.master.playlists[0].id],
     'updated the loadedPlaylists_'
   );
   assert.strictEqual(loader.state, 'HAVE_METADATA', 'state should be HAVE_METADATA');
@@ -888,8 +902,8 @@ QUnit.test('media: switches to a new playlist from a loaded one', function(asser
   assert.deepEqual(
     Object.keys(loader.loadedPlaylists_),
     [
-      loader.master.playlists[0].uri,
-      loader.master.playlists[1].uri
+      loader.master.playlists[0].id,
+      loader.master.playlists[1].id
     ],
     'updated loadedPlaylists_'
   );
@@ -964,8 +978,8 @@ QUnit.test('media: switches to a previously loaded playlist immediately', functi
   assert.deepEqual(
     Object.keys(loader.loadedPlaylists_),
     [
-      loader.master.playlists[0].uri,
-      loader.master.playlists[1].uri
+      loader.master.playlists[0].id,
+      loader.master.playlists[1].id
     ],
     'loadedPlaylists_ only updated for new playlists'
   );
@@ -1072,7 +1086,7 @@ QUnit.test('haveMetadata: triggers loadedplaylist if initial selection', functio
   );
   assert.deepEqual(
     Object.keys(loader.loadedPlaylists_),
-    [loader.master.playlists[0].uri],
+    [loader.master.playlists[0].id],
     'updated loadedPlaylists_'
   );
   assert.strictEqual(loadedPlaylists, 1, 'one loadedplaylists');
@@ -1130,8 +1144,8 @@ QUnit.test('haveMetadata: triggers mediachange if new selection', function(asser
   assert.deepEqual(
     Object.keys(loader.loadedPlaylists_),
     [
-      loader.master.playlists[1].uri,
-      loader.master.playlists[0].uri
+      loader.master.playlists[1].id,
+      loader.master.playlists[0].id
     ],
     'updated loadedPlaylists_'
   );
@@ -1166,7 +1180,7 @@ QUnit.test('haveMaster: sets media on child loader', function(assert) {
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  childPlaylist = loader.master.playlists['placeholder-uri-AUDIO-audio-main'];
+  childPlaylist = loader.master.playlists['0-placeholder-uri-AUDIO-audio-main'];
   childLoader = new DashPlaylistLoader(childPlaylist, this.fakeHls, false, loader);
 
   mediaStub = sinon.stub(childLoader, 'media');
@@ -1189,10 +1203,11 @@ QUnit.test('parseMasterXml: setup phony playlists and resolves uris', function(a
 
   assert.strictEqual(masterPlaylist.uri, loader.srcUrl, 'master playlist uri set correctly');
   assert.strictEqual(masterPlaylist.playlists[0].uri, 'placeholder-uri-0');
+  assert.strictEqual(masterPlaylist.playlists[0].id, '0-placeholder-uri-0');
   assert.deepEqual(
-    masterPlaylist.playlists['placeholder-uri-0'],
+    masterPlaylist.playlists['0-placeholder-uri-0'],
     masterPlaylist.playlists[0],
-    'phony uri setup correctly for playlist'
+    'phony id setup correctly for playlist'
   );
   assert.ok(
     Object.keys(masterPlaylist.mediaGroups.AUDIO).length,
@@ -1279,7 +1294,7 @@ QUnit.test('refreshMedia: updates master and media playlists for master loader',
   const newMasterXml = testDataManifests['dash-live'];
 
   loader.masterXml_ = newMasterXml;
-  loader.refreshMedia_(loader.media().uri);
+  loader.refreshMedia_(loader.media().id);
 
   assert.notEqual(loader.master, oldMaster, 'new master set');
   assert.strictEqual(loadedPlaylists, 1, 'one loadedplaylist');
@@ -1312,7 +1327,7 @@ QUnit.test(
     playlistUnchanged++;
   });
 
-  loader.refreshMedia_(loader.media().uri);
+  loader.refreshMedia_(loader.media().id);
   assert.strictEqual(loadedPlaylists, 1, 'one loadedplaylists');
   assert.strictEqual(playlistUnchanged, 1, 'one playlistunchanged');
 });
@@ -1347,7 +1362,7 @@ QUnit.test('refreshMedia: updates master and media playlists for child loader', 
   const newMasterXml = testDataManifests['dash-live'];
 
   loader.masterXml_ = newMasterXml;
-  childLoader.refreshMedia_(loader.media().uri);
+  childLoader.refreshMedia_(loader.media().id);
 
   assert.notEqual(loader.master, oldMaster, 'new master set on master loader');
   assert.strictEqual(loadedPlaylists, 1, 'one loadedplaylist');
@@ -1382,7 +1397,7 @@ QUnit.test(
     playlistUnchanged++;
   });
 
-  childLoader.refreshMedia_(loader.media().uri);
+  childLoader.refreshMedia_(loader.media().id);
 
   assert.strictEqual(loadedPlaylists, 1, 'one loadedplaylist');
   assert.strictEqual(playlistUnchanged, 1, 'one playlistunchanged');
@@ -1443,6 +1458,7 @@ QUnit.test('sidxRequestFinished_: updates master with sidx information', functio
   const loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
   const fakePlaylist = {
     segments: [],
+    id: 'fakeplaylist',
     uri: 'fakeplaylist',
     sidx: {
       byterange: {
@@ -1490,6 +1506,7 @@ QUnit.test('sidxRequestFinished_: errors if request for sidx fails', function(as
       uri: 'fake-segment',
       duration: 15360
     }],
+    id: 'fakeplaylist',
     uri: 'fakeplaylist',
     sidx: {
       byterange: {
@@ -1536,8 +1553,8 @@ QUnit.test('sidxRequestFinished_: errors if request for sidx fails', function(as
 
 QUnit.test('setupChildLoader: sets masterPlaylistLoader and ' +
   'playlist on child loader', function(assert) {
-  const fakePlaylist = { uri: 'fakeplaylist1' };
-  const newPlaylist = { uri: 'fakeplaylist2' };
+  const fakePlaylist = { uri: 'fakeplaylist1', id: 'fakeplaylist1' };
+  const newPlaylist = { uri: 'fakeplaylist2', id: 'fakeplaylist2' };
   const loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
   const newLoader = new DashPlaylistLoader('dash-sidx.mpd', this.fakeHls);
   const childLoader = new DashPlaylistLoader(fakePlaylist, this.fakeHls, false, loader);
@@ -1595,7 +1612,7 @@ QUnit.test('hasPendingRequest: returns true if async code is running in child lo
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  childPlaylist = loader.master.playlists['placeholder-uri-AUDIO-audio-main'];
+  childPlaylist = loader.master.playlists['0-placeholder-uri-AUDIO-audio-main'];
   childLoader = new DashPlaylistLoader(childPlaylist, this.fakeHls, false, loader);
   assert.notOk(childLoader.hasPendingRequest(), 'no pending requests on construction');
 
@@ -1672,7 +1689,7 @@ QUnit.test('redirect src request when handleManifestRedirects is true', function
   modifiedRequest.responseURL = 'http://differenturi.com/test.mpd';
   this.standardXHRResponse(modifiedRequest);
 
-  let childLoader = new DashPlaylistLoader(loader.master.playlists['placeholder-uri-0'], this.fakeHls, false, loader);
+  const childLoader = new DashPlaylistLoader(loader.master.playlists['0-placeholder-uri-0'], this.fakeHls, false, loader);
 
   childLoader.load();
   this.clock.tick(1);
@@ -1769,7 +1786,7 @@ QUnit.test('child loader moves to HAVE_METADATA when initialized with a master p
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  playlist = loader.master.playlists['placeholder-uri-AUDIO-audio-main'];
+  playlist = loader.master.playlists['0-placeholder-uri-AUDIO-audio-main'];
   childLoader = new DashPlaylistLoader(playlist, this.fakeHls, false, loader);
 
   childLoader.on('loadedplaylist', function() {
@@ -1804,7 +1821,7 @@ QUnit.test('child playlist moves to HAVE_METADATA when initialized with a live m
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  playlist = loader.master.playlists['placeholder-uri-AUDIO-audio-main'];
+  playlist = loader.master.playlists['0-placeholder-uri-AUDIO-audio-main'];
   childLoader = new DashPlaylistLoader(playlist, this.fakeHls, false, loader);
 
   childLoader.on('loadedplaylist', function() {
@@ -1958,11 +1975,11 @@ QUnit.test('can switch playlists after the master is downloaded', function(asser
   loader.load();
 
   this.standardXHRResponse(this.requests.shift());
-  loader.media('placeholder-uri-0');
+  loader.media('0-placeholder-uri-0');
   clock.tick(1);
 
   assert.equal(loader.media().uri, 'placeholder-uri-0', 'changed to new playlist');
-  loader.media('placeholder-uri-1');
+  loader.media('1-placeholder-uri-1');
   clock.tick(1);
   assert.equal(loader.media().uri, 'placeholder-uri-1', 'changed to new playlist');
 });
@@ -1973,11 +1990,11 @@ QUnit.test('can switch playlists based on object or URI', function(assert) {
   loader.load();
   this.standardXHRResponse(this.requests.shift());
 
-  loader.media('placeholder-uri-0');
+  loader.media('0-placeholder-uri-0');
   this.clock.tick(1);
   assert.equal(loader.media().uri, 'placeholder-uri-0', 'changed to playlist by uri');
 
-  loader.media('placeholder-uri-1');
+  loader.media('1-placeholder-uri-1');
   this.clock.tick(1);
   assert.equal(loader.media().uri, 'placeholder-uri-1', 'changed to playlist by uri');
 
@@ -2002,28 +2019,54 @@ QUnit.test('errors if requests take longer than 45s', function(assert) {
   assert.strictEqual(loader.error.code, 2, 'fired a network error');
 });
 
-QUnit.test('parseMasterXml parses master manifest and sets up uri references',
-function(assert) {
-  let loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
+QUnit.test(
+  'parseMasterXml parses master manifest and sets up uri references',
+  function(assert) {
+    const loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
 
-  loader.load();
+    loader.load();
 
-  this.standardXHRResponse(this.requests.shift());
+    this.standardXHRResponse(this.requests.shift());
 
-  assert.equal(loader.master.playlists[0].uri, 'placeholder-uri-0',
-    'setup phony uri for media playlist');
-  assert.strictEqual(loader.master.playlists['placeholder-uri-0'],
-    loader.master.playlists[0], 'set reference by uri for easy access');
-  assert.equal(loader.master.playlists[1].uri, 'placeholder-uri-1',
-    'setup phony uri for media playlist');
-  assert.strictEqual(loader.master.playlists['placeholder-uri-1'],
-    loader.master.playlists[1], 'set reference by uri for easy access');
-  assert.equal(loader.master.mediaGroups.AUDIO.audio.main.playlists[0].uri,
-    'placeholder-uri-AUDIO-audio-main', 'setup phony uri for media groups');
-  assert.strictEqual(loader.master.playlists['placeholder-uri-AUDIO-audio-main'],
-    loader.master.mediaGroups.AUDIO.audio.main.playlists[0],
-    'set reference by uri for easy access');
-});
+    assert.equal(
+      loader.master.playlists[0].uri, 'placeholder-uri-0',
+      'setup phony uri for media playlist'
+    );
+    assert.equal(
+      loader.master.playlists[0].id, '0-placeholder-uri-0',
+      'setup phony id for media playlist'
+    );
+    assert.strictEqual(
+      loader.master.playlists['0-placeholder-uri-0'],
+      loader.master.playlists[0], 'set reference by uri for easy access'
+    );
+    assert.equal(
+      loader.master.playlists[1].uri, 'placeholder-uri-1',
+      'setup phony uri for media playlist'
+    );
+    assert.equal(
+      loader.master.playlists[1].id, '1-placeholder-uri-1',
+      'setup phony id for media playlist'
+    );
+    assert.strictEqual(
+      loader.master.playlists['1-placeholder-uri-1'],
+      loader.master.playlists[1], 'set reference by uri for easy access'
+    );
+    assert.equal(
+      loader.master.mediaGroups.AUDIO.audio.main.playlists[0].uri,
+      'placeholder-uri-AUDIO-audio-main', 'setup phony uri for media groups'
+    );
+    assert.equal(
+      loader.master.mediaGroups.AUDIO.audio.main.playlists[0].id,
+      '0-placeholder-uri-AUDIO-audio-main', 'setup phony id for media groups'
+    );
+    assert.strictEqual(
+      loader.master.playlists['0-placeholder-uri-AUDIO-audio-main'],
+      loader.master.mediaGroups.AUDIO.audio.main.playlists[0],
+      'set reference by uri for easy access'
+    );
+  }
+);
 
 QUnit.test('refreshes the xml if there is a minimumUpdatePeriod', function(assert) {
   let loader = new DashPlaylistLoader('dash-live.mpd', this.fakeHls);
@@ -2138,7 +2181,7 @@ QUnit.test('child loaders wait for async action before moving to HAVE_MASTER', f
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  const childPlaylist = loader.master.playlists['placeholder-uri-AUDIO-audio-main'];
+  const childPlaylist = loader.master.playlists['0-placeholder-uri-AUDIO-audio-main'];
   const childLoader = new DashPlaylistLoader(childPlaylist, this.fakeHls, false, loader);
 
   childLoader.load();

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -117,6 +117,7 @@ QUnit.test('updateMaster returns null when no change', function(assert) {
         BANDWIDTH: 9
       },
       uri: 'playlist-0-uri',
+      id: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
         duration: 10,
@@ -131,6 +132,7 @@ QUnit.test('updateMaster returns null when no change', function(assert) {
       BANDWIDTH: 9
     },
     uri: 'playlist-0-uri',
+    id: 'playlist-0-uri',
     segments: [{
       duration: 10,
       uri: 'segment-0-uri'
@@ -148,6 +150,7 @@ QUnit.test('updateMaster updates master when new media sequence', function(asser
         BANDWIDTH: 9
       },
       uri: 'playlist-0-uri',
+      id: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
         duration: 10,
@@ -162,13 +165,14 @@ QUnit.test('updateMaster updates master when new media sequence', function(asser
       BANDWIDTH: 9
     },
     uri: 'playlist-0-uri',
+    id: 'playlist-0-uri',
     segments: [{
       duration: 10,
       uri: 'segment-0-uri'
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -179,6 +183,7 @@ QUnit.test('updateMaster updates master when new media sequence', function(asser
           BANDWIDTH: 9
         },
         uri: 'playlist-0-uri',
+        id: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
           duration: 10,
@@ -198,6 +203,7 @@ QUnit.test('updateMaster updates master when endList changes', function(assert) 
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -213,6 +219,7 @@ QUnit.test('updateMaster updates master when endList changes', function(assert) 
     attributes: {
       BANDWIDTH: 9
     },
+    id: 'playlist-0-uri',
     uri: 'playlist-0-uri',
     segments: [{
       duration: 10,
@@ -220,7 +227,7 @@ QUnit.test('updateMaster updates master when endList changes', function(assert) 
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -231,6 +238,7 @@ QUnit.test('updateMaster updates master when endList changes', function(assert) 
         attributes: {
           BANDWIDTH: 9
         },
+        id: 'playlist-0-uri',
         uri: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
@@ -258,6 +266,7 @@ QUnit.test('updateMaster retains top level values in master', function(assert) {
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -272,6 +281,7 @@ QUnit.test('updateMaster retains top level values in master', function(assert) {
     attributes: {
       BANDWIDTH: 9
     },
+    id: 'playlist-0-uri',
     uri: 'playlist-0-uri',
     segments: [{
       duration: 10,
@@ -279,7 +289,7 @@ QUnit.test('updateMaster retains top level values in master', function(assert) {
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -297,6 +307,7 @@ QUnit.test('updateMaster retains top level values in master', function(assert) {
         attributes: {
           BANDWIDTH: 9
         },
+        id: 'playlist-0-uri',
         uri: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
@@ -324,6 +335,7 @@ QUnit.test('updateMaster adds new segments to master', function(assert) {
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -338,6 +350,7 @@ QUnit.test('updateMaster adds new segments to master', function(assert) {
     attributes: {
       BANDWIDTH: 9
     },
+    id: 'playlist-0-uri',
     uri: 'playlist-0-uri',
     segments: [{
       duration: 10,
@@ -348,7 +361,7 @@ QUnit.test('updateMaster adds new segments to master', function(assert) {
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -366,6 +379,7 @@ QUnit.test('updateMaster adds new segments to master', function(assert) {
         attributes: {
           BANDWIDTH: 9
         },
+        id: 'playlist-0-uri',
         uri: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
@@ -397,6 +411,7 @@ QUnit.test('updateMaster changes old values', function(assert) {
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -412,6 +427,7 @@ QUnit.test('updateMaster changes old values', function(assert) {
       BANDWIDTH: 8,
       newField: 1
     },
+    id: 'playlist-0-uri',
     uri: 'playlist-0-uri',
     segments: [{
       duration: 8,
@@ -422,7 +438,7 @@ QUnit.test('updateMaster changes old values', function(assert) {
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -441,6 +457,7 @@ QUnit.test('updateMaster changes old values', function(assert) {
           BANDWIDTH: 8,
           newField: 1
         },
+        id: 'playlist-0-uri',
         uri: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
@@ -461,6 +478,7 @@ QUnit.test('updateMaster retains saved segment values', function(assert) {
   const master = {
     playlists: [{
       mediaSequence: 0,
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -474,6 +492,7 @@ QUnit.test('updateMaster retains saved segment values', function(assert) {
   };
   const media = {
     mediaSequence: 0,
+    id: 'playlist-0-uri',
     uri: 'playlist-0-uri',
     segments: [{
       duration: 8,
@@ -484,13 +503,14 @@ QUnit.test('updateMaster retains saved segment values', function(assert) {
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
     {
       playlists: [{
         mediaSequence: 0,
+        id: 'playlist-0-uri',
         uri: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
@@ -516,6 +536,7 @@ QUnit.test('updateMaster resolves key and map URIs', function(assert) {
       attributes: {
         BANDWIDTH: 9
       },
+      id: 'playlist-0-uri',
       uri: 'playlist-0-uri',
       resolvedUri: urlTo('playlist-0-uri'),
       segments: [{
@@ -534,6 +555,7 @@ QUnit.test('updateMaster resolves key and map URIs', function(assert) {
     attributes: {
       BANDWIDTH: 9
     },
+    id: 'playlist-0-uri',
     uri: 'playlist-0-uri',
     segments: [{
       duration: 9,
@@ -556,7 +578,7 @@ QUnit.test('updateMaster resolves key and map URIs', function(assert) {
     }]
   };
 
-  master.playlists[media.uri] = master.playlists[0];
+  master.playlists[media.id] = master.playlists[0];
 
   assert.deepEqual(
     updateMaster(master, media),
@@ -567,6 +589,7 @@ QUnit.test('updateMaster resolves key and map URIs', function(assert) {
           BANDWIDTH: 9
         },
         uri: 'playlist-0-uri',
+        id: 'playlist-0-uri',
         resolvedUri: urlTo('playlist-0-uri'),
         segments: [{
           duration: 9,
@@ -623,21 +646,21 @@ QUnit.test('setupMediaPlaylists adds URI keys for each playlist', function(asser
     attributes: {},
     resolvedUri: urlTo('uri-0'),
     uri: 'uri-0',
-    id: 0
+    id: '0-uri-0'
   };
   const expectedPlaylist1 = {
     attributes: {},
     resolvedUri: urlTo('uri-1'),
     uri: 'uri-1',
-    id: 1
+    id: '1-uri-1'
   };
 
   setupMediaPlaylists(master);
 
   assert.deepEqual(master.playlists[0], expectedPlaylist0, 'retained playlist indices');
   assert.deepEqual(master.playlists[1], expectedPlaylist1, 'retained playlist indices');
-  assert.deepEqual(master.playlists['uri-0'], expectedPlaylist0, 'added playlist key');
-  assert.deepEqual(master.playlists['uri-1'], expectedPlaylist1, 'added playlist key');
+  assert.deepEqual(master.playlists['0-uri-0'], expectedPlaylist0, 'added playlist key');
+  assert.deepEqual(master.playlists['1-uri-1'], expectedPlaylist1, 'added playlist key');
 
   assert.equal(this.env.log.warn.calls, 2, 'logged two warnings');
   assert.equal(this.env.log.warn.args[0],
@@ -710,6 +733,7 @@ QUnit.test('resolveMediaGroupUris resolves media group URIs', function(assert) {
     uri: 'master-uri',
     playlists: [{
       attributes: { BANDWIDTH: 10 },
+      id: 'playlist-0',
       uri: 'playlist-0'
     }],
     mediaGroups: {
@@ -769,6 +793,7 @@ QUnit.test('resolveMediaGroupUris resolves media group URIs', function(assert) {
     uri: 'master-uri',
     playlists: [{
       attributes: { BANDWIDTH: 10 },
+      id: 'playlist-0',
       uri: 'playlist-0'
     }],
     mediaGroups: {
@@ -1417,9 +1442,10 @@ QUnit.test('clears the update timeout when switching quality', function(assert) 
                               '#EXTINF:10,\n' +
                               'low-0.ts\n');
   // change to a higher quality playlist
-  loader.media('live-high.m3u8');
-  this.requests.pop().respond(200, null,
-                              '#EXTM3U\n' +
+  loader.media('1-live-high.m3u8');
+  this.requests.pop().respond(
+    200, null,
+    '#EXTM3U\n' +
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
                               'high-0.ts\n');
@@ -1515,11 +1541,12 @@ function(assert) {
 
   loader.load();
 
-  loader.on('loadedplaylist', function() {
-    loader.media('high.m3u8');
-  });
-  this.requests.pop().respond(200, null,
-                              '#EXTM3U\n' +
+    loader.on('loadedplaylist', function() {
+      loader.media('1-high.m3u8');
+    });
+    this.requests.pop().respond(
+      200, null,
+      '#EXTM3U\n' +
                               '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
                               'low.m3u8\n' +
                               '#EXT-X-STREAM-INF:BANDWIDTH=2\n' +
@@ -1527,8 +1554,8 @@ function(assert) {
   assert.equal(this.requests[0].url, urlTo('high.m3u8'), 'switched variants immediately');
 });
 
-QUnit.test('can switch media playlists based on URI', function(assert) {
-  let loader = new PlaylistLoader('master.m3u8', this.fakeHls);
+QUnit.test('can switch media playlists based on ID', function(assert) {
+  const loader = new PlaylistLoader('master.m3u8', this.fakeHls);
 
   loader.load();
 
@@ -1544,7 +1571,7 @@ QUnit.test('can switch media playlists based on URI', function(assert) {
                               '#EXTINF:10,\n' +
                               'low-0.ts\n');
 
-  loader.media('high.m3u8');
+  loader.media('1-high.m3u8');
   assert.strictEqual(loader.state, 'SWITCHING_MEDIA', 'updated the state');
 
   this.requests.pop().respond(200, null,
@@ -1575,7 +1602,7 @@ QUnit.test('aborts in-flight playlist refreshes when switching', function(assert
                               '#EXTINF:10,\n' +
                               'low-0.ts\n');
   this.clock.tick(10 * 1000);
-  loader.media('high.m3u8');
+  loader.media('1-high.m3u8');
   assert.strictEqual(this.requests[0].aborted, true, 'aborted refresh request');
   assert.ok(!this.requests[0].onreadystatechange,
            'onreadystatechange handlers should be removed on abort');
@@ -1600,8 +1627,9 @@ QUnit.test('switching to the active playlist is a no-op', function(assert) {
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
                               'low-0.ts\n' +
-                              '#EXT-X-ENDLIST\n');
-  loader.media('low.m3u8');
+                              '#EXT-X-ENDLIST\n'
+  );
+  loader.media('0-low.m3u8');
 
   assert.strictEqual(this.requests.length, 0, 'no requests are sent');
 });
@@ -1621,8 +1649,9 @@ QUnit.test('switching to the active live playlist is a no-op', function(assert) 
                               '#EXTM3U\n' +
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
-                              'low-0.ts\n');
-  loader.media('low.m3u8');
+                              'low-0.ts\n'
+  );
+  loader.media('0-low.m3u8');
 
   assert.strictEqual(this.requests.length, 0, 'no requests are sent');
 });
@@ -1644,15 +1673,18 @@ function(assert) {
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
                               'low-0.ts\n' +
-                              '#EXT-X-ENDLIST\n');
-  loader.media('high.m3u8');
-  this.requests.pop().respond(200, null,
-                              '#EXTM3U\n' +
+                              '#EXT-X-ENDLIST\n'
+    );
+    loader.media('1-high.m3u8');
+    this.requests.pop().respond(
+      200, null,
+      '#EXTM3U\n' +
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
                               'high-0.ts\n' +
-                              '#EXT-X-ENDLIST\n');
-  loader.media('low.m3u8');
+                              '#EXT-X-ENDLIST\n'
+    );
+    loader.media('0-low.m3u8');
 
   assert.strictEqual(this.requests.length, 0, 'no outstanding requests');
   assert.strictEqual(loader.state, 'HAVE_METADATA', 'returned to loaded playlist');
@@ -1675,24 +1707,36 @@ function(assert) {
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
                               'low-0.ts\n' +
-                              '#EXT-X-ENDLIST\n');
-  loader.media('high.m3u8');
-  loader.media('low.m3u8');
+                              '#EXT-X-ENDLIST\n'
+    );
+    loader.media('1-high.m3u8');
+    loader.media('0-low.m3u8');
 
-  assert.strictEqual(this.requests.length,
-                    1,
-                    'requested high playlist');
-  assert.ok(this.requests[0].aborted,
-          'aborted playlist request');
-  assert.ok(!this.requests[0].onreadystatechange,
-           'onreadystatechange handlers should be removed on abort');
-  assert.strictEqual(loader.state,
-                    'HAVE_METADATA',
-                    'returned to loaded playlist');
-  assert.strictEqual(loader.media(),
-                    loader.master.playlists[0],
-                    'switched to loaded playlist');
-});
+    assert.strictEqual(
+      this.requests.length,
+      1,
+      'requested high playlist'
+    );
+    assert.ok(
+      this.requests[0].aborted,
+      'aborted playlist request'
+    );
+    assert.ok(
+      !this.requests[0].onreadystatechange,
+      'onreadystatechange handlers should be removed on abort'
+    );
+    assert.strictEqual(
+      loader.state,
+      'HAVE_METADATA',
+      'returned to loaded playlist'
+    );
+    assert.strictEqual(
+      loader.media(),
+      loader.master.playlists[0],
+      'switched to loaded playlist'
+    );
+  }
+);
 
 QUnit.test('does not abort requests when the same playlist is re-requested',
 function(assert) {
@@ -1711,9 +1755,10 @@ function(assert) {
                               '#EXT-X-MEDIA-SEQUENCE:0\n' +
                               '#EXTINF:10,\n' +
                               'low-0.ts\n' +
-                              '#EXT-X-ENDLIST\n');
-  loader.media('high.m3u8');
-  loader.media('high.m3u8');
+                              '#EXT-X-ENDLIST\n'
+    );
+    loader.media('1-high.m3u8');
+    loader.media('1-high.m3u8');
 
   assert.strictEqual(this.requests.length, 1, 'made only one request');
   assert.ok(!this.requests[0].aborted, 'request not aborted');
@@ -1725,7 +1770,7 @@ QUnit.test('throws an error if a media switch is initiated too early', function(
   loader.load();
 
   assert.throws(function() {
-    loader.media('high.m3u8');
+    loader.media('1-high.m3u8');
   }, 'threw an error from HAVE_NOTHING');
 
   this.requests.pop().respond(200, null,
@@ -1844,7 +1889,7 @@ QUnit.test('triggers an event when the active media changes', function(assert) {
   assert.strictEqual(loadedPlaylists, 2, 'two loadedplaylists');
   assert.strictEqual(loadedMetadata, 1, 'fired loadedMetadata');
 
-  loader.media('high.m3u8');
+  loader.media('1-high.m3u8');
   assert.strictEqual(mediaChangings, 1, 'mediachanging fires immediately');
   assert.strictEqual(mediaChanges, 0, 'mediachange does not fire immediately');
   assert.strictEqual(loadedPlaylists, 2, 'still two loadedplaylists');
@@ -1862,7 +1907,7 @@ QUnit.test('triggers an event when the active media changes', function(assert) {
   assert.strictEqual(loadedMetadata, 1, 'still one loadedmetadata');
 
   // switch back to an already loaded playlist
-  loader.media('low.m3u8');
+  loader.media('0-low.m3u8');
   assert.strictEqual(this.requests.length, 0, 'no requests made');
   assert.strictEqual(mediaChangings, 2, 'mediachanging fires');
   assert.strictEqual(mediaChanges, 2, 'fired a mediachange');
@@ -1870,7 +1915,7 @@ QUnit.test('triggers an event when the active media changes', function(assert) {
   assert.strictEqual(loadedMetadata, 1, 'still one loadedmetadata');
 
   // trigger a no-op switch
-  loader.media('low.m3u8');
+  loader.media('0-low.m3u8');
   assert.strictEqual(this.requests.length, 0, 'no requests made');
   assert.strictEqual(mediaChangings, 2, 'mediachanging ignored the no-op');
   assert.strictEqual(mediaChanges, 2, 'ignored a no-op media change');
@@ -1890,6 +1935,34 @@ function(assert) {
                                 '#EXT-X-MEDIA-SEQUENCE:0\n' +
                                 '#EXTINF:10,\n' +
                                 'low-0.ts\n' +
-                                '#EXT-X-ENDLIST');
-  assert.ok(loader.media().endList, 'flushed the final line of input');
+                                '#EXT-X-ENDLIST'
+    );
+    assert.ok(loader.media().endList, 'flushed the final line of input');
+  }
+);
+
+QUnit.test('Supports multiple STREAM-INF with the same URI', function(assert) {
+  const loader = new PlaylistLoader('master.m3u8', this.fakeHls);
+
+  loader.load();
+
+  this.requests.shift().respond(
+    200, null,
+    '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=1,AUDIO="aud0"\n' +
+                                'video/media.m3u8\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=2,AUDIO="aud1"\n' +
+                                'video/media.m3u8\n'
+  );
+  assert.equal(
+    loader.master.playlists['0-video/media.m3u8'].id,
+    loader.master.playlists[0].id,
+    'created key based on playlist id'
+  );
+
+  assert.equal(
+    loader.master.playlists['1-video/media.m3u8'].id,
+    loader.master.playlists[1].id,
+    'created key based on playlist id'
+  );
 });

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -388,8 +388,11 @@ export const playlistWithDuration = function(time, conf) {
       conf && conf.discontinuitySequence ? conf.discontinuitySequence : 0,
     attributes: conf && typeof conf.attributes !== 'undefined' ? conf.attributes : {}
   };
-  let count = Math.floor(time / 10);
-  let remainder = time % 10;
+
+  result.id = result.uri;
+
+  const count = Math.floor(time / 10);
+  const remainder = time % 10;
   let i;
   let isEncrypted = conf && conf.isEncrypted;
   let extension = conf && conf.extension ? conf.extension : '.ts';

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1860,7 +1860,7 @@ QUnit.test('playlist blacklisting duration is set through options', function(ass
                            'media1.m3u8\n');
   this.requests[1].respond(404);
   // media
-  const url = this.requests[1].url.slice(this.requests[1].url.lastIndexOf('/') + 1);
+  url = this.requests[1].url.slice(this.requests[1].url.lastIndexOf('/') + 1);
   let index;
 
   if (url === 'media.m3u8') {
@@ -1868,7 +1868,7 @@ QUnit.test('playlist blacklisting duration is set through options', function(ass
   } else {
     index = 1;
   }
-  const media = this.player.tech_.hls.playlists.master.playlists[createPlaylistID(index, url)];
+  media = this.player.tech_.hls.playlists.master.playlists[createPlaylistID(index, url)];
 
   assert.ok(media.excludeUntil > 0, 'original media blacklisted for some time');
   assert.equal(this.env.log.warn.calls, 1, 'warning logged for blacklist');


### PR DESCRIPTION
## Description
Fixes #663 

backport of #670 

## Specific Changes proposed
Instead of using playlist `URI` as a unique identifier for streams, create an `id` property that is the combination of `uri` and index within the master manifest. 