### PR TITLE
add uri playlist references for backwards compatibility

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -469,7 +469,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
         properties.playlists[0].uri = phonyUri;
         properties.playlists[0].id = id;
-        // setup ID and URI references (URI for backwards compatability)
+        // setup ID and URI references (URI for backwards compatibility)
         master.playlists[id] = properties.playlists[0];
         master.playlists[phonyUri] = properties.playlists[0];
       }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -469,8 +469,9 @@ export default class DashPlaylistLoader extends EventTarget {
 
         properties.playlists[0].uri = phonyUri;
         properties.playlists[0].id = id;
-        // setup URI references
+        // setup ID and URI references (URI for backwards compatability)
         master.playlists[id] = properties.playlists[0];
+        master.playlists[phonyUri] = properties.playlists[0];
       }
     });
 

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -127,6 +127,8 @@ export const updateMaster = (master, media) => {
     }
   }
   result.playlists[media.id] = mergedPlaylist;
+  // URI reference added for backwards compatibility
+  result.playlists[media.uri] = mergedPlaylist;
 
   return result;
 };
@@ -146,6 +148,8 @@ export const setupMediaPlaylists = (master) => {
     playlist.id = createPlaylistID(i, playlist.uri);
 
     master.playlists[playlist.id] = playlist;
+    // URI reference added for backwards compatibility
+    master.playlists[playlist.uri] = playlist;
 
     if (!playlist.attributes) {
       // Although the spec states an #EXT-X-STREAM-INF tag MUST have a
@@ -597,6 +601,9 @@ export default class PlaylistLoader extends EventTarget {
         }]
       };
       this.master.playlists[id] = this.master.playlists[0];
+      // URI reference added for backwards compatibility
+      this.master.playlists[this.srcUrl] = this.master.playlists[0];
+
       this.haveMetadata(req, this.srcUrl, id);
       return this.trigger('loadedmetadata');
     });


### PR DESCRIPTION
#670 fixed #663 but I realized that it would be considered a breaking change as you could no longer use uri to reference playlists. While this will still not work properly for stream-inf with the same URI, the majority of sources that do not do that should still be able to work using uri. 