### PR TITLE
Don't try to initialize media keys in IE11

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -224,8 +224,9 @@ const setupEmeOptions = (hlsHandler) => {
     if (sourceOptions) {
       player.currentSource().keySystems = sourceOptions;
 
-      // works around https://bugs.chromium.org/p/chromium/issues/detail?id=895449
-      if (player.eme.initializeMediaKeys) {
+      // Works around https://bugs.chromium.org/p/chromium/issues/detail?id=895449
+      // in non-IE11 browsers. In IE11 this is too early to initialize media keys
+      if (!(videojs.browser.IE_VERSION === 11) && player.eme.initializeMediaKeys) {
         player.eme.initializeMediaKeys();
       }
     }


### PR DESCRIPTION
## Description
PlayReady media key setup (done via `msSetMediaKeys()` in IE11) is a side effect of the on-demand `player.eme.initializeMediaKeys()` call and fails because the video `readyState` is still 0 at that point. For `msSetMediaKeys()` to work the `readyState` apparently has to be > 0. Therefore, we need to bypass `initializeMediaKeys()` in IE11 and delay the `msSetMediaKeys()` call until the video element is ready.

## Specific Changes proposed
Add a `!(videojs.browser.IE_VERSION === 11)` condition before calling `initializeMediaKeys()`, so that we fall back to the old [contrib-eme key setup behavior](https://github.com/videojs/videojs-contrib-eme/blob/master/src/plugin.js#L255) that waits until the `msneedkey` event in IE 11, and continue to use the on-demand key setup behavior everywhere else.

