### PR TITLE
Fix live startup failures when play happens before playlist is downloaded

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -121,12 +121,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
       seeking: () => this.tech_.seeking(),
       duration: () => this.mediaSource.duration,
       hasPlayed: () => this.hasPlayed_,
-      // While hasPlayed is used to determine if play() has been called (by user
-      // interaction, API, autoplay, etc.), hasPlayedContent is used to determine if
-      // the content has started playback. This is an important distinction, as playback
-      // of content entails many actions of setup, buffering, etc. that may or may not
-      // have taken place when hasPlayed has changed.
-      hasPlayedContent: () => this.tech_.el() && this.tech_.played().length > 0,
       goalBufferLength: () => this.goalBufferLength(),
       bandwidth,
       syncController: this.syncController_,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -157,6 +157,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // private settings
     this.hasPlayed_ = settings.hasPlayed;
+    this.hasPlayedContent_ = settings.hasPlayedContent;
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
     this.seeking_ = settings.seeking;
@@ -487,7 +488,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // when we haven't started playing yet, the start of a live playlist
     // is always our zero-time so force a sync update each time the playlist
     // is refreshed from the server
-    if (!this.hasPlayed_()) {
+    if (!this.hasPlayedContent_()) {
       newPlaylist.syncInfo = {
         mediaSequence: newPlaylist.mediaSequence,
         time: 0

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -157,7 +157,6 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // private settings
     this.hasPlayed_ = settings.hasPlayed;
-    this.hasPlayedContent_ = settings.hasPlayedContent;
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
     this.seeking_ = settings.seeking;
@@ -488,7 +487,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     // when we haven't started playing yet, the start of a live playlist
     // is always our zero-time so force a sync update each time the playlist
     // is refreshed from the server
-    if (!this.hasPlayedContent_()) {
+    //
+    // Use the INIT state to determine if playback has started, as the playlist sync info
+    // should be fixed once requests begin (as sync points are generated based on sync
+    // info), but not before then.
+    if (this.state === 'INIT') {
       newPlaylist.syncInfo = {
         mediaSequence: newPlaylist.mediaSequence,
         time: 0

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -27,6 +27,7 @@ export const LoaderCommonHooks = {
     };
     this.seeking = false;
     this.hasPlayed = true;
+    this.hasPlayedContent = true;
     this.paused = false;
     this.playbackRate = 1;
     this.fakeHls = {
@@ -69,6 +70,7 @@ export const LoaderCommonSettings = function(settings) {
     seekable: () => this.seekable,
     seeking: () => this.seeking,
     hasPlayed: () => this.hasPlayed,
+    hasPlayedContent: () => this.hasPlayedContent,
     duration: () => this.mediaSource.duration,
     goalBufferLength: () => this.goalBufferLength(),
     mediaSource: this.mediaSource,
@@ -1151,6 +1153,45 @@ export const LoaderCommonFactory = (LoaderConstructor,
       assert.equal(this.clock.methods.length,
                    timeoutCount,
                    'timeout count remains the same');
+    });
+
+    QUnit.test('maintains initial sync info if playlist is changed before playback starts', function(assert) {
+      this.hasPlayedContent = false;
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 1,
+        endList: false
+      }));
+
+      assert.deepEqual(
+        loader.playlist_.syncInfo,
+        {
+          mediaSequence: 1,
+          time: 0
+        },
+        'updated sync info to start at media sequence 1 and time 0'
+      );
+
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.deepEqual(
+        loader.playlist_.syncInfo,
+        {
+          mediaSequence: 2,
+          time: 0
+        },
+        'updated sync info to start at media sequence 2 and time 0'
+      );
+
+      this.hasPlayedContent = true;
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.notOk(loader.playlist_.syncInfo, 'did not set sync info on new playlist');
     });
   });
 };

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -27,7 +27,6 @@ export const LoaderCommonHooks = {
     };
     this.seeking = false;
     this.hasPlayed = true;
-    this.hasPlayedContent = true;
     this.paused = false;
     this.playbackRate = 1;
     this.fakeHls = {
@@ -70,7 +69,6 @@ export const LoaderCommonSettings = function(settings) {
     seekable: () => this.seekable,
     seeking: () => this.seeking,
     hasPlayed: () => this.hasPlayed,
-    hasPlayedContent: () => this.hasPlayedContent,
     duration: () => this.mediaSource.duration,
     goalBufferLength: () => this.goalBufferLength(),
     mediaSource: this.mediaSource,
@@ -1156,7 +1154,6 @@ export const LoaderCommonFactory = (LoaderConstructor,
     });
 
     QUnit.test('maintains initial sync info if playlist is changed before playback starts', function(assert) {
-      this.hasPlayedContent = false;
       loader.playlist(playlistWithDuration(50, {
         mediaSequence: 1,
         endList: false
@@ -1185,7 +1182,8 @@ export const LoaderCommonFactory = (LoaderConstructor,
         'updated sync info to start at media sequence 2 and time 0'
       );
 
-      this.hasPlayedContent = true;
+      loader.load();
+
       loader.playlist(playlistWithDuration(50, {
         mediaSequence: 2,
         endList: false

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1191,5 +1191,33 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.notOk(loader.playlist_.syncInfo, 'did not set sync info on new playlist');
     });
+
+    QUnit.test('maintains initial sync info if playlist is changed while segment in-flight', function(assert) {
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 1,
+        endList: false
+      }));
+
+      assert.deepEqual(
+        loader.playlist_.syncInfo,
+        {
+          mediaSequence: 1,
+          time: 0
+        },
+        'updated sync info to start at media sequence 1 and time 0'
+      );
+
+      assert.equal(this.requests.length, 0, 'no in-flight requests');
+      loader.load();
+      this.clock.tick(1);
+      assert.equal(this.requests.length, 1, 'one in-flight requests');
+
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.notOk(loader.playlist_.syncInfo, 'did not set sync info on new playlist');
+    });
   });
 };


### PR DESCRIPTION
When joining a live stream, VHS starts playback at a time of 0,
regardless of how long the stream has been playing. This means that the
playlist will start with sync info of time 0 for the first media index.

However, if the stream "played" (either via API, autoplay, etc.) before
a playlist was downloaded, then after the playlist downloaded the
loader would reset the sync info, erasing the assumed time 0 for first
media index, and the player would request segments ad infinitum, never
able to place them in the timeline and get a new sync point.

This separates the notion of played between play initiation and playback
of content (progress on the timeline), in order to ensure that the
initial sync info is maintained.

This continues the work done by @gkatsev in https://github.com/videojs/http-streaming/pull/496

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
