### PR TITLE
fix: race condition preventing qualityLevels from being populating

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
     <li><a href="test/">Run unit tests in browser.</a></li>
     <li><a href="docs/api/">Read generated docs.</a></li>
     <li><a href="examples">Browse Examples</a></li>
+    <li><a href="utils/stats/">Stats</a></li>
   </ul>
 
   <script src="node_modules/video.js/dist/alt/video.core.js"></script>

--- a/scripts/netlify.js
+++ b/scripts/netlify.js
@@ -1,12 +1,14 @@
 const path = require('path');
 const sh = require('shelljs');
-const fs = require('fs');
-
-const vjs = 'node_modules/video.js/dist/alt/video.core.js';
-const vjsCss = 'node_modules/video.js/dist/video-js.css';
-const eme = 'node_modules/videojs-contrib-eme/dist/videojs-contrib-eme.js';
 const deployDir = 'deploy';
-const files = [vjs, vjsCss, eme];
+
+const files = [
+  'node_modules/video.js/dist/video-js.css',
+  'node_modules/video.js/dist/alt/video.core.js',
+  'node_modules/videojs-contrib-eme/dist/videojs-contrib-eme.js',
+  'node_modules/videojs-contrib-quality-levels/dist/videojs-contrib-quality-levels.js',
+  'node_modules/d3/d3.min.js'
+];
 
 // cleanup previous deploy
 sh.rm('-rf', deployDir);
@@ -20,5 +22,5 @@ files
 
 // copy over files, dist, and html files
 files
-.concat('dist', 'index.html', 'index.min.html')
+.concat('dist', 'index.html', 'index.min.html', 'utils')
 .forEach((file) => sh.cp('-r', file, path.join(deployDir, file)));

--- a/scripts/netlify.js
+++ b/scripts/netlify.js
@@ -20,7 +20,7 @@ files
 .map((file) => path.dirname(file))
 .forEach((dir) => sh.mkdir('-p', path.join(deployDir, dir)));
 
-// copy over files, dist, and html files
+// copy files/folders to deploy dir
 files
 .concat('dist', 'index.html', 'index.min.html', 'utils')
 .forEach((file) => sh.cp('-r', file, path.join(deployDir, file)));

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -92,6 +92,9 @@ let renditionSelectionMixin = function(hlsHandler) {
 
   // Add a single API-specific function to the HlsHandler instance
   hlsHandler.representations = () => {
+    if (!playlists || !playlists.master || !playlists.master.playlists) {
+      return [];
+    }
     return playlists
       .master
       .playlists

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -737,17 +737,21 @@ class HlsHandler extends Component {
   setupQualityLevels_() {
     let player = videojs.players[this.tech_.options_.playerId];
 
-    if (player && player.qualityLevels) {
-      this.qualityLevels_ = player.qualityLevels();
-
-      this.masterPlaylistController_.on('selectedinitialmedia', () => {
-        handleHlsLoadedMetadata(this.qualityLevels_, this);
-      });
-
-      this.playlists.on('mediachange', () => {
-        handleHlsMediaChange(this.qualityLevels_, this.playlists);
-      });
+    // if there isn't a player or there isn't a qualityLevels plugin
+    // or qualityLevels_ listeners have already been setup, do nothing.
+    if (!player || !player.qualityLevels || this.qualityLevels_) {
+      return;
     }
+
+    this.qualityLevels_ = player.qualityLevels();
+
+    this.masterPlaylistController_.on('selectedinitialmedia', () => {
+      handleHlsLoadedMetadata(this.qualityLevels_, this);
+    });
+
+    this.playlists.on('mediachange', () => {
+      handleHlsMediaChange(this.qualityLevels_, this.playlists);
+    });
   }
 
   /**

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -716,7 +716,7 @@ class HlsHandler extends Component {
       this.tech_.trigger('progress');
     });
 
-    this.tech_.ready(() => this.setupQualityLevels_());
+    this.setupQualityLevels_();
 
     // do nothing if the tech has been disposed already
     // this can occur if someone sets the src in player.ready(), for instance

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -3094,8 +3094,7 @@ QUnit.test('passes useCueTags hls option to master playlist controller', functio
   videojs.options.hls = origHlsOptions;
 });
 
-// TODO: This test fails intermittently. Turn on when fixed to always pass.
-QUnit.skip('populates quality levels list when available', function(assert) {
+QUnit.test('populates quality levels list when available', function(assert) {
   this.player.src({
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -20,7 +20,7 @@
 
   <!-- player stats visualization -->
   <link href="stats.css" rel="stylesheet">
-  <script src="/node_modules/d3/d3.min.js"></script>
+  <script src="../../node_modules/d3/d3.min.js"></script>
 
   <style>
     body {
@@ -347,12 +347,7 @@
 
         player.ready(function() {
           var qualityLevels = player.qualityLevels();
-
-          qualityLevels.on('addqualitylevel', function(event) {
-            createQualityButton(event.qualityLevel, qualityButtons);
-          });
-
-          qualityLevels.on('change', function(event) {
+          var setupLevels = function() {
             for (var i = 0; i < qualityLevels.length; i++) {
               var level = qualityLevels[i];
               var button = document.getElementById('quality-level-' + level.id);
@@ -360,10 +355,17 @@
               button.classList.remove('selected');
             }
 
-            var selected = qualityLevels[event.selectedIndex];
+            var selected = qualityLevels[qualityLevels.selectedIndex];
             var button = document.getElementById('quality-level-' + selected.id);
             button.classList.add('selected');
+          };
+
+          qualityLevels.on('addqualitylevel', function(event) {
+            createQualityButton(event.qualityLevel, qualityButtons);
           });
+
+          qualityLevels.on('change', setupLevels);
+          setupLevels();
         });
       });
     }

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -345,27 +345,23 @@
         videojs.Hls.displayStats(document.querySelector('.switching-stats'), player);
         videojs.Hls.displayCues(document.querySelector('.segment-timeline'), player);
 
-        player.ready(function() {
-          var qualityLevels = player.qualityLevels();
-          var setupLevels = function() {
-            for (var i = 0; i < qualityLevels.length; i++) {
-              var level = qualityLevels[i];
-              var button = document.getElementById('quality-level-' + level.id);
+        var qualityLevels = player.qualityLevels();
 
-              button.classList.remove('selected');
-            }
+        qualityLevels.on('addqualitylevel', function(event) {
+          createQualityButton(event.qualityLevel, qualityButtons);
+        });
 
-            var selected = qualityLevels[qualityLevels.selectedIndex];
-            var button = document.getElementById('quality-level-' + selected.id);
-            button.classList.add('selected');
-          };
+        qualityLevels.on('change', function(event) {
+          for (var i = 0; i < qualityLevels.length; i++) {
+            var level = qualityLevels[i];
+            var button = document.getElementById('quality-level-' + level.id);
 
-          qualityLevels.on('addqualitylevel', function(event) {
-            createQualityButton(event.qualityLevel, qualityButtons);
-          });
+            button.classList.remove('selected');
+          }
 
-          qualityLevels.on('change', setupLevels);
-          setupLevels();
+          var selected = qualityLevels[event.selectedIndex];
+          var button = document.getElementById('quality-level-' + selected.id);
+          button.classList.add('selected');
         });
       });
     }


### PR DESCRIPTION
## Description
Quality levels is not being populated due to a race condition where the tech is not ready until after we have fired `selectedintialmedia`. You can get this to happen by in chrome by loading the tab in the background for 10s or by using a slow browser like ie 11, where it will happen in the main tab.

## Steps to reproduce
1. Open `index.html`
2. Open the link to `Stats` in a new page, and wait 10s before switching to that tab.
3. Note that the `qualityLevels` do not show up on the page, and `player.qualityLevels().levels_` is a 0 length array
4. Note that `player.representations()` has the correct representations in the returned array. 
5. Note that the `qualityLevels` buttons do not show up on the page.

## Specific Changes proposed
1. The first commit deploys the stats page, and fixes a bug with the stats page. That allows this bug to be tested before the fix.  
2. The second commit remove the tech ready wrapper around `this.setupQualityLevels_()`


## Testing
1. Open the [netlify deploy from #708](https://deploy-preview-708--videojs-http-streaming.netlify.com/) and follow the steps to reproduce.
2. Open [netlify deploy for this pull request](https://deploy-preview-707--videojs-http-streaming.netlify.com/) and follow the steps to reproduce, noting that steps 3, 4, and 5 are no longer an issue.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

Closes #708
Fixes #677  
