### PR TITLE
fix: don't try to initialize media keys in ie11, #682 master

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -177,7 +177,8 @@ const setupEmeOptions = (hlsHandler) => {
       player.currentSource().keySystems = sourceOptions;
 
       // works around https://bugs.chromium.org/p/chromium/issues/detail?id=895449
-      if (player.eme.initializeMediaKeys) {
+      // in non-IE11 browsers. In IE11 this is too early to initialize media keys
+      if (!(videojs.browser.IE_VERSION === 11) && player.eme.initializeMediaKeys) {
         player.eme.initializeMediaKeys();
       }
     }


### PR DESCRIPTION
Pulling the change from #682 into the master/tba-lhls work
