### PR TITLE
fix: live startup failures when play happens before playlist is downl…

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -115,7 +115,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // everything, and the MediaSource should not be detached without a proper disposal
 
     this.seekable_ = videojs.createTimeRanges();
-    this.hasPlayed_ = () => false;
+    this.hasPlayed_ = false;
 
     this.syncController_ = new SyncController(options);
     this.segmentMetadataTrack_ = tech.addRemoteTextTrack({
@@ -134,7 +134,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       seekable: () => this.seekable(),
       seeking: () => this.tech_.seeking(),
       duration: () => this.duration(),
-      hasPlayed: () => this.hasPlayed_(),
+      hasPlayed: () => this.hasPlayed_,
       goalBufferLength: () => this.goalBufferLength(),
       bandwidth,
       syncController: this.syncController_,
@@ -575,7 +575,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.seekTo_(0);
     }
 
-    if (this.hasPlayed_()) {
+    if (this.hasPlayed_) {
       this.load();
     }
 
@@ -602,7 +602,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     //     2) the player is paused
     //     3) the first play has already been setup
     // then exit early
-    if (!media || this.tech_.paused() || this.hasPlayed_()) {
+    if (!media || this.tech_.paused() || this.hasPlayed_) {
       return false;
     }
 
@@ -623,7 +623,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
         this.tech_.one('loadedmetadata', () => {
           this.trigger('firstplay');
           this.seekTo_(seekable.end(0));
-          this.hasPlayed_ = () => true;
+          this.hasPlayed_ = true;
         });
 
         return false;
@@ -635,7 +635,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.seekTo_(seekable.end(0));
     }
 
-    this.hasPlayed_ = () => true;
+    this.hasPlayed_ = true;
     // we can begin loading now that everything is ready
     this.load();
     return true;

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -549,7 +549,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     // when we haven't started playing yet, the start of a live playlist
     // is always our zero-time so force a sync update each time the playlist
     // is refreshed from the server
-    if (!this.hasPlayed_()) {
+    //
+    // Use the INIT state to determine if playback has started, as the playlist sync info
+    // should be fixed once requests begin (as sync points are generated based on sync
+    // info), but not before then.
+    if (this.state === 'INIT') {
       newPlaylist.syncInfo = {
         mediaSequence: newPlaylist.mediaSequence,
         time: 0

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1326,5 +1326,72 @@ export const LoaderCommonFactory = ({
         );
       }
     );
+
+    QUnit.test('maintains initial sync info if playlist is changed before playback starts', function(assert) {
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 1,
+        endList: false
+      }));
+
+      assert.deepEqual(
+        loader.playlist_.syncInfo,
+        {
+          mediaSequence: 1,
+          time: 0
+        },
+        'updated sync info to start at media sequence 1 and time 0'
+      );
+
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.deepEqual(
+        loader.playlist_.syncInfo,
+        {
+          mediaSequence: 2,
+          time: 0
+        },
+        'updated sync info to start at media sequence 2 and time 0'
+      );
+
+      loader.load();
+
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.notOk(loader.playlist_.syncInfo, 'did not set sync info on new playlist');
+    });
+
+    QUnit.test('maintains initial sync info if playlist is changed while segment in-flight', function(assert) {
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 1,
+        endList: false
+      }));
+
+      assert.deepEqual(
+        loader.playlist_.syncInfo,
+        {
+          mediaSequence: 1,
+          time: 0
+        },
+        'updated sync info to start at media sequence 1 and time 0'
+      );
+
+      assert.equal(this.requests.length, 0, 'no in-flight requests');
+      loader.load();
+      this.clock.tick(1);
+      assert.equal(this.requests.length, 1, 'one in-flight requests');
+
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.notOk(loader.playlist_.syncInfo, 'did not set sync info on new playlist');
+    });
   });
 };


### PR DESCRIPTION
…oaded (#700 from 1.x)

When joining a live stream, VHS starts playback at a time of 0,
regardless of how long the stream has been playing. This means that the
playlist will start with sync info of time 0 for the first media index.

However, if the stream "played" (either via API, autoplay, etc.) before
a playlist was downloaded, then after the playlist downloaded the
loader would reset the sync info, erasing the assumed time 0 for first
media index, and the player would request segments ad infinitum, never
able to place them in the timeline and get a new sync point.

This separates the notion of played between play initiation and playback
of content (progress on the timeline), in order to ensure that the
initial sync info is maintained.

* Use segment loader's state to determine when to update sync info

While using hasPlayedContent helped to alleviate most issues around
when to update the sync info in segment loader when updating a live
playlist, there still remained potential issues when a segment was
requested and the sync info was changed for the in-flight segment.

This change uses the segment loader's INIT state to determine if the
sync info should be updated, meaning in-flight segment requests keep
their sync info fixed.

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
