### PR TITLE
fix: add native cues when using native text tracks

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -167,7 +167,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     this.subtitleSegmentLoader_ =
       new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
-        loaderType: 'vtt'
+        loaderType: 'vtt',
+        featuresNativeTextTracks: this.tech_.featuresNativeTextTracks
       }), options);
 
     this.setupSegmentLoaderListeners_();

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -34,6 +34,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.subtitlesTrack_ = null;
 
     this.loaderType_ = 'subtitle';
+
+    this.featuresNativeTextTracks_ = settings.featuresNativeTextTracks;
   }
 
   createTransmuxer_() {
@@ -361,7 +363,9 @@ export default class VTTSegmentLoader extends SegmentLoader {
     segmentInfo.cues.forEach((cue) => {
       // remove any overlapping cues to prevent doubling
       this.remove(cue.startTime, cue.endTime);
-      this.subtitlesTrack_.addCue(cue);
+      this.subtitlesTrack_.addCue(this.featuresNativeTextTracks_ ?
+        new window.VTTCue(cue.startTime, cue.endTime, cue.text) :
+        cue);
     });
 
     this.handleAppendsDone_();

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -522,6 +522,50 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
     );
 
     QUnit.test(
+      'adds native VTTCues when featuresNativeTextTracks option is enabled',
+      function(assert) {
+        loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
+          loaderType: 'vtt',
+          featuresNativeTextTracks: true
+        }), {});
+
+        this.track = new MockTextTrack();
+
+        const playlist = playlistWithDuration(20);
+
+        loader.parseVTTCues_ = (segmentInfo) => {
+          segmentInfo.cues = [{ startTime: 0, endTime: 5}, { startTime: 5, endTime: 15}];
+          segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
+        };
+
+        loader.playlist(playlist);
+        loader.track(this.track);
+        loader.load();
+
+        this.clock.tick(1);
+
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+
+        this.clock.tick(1);
+
+        loader.parseVTTCues_ = (segmentInfo) => {
+          segmentInfo.cues = [{ startTime: 5, endTime: 15}, { startTime: 15, endTime: 20}];
+          segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
+        };
+
+        this.clock.tick(1);
+
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+
+        this.clock.tick(1);
+
+        assert.ok(loader.subtitlesTrack_.cues.every(c => c instanceof window.VTTCue), 'added native VTTCues');
+      }
+    );
+
+    QUnit.test(
       'loader does not re-request segments that contain no subtitles',
       function(assert) {
         const playlist = playlistWithDuration(60);


### PR DESCRIPTION
Co-authored-by: Kyle Boutette <kyleveb@gmail.com>

## Description
<!--- Please describe the change as necessary. ---> 
<!--- If it's a feature or enhancement please be as detailed as possible. --->
<!--- If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail. --->
When native text tracks are used, the cues added need to be native cues.

Related to this PR in the player: https://github.com/videojs/video.js/pull/6410

## Specific Changes proposed
Checks to see if native tracks are being used, and if so converts the cue into a native cue.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
