### PR TITLE
fix: resume live DASH playlist refreshes after pausing and loading DASH playlist loader

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -464,7 +464,11 @@ export default class DashPlaylistLoader extends EventTarget {
       return;
     }
 
-    this.trigger('loadedplaylist');
+    if (media && !media.endList) {
+      this.trigger('mediaupdatetimeout');
+    } else {
+      this.trigger('loadedplaylist');
+    }
   }
 
   start() {

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -2241,3 +2241,42 @@ QUnit.test('child loaders wait for async action before moving to HAVE_MASTER', f
   // media playlist is chosen automatically
   assert.strictEqual(childLoader.state, 'HAVE_METADATA');
 });
+
+QUnit.test('load resumes the media update timer for live playlists', function(assert) {
+  const loader = new DashPlaylistLoader('dash-live.mpd', this.fakeHls);
+
+  loader.load();
+  this.standardXHRResponse(this.requests.shift());
+  this.clock.tick(1);
+
+  const origMediaUpdateTimeout = loader.mediaUpdateTimeout;
+
+  assert.ok(origMediaUpdateTimeout, 'media update timeout set');
+
+  loader.pause();
+  loader.load();
+
+  const newMediaUpdateTimeout = loader.mediaUpdateTimeout;
+
+  assert.ok(newMediaUpdateTimeout, 'media update timeout set');
+  assert.notEqual(
+    origMediaUpdateTimeout,
+    newMediaUpdateTimeout,
+    'media update timeout is different'
+  );
+});
+
+QUnit.test('load does not resume the media update timer for non live playlists', function(assert) {
+  const loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
+
+  loader.load();
+  this.standardXHRResponse(this.requests.shift());
+  this.clock.tick(1);
+
+  assert.notOk(loader.mediaUpdateTimeout, 'media update timeout not set');
+
+  loader.pause();
+  loader.load();
+
+  assert.notOk(loader.mediaUpdateTimeout, 'media update timeout not set');
+});


### PR DESCRIPTION
This particular issue was noticed when rendition switches while playing
live DASH resulted in the audio buffer no longer filling, and the content
stopping playback after finishing the currently buffered media.

In the code, the media groups module paused the audio playlist loader, which
cleared its refresh timeout, but on calling load to resume the loader, the
refresh timeout was not set, as it is in the normal playlist loader. The
added logic matches the normal playlist loader's load function.

Copy of https://github.com/videojs/http-streaming/pull/736 for master