### PR TITLE
fix: live captions don't show up in consistent manner

### DIFF
--- a/docs/sync-controller.md
+++ b/docs/sync-controller.md
@@ -1,0 +1,114 @@
+# Sync Controller
+
+## Purpose
+
+The [SyncController][sc] (SC) is responsible for maintaining synchronization across different Segment Loaders. The [SC] is shared by Main(Video)/Audio [Segment Loader][sl] and [VTT Segment Loader][vttsl] to take segment loading decisions based on the state of the [SC].
+
+## Properties
+
+1. `timelines[x]` refers to the media-time for the first segment loaded with timeline x.
+2. `discontinuities[x]` refers to the time and accuracy(based on segment number), for the discontinuity segment number x, in the media playlist.
+3. `lastBufferedSegmentTimestamp` refers to the timestamp information for the last segment loaded by the segment loader.
+
+## Other useful information
+For LIVE/VOD workflows, the discontinuity information (segment with discontinuity) might not be consistent across media-playlists(audio/video/vtt). So, for segment loading decisions, we're leveraging `lastBufferedSegmentTimestamp`.
+for example: 
+
+####Manifest(video,format=m3u8-aapl)
+```
+#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:17
+#EXT-X-PROGRAM-DATE-TIME:2020-02-12T09:52:26Z
+#EXTINF:16.666000,no-desc
+Fragments(video=0,format=m3u8-aapl)
+#EXTINF:16.666000,no-desc
+Fragments(video=1499940,format=m3u8-aapl)
+#EXTINF:16.667000,no-desc
+Fragments(video=2999880,format=m3u8-aapl)
+#EXTINF:16.667000,no-desc
+Fragments(video=4499910,format=m3u8-aapl)
+#EXTINF:16.666000,no-desc
+Fragments(video=5999940,format=m3u8-aapl)
+#EXTINF:14.300000,no-desc
+Fragments(video=7499880,format=m3u8-aapl)
+``` 
+
+####Manifest(audio_und,format=m3u8-aapl)
+```
+#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:17
+#EXT-X-PROGRAM-DATE-TIME:2020-02-12T09:52:26Z
+#EXTINF:16.624989,no-desc
+Fragments(audio_und=2911,format=m3u8-aapl)
+#EXTINF:16.671926,no-desc
+Fragments(audio_und=736073,format=m3u8-aapl)
+#EXTINF:16.671926,no-desc
+Fragments(audio_und=1471305,format=m3u8-aapl)
+#EXTINF:16.671926,no-desc
+Fragments(audio_und=2206537,format=m3u8-aapl)
+#EXTINF:16.625488,no-desc
+Fragments(audio_und=2941769,format=m3u8-aapl)
+#EXTINF:14.326712,no-desc
+Fragments(audio_und=3674953,format=m3u8-aapl)
+```
+
+####Manifest(textstream_und,format=m3u8-aapl)
+```
+#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-PROGRAM-DATE-TIME:2020-02-12T09:52:26Z
+#EXTINF:2.944000,no-desc
+Fragments(textstream_und=16896,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=64000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=128000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=192000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=256000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=320000,format=m3u8-aapl)
+#EXT-X-PROGRAM-DATE-TIME:2020-02-12T09:53:32.944Z
+#EXT-X-DISCONTINUITY
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1088000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1152000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1216000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1280000,format=m3u8-aapl)
+#EXT-X-PROGRAM-DATE-TIME:2020-02-12T09:53:52.944Z
+#EXT-X-DISCONTINUITY
+#EXTINF:2.000000,no-desc
+Fragments(textstream_und=1408000,format=m3u8-aapl)
+#EXT-X-PROGRAM-DATE-TIME:2020-02-12T09:53:58.944Z
+#EXT-X-DISCONTINUITY
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1504000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1568000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1632000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1696000,format=m3u8-aapl)
+#EXTINF:4.000000,no-desc
+Fragments(textstream_und=1760000,format=m3u8-aapl)
+```
+
+
+[sc]: ../src/sync-controller.js
+[pl]: ../src/playlist-loader.js
+[sl]: ../src/segment-loader.js
+[vttsl]: ../src/vtt-segment-loader.js
+[vhs]: intro.md

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -161,6 +161,7 @@ export default class SyncController extends videojs.EventTarget {
     // ...for synching across variants
     this.timelines = [];
     this.discontinuities = [];
+    this.lastBufferedSegmentTimestamp = 0;
     this.datetimeToDisplayTime = null;
 
     this.logger_ = logger('SyncController');
@@ -382,11 +383,12 @@ export default class SyncController extends videojs.EventTarget {
     }
   }
 
-  timestampOffsetForTimeline(timeline) {
-    if (typeof this.timelines[timeline] === 'undefined') {
+  timestampOffsetForSegment(segmentInfo) {
+    if (segmentInfo.timeline > 0 &&
+      (!segmentInfo.startOfSegment || segmentInfo.startOfSegment > this.lastBufferedSegmentTimestamp)) {
       return null;
     }
-    return this.timelines[timeline].time;
+    return this.lastBufferedSegmentTimestamp;
   }
 
   mappingForTimeline(timeline) {
@@ -418,6 +420,7 @@ export default class SyncController extends videojs.EventTarget {
         mapping: segmentInfo.startOfSegment - timingInfo.start
       };
       this.timelines[segmentInfo.timeline] = mappingObj;
+      this.lastBufferedSegmentTimestamp = Math.max(segmentInfo.startOfSegment, this.lastBufferedSegmentTimestamp);
       this.trigger('timestampoffset');
 
       this.logger_(`time mapping for timeline ${segmentInfo.timeline}: ` +
@@ -428,6 +431,8 @@ export default class SyncController extends videojs.EventTarget {
     } else if (mappingObj) {
       segment.start = timingInfo.start + mappingObj.mapping;
       segment.end = timingInfo.end + mappingObj.mapping;
+      this.lastBufferedSegmentTimestamp = Math.max(segmentInfo.startOfSegment, this.lastBufferedSegmentTimestamp);
+      this.trigger('lastbufferedsegmentupdate');
     } else {
       return false;
     }

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -384,8 +384,9 @@ export default class SyncController extends videojs.EventTarget {
   }
 
   timestampOffsetForSegment(segmentInfo) {
-    if (segmentInfo.timeline > 0 &&
-      (!segmentInfo.startOfSegment || segmentInfo.startOfSegment > this.lastBufferedSegmentTimestamp)) {
+    const segmentOccursAfterLastBufferedSegment = (!segmentInfo.startOfSegment || segmentInfo.startOfSegment > this.lastBufferedSegmentTimestamp);
+
+    if (segmentInfo.timeline > 0 && segmentOccursAfterLastBufferedSegment) {
       return null;
     }
     return this.lastBufferedSegmentTimestamp;

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -192,7 +192,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
       return;
     }
 
-    if (this.syncController_.timestampOffsetForTimeline(segmentInfo.timeline) === null) {
+    if (this.syncController_.timestampOffsetForSegment(segmentInfo) === null) {
       // We don't have the timestamp offset that we need to sync subtitles.
       // Rerun on a timestamp offset or user interaction.
       const checkTimestampOffset = () => {
@@ -204,6 +204,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
       };
 
       this.syncController_.one('timestampoffset', checkTimestampOffset);
+      this.syncController_.one('lastbufferedsegmentupdate', checkTimestampOffset);
       this.state = 'WAITING_ON_TIMELINE';
       return;
     }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2975,7 +2975,7 @@ QUnit.test('switches off subtitles on subtitle errors', function(assert) {
   const syncController = masterPlaylistController.subtitleSegmentLoader_.syncController_;
 
   // required for the vtt request to be made
-  syncController.timestampOffsetForTimeline = () => 0;
+  syncController.timestampOffsetForSegment = () => 0;
 
   this.clock.tick(1);
 

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -292,6 +292,7 @@ QUnit.test('saves segment timing info', function(assert) {
     syncCon.timelines[0], { time: 0, mapping: -5 },
     'mapping object correct'
   );
+  assert.equal(syncCon.lastBufferedSegmentTimestamp, 0, 'correctly calculated lastBufferedSegmentTimestamp');
   assert.equal(segment.start, 0, 'correctly calculated segment start');
   assert.equal(segment.end, 10, 'correctly calculated segment end');
   assert.ok(syncCon.discontinuities[1], 'created discontinuity info for timeline 1');
@@ -308,6 +309,7 @@ QUnit.test('saves segment timing info', function(assert) {
 
   updateTimingInfo(segmentInfo);
   syncCon.saveSegmentTimingInfo(segmentInfo);
+  assert.equal(syncCon.lastBufferedSegmentTimestamp, 10, 'correctly calculated lastBufferedSegmentTimestamp');
   assert.equal(segment.start, 10, 'correctly calculated segment start');
   assert.equal(segment.end, 20, 'correctly calculated segment end');
   assert.deepEqual(
@@ -329,6 +331,7 @@ QUnit.test('saves segment timing info', function(assert) {
     syncCon.timelines[1], { time: 30, mapping: -11 },
     'mapping object correct'
   );
+  assert.equal(syncCon.lastBufferedSegmentTimestamp, 30, 'correctly calculated lastBufferedSegmentTimestamp');
   assert.equal(segment.start, 30, 'correctly calculated segment start');
   assert.equal(segment.end, 40, 'correctly calculated segment end');
   assert.deepEqual(

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -266,7 +266,7 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
         loadedSegment = true;
       };
       loader.checkBuffer_ = () => {
-        return { mediaIndex: 2, timeline: 2, segment: { } };
+        return { mediaIndex: 2, timeline: 2, startOfSegment: 10, segment: { } };
       };
 
       loader.playlist(playlist);
@@ -287,6 +287,7 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
 
       // simulate the main segment loader finding timeline info for the new timeline
       loader.syncController_.timelines[2] = { time: 20, mapping: -10 };
+      loader.syncController_.lastBufferedSegmentTimestamp = 20;
       loader.syncController_.trigger('timestampoffset');
 
       assert.equal(


### PR DESCRIPTION
## Description
This is a fix for live captions, i.e. during LIVE streaming, subtitles used to show up in an inconsistent fashion. 
If there's any "DISCONTINUITY" tag in the subtitle playlist, and if the discontinuities for subtitle playlist are not synchronized/aligned with the audio, video playlists then we observe that the subtitles either don't show up at all, or stop showing after some time. This PR addreses the same issue
Linked issues: https://github.com/videojs/video.js/issues/6353

## Specific Changes proposed
For LIVE/VOD workflows, the discontinuity information (segment with discontinuity) might not be consistent across media-playlists(audio/video/vtt). So, for segment loading decisions, we're leveraging "lastBufferedSegmentTimestamp". Based on the start-time of the segment last buffered by audio/video segment loaders, vtt-segment-loader decides whether to loading future segments or not, after comparing start-time values.
