### PR TITLE
Take devicePixelRatio into account

### DIFF
--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -121,9 +121,9 @@ export const comparePlaylistResolution = function(left, right) {
  * @param {number} playerBandwidth
  *        Current calculated bandwidth of the player
  * @param {number} playerWidth
- *        Current width of the player element
+ *        Current width of the player element (should account for the device pixel ratio)
  * @param {number} playerHeight
- *        Current height of the player element
+ *        Current height of the player element (should account for the device pixel ratio)
  * @param {boolean} limitRenditionByPlayerDimensions
  *        True if the player width and height should be used during the selection, false otherwise
  * @return {Playlist} the highest bitrate playlist less than the

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -252,11 +252,12 @@ export const simpleSelector = function(
  * bandwidth variance
  */
 export const lastBandwidthSelector = function() {
+  let pixelRatio = window.devicePixelRatio || 1;
   return simpleSelector(
     this.playlists.master,
     this.systemBandwidth,
-    parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10),
-    parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10),
+    parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10) * pixelRatio,
+    parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10) * pixelRatio,
     this.limitRenditionByPlayerDimensions
   );
 };
@@ -288,11 +289,12 @@ export const movingAverageBandwidthSelector = function(decay) {
     }
 
     average = decay * this.systemBandwidth + (1 - decay) * average;
+    let pixelRatio = window.devicePixelRatio || 1;
     return simpleSelector(
       this.playlists.master,
       average,
-      parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10),
-      parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10),
+      parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10) * pixelRatio,
+      parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10) * pixelRatio,
       this.limitRenditionByPlayerDimensions
     );
   };

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -252,7 +252,8 @@ export const simpleSelector = function(
  * bandwidth variance
  */
 export const lastBandwidthSelector = function() {
-  let pixelRatio = window.devicePixelRatio || 1;
+  const pixelRatio = window.devicePixelRatio || 1;
+
   return simpleSelector(
     this.playlists.master,
     this.systemBandwidth,
@@ -278,6 +279,7 @@ export const lastBandwidthSelector = function() {
  */
 export const movingAverageBandwidthSelector = function(decay) {
   let average = -1;
+  const pixelRatio = window.devicePixelRatio || 1;
 
   if (decay < 0 || decay > 1) {
     throw new Error('Moving average bandwidth decay must be between 0 and 1.');
@@ -289,7 +291,6 @@ export const movingAverageBandwidthSelector = function(decay) {
     }
 
     average = decay * this.systemBandwidth + (1 - decay) * average;
-    let pixelRatio = window.devicePixelRatio || 1;
     return simpleSelector(
       this.playlists.master,
       average,


### PR DESCRIPTION
## Description
Currently player dimensions is not determined correctly and cause lower quality playlist to be played.
This fix calculate real player dimensions on devices that have devicePixelRatio greater than 1 (retina displays and most mobile devices).


## Specific Changes proposed
multiply player width and height by devicePixelRatio .

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
