### PR TITLE
fix: only reset syncController if we passed a discontinuity

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -111,6 +111,46 @@ const segmentInfoString = (segmentInfo) => {
 const timingInfoPropertyForMedia = (mediaType) => `${mediaType}TimingInfo`;
 
 /**
+ * Returns the timestamp offset to use for the segment.
+ *
+ * @param {number} segmentTimeline
+ *        The timeline of the segment
+ * @param {number} currentTimeline
+ *        The timeline currently being followed by the loader
+ * @param {number} startOfSegment
+ *        The estimated segment start
+ * @param {TimeRange[]} buffered
+ *        The loader's buffer
+ *
+ * @return {number|null}
+ *         Either a number representing a new timestamp offset, or null if the segment is
+ *         part of the same timeline
+ */
+export const timestampOffsetForSegment = ({
+  segmentTimeline,
+  currentTimeline,
+  startOfSegment,
+  buffered
+}) => {
+  // Check to see if we are crossing a discontinuity to see if we need to set the
+  // timestamp offset on the transmuxer and source buffer.
+  //
+  // Previously, we changed the timestampOffset if the start of this segment was less than
+  // the currently set timestampOffset, but this isn't desirable as it can produce bad
+  // behavior, especially around long running live streams.
+  if (segmentTimeline === currentTimeline) {
+    return null;
+  }
+
+  // segmentInfo.startOfSegment used to be used as the timestamp offset, however, that
+  // value uses the end of the last segment if it is available. While this value
+  // should often be correct, it's better to rely on the buffered end, as the new
+  // content post discontinuity should line up with the buffered end as if it were
+  // time 0 for the new content.
+  return buffered.length ? buffered.end(buffered.length - 1) : startOfSegment;
+};
+
+/**
  * An object that manages segment loading and appending.
  *
  * @class SegmentLoader
@@ -842,41 +882,14 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    // check to see if we are crossing a discontinuity or requesting a segment that starts
-    // earlier than the last set timestamp offset to see if we need to set the timestamp
-    // offset on the transmuxer and source buffer
-    if (segmentInfo.timeline !== this.currentTimeline_ ||
-        this.startsBeforeSourceBufferTimestampOffset(segmentInfo)) {
-      // segmentInfo.startOfSegment used to be used as the timestamp offset, however, that
-      // value uses the end of the last segment if it is available. While this value
-      // should often be correct, it's better to rely on the buffered end, as the new
-      // content post discontinuity should line up with the buffered end as if it were
-      // time 0 for the new content.
-      segmentInfo.timestampOffset =
-        buffered.length ? buffered.end(buffered.length - 1) : segmentInfo.startOfSegment;
-      if (this.captionParser_) {
-        this.captionParser_.clearAllCaptions();
-      }
-    }
+    segmentInfo.timestampOffset = timestampOffsetForSegment({
+      segmentTimeline: segmentInfo.timeline,
+      currentTimeline: this.currentTimeline_,
+      startOfSegment: segmentInfo.startOfSegment,
+      buffered
+    });
 
     this.loadSegment_(segmentInfo);
-  }
-
-  startsBeforeSourceBufferTimestampOffset(segmentInfo) {
-    if (segmentInfo.startOfSegment === null) {
-      return false;
-    }
-
-    if (this.loaderType_ === 'main' &&
-        segmentInfo.startOfSegment < this.sourceUpdater_.videoTimestampOffset()) {
-      return true;
-    }
-
-    if (this.audioDisabled_) {
-      return false;
-    }
-
-    return segmentInfo.startOfSegment < this.sourceUpdater_.audioTimestampOffset();
   }
 
   /**
@@ -1644,6 +1657,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.state = 'WAITING';
     this.pendingSegment_ = segmentInfo;
     this.trimBackBuffer_(segmentInfo);
+
+    if (typeof segmentInfo.timestampOffset === 'number') {
+      if (this.captionParser_) {
+        this.captionParser_.clearAllCaptions();
+      }
+    }
 
     // We'll update the source buffer's timestamp offset once we have transmuxed data, but
     // the transmuxer still needs to be updated before then.

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -2,7 +2,8 @@ import QUnit from 'qunit';
 import {
   default as SegmentLoader,
   illegalMediaSwitch,
-  safeBackBufferTrimTime
+  safeBackBufferTrimTime,
+  timestampOffsetForSegment
 } from '../src/segment-loader';
 import segmentTransmuxer from '../src/segment-transmuxer';
 import videojs from 'video.js';
@@ -146,6 +147,56 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
                ' To get rid of this message, please add codec information to the' +
                ' manifest.',
     'error when video only to audio only'
+  );
+});
+
+QUnit.module('timestampOffsetForSegment');
+
+QUnit.test('returns startOfSegment when timeline changes and the buffer is empty', function(assert) {
+  assert.equal(
+    timestampOffsetForSegment({
+      segmentTimeline: 1,
+      currentTimeline: 0,
+      startOfSegment: 3,
+      buffered: videojs.createTimeRanges()
+    }),
+    3,
+    'returned startOfSegment'
+  );
+});
+
+QUnit.test('returns buffered end when timeline changes and there exists buffered content', function(assert) {
+  assert.equal(
+    timestampOffsetForSegment({
+      segmentTimeline: 1,
+      currentTimeline: 0,
+      startOfSegment: 3,
+      buffered: videojs.createTimeRanges([[1, 5], [7, 8]])
+    }),
+    8,
+    'returned buffered end'
+  );
+});
+
+QUnit.test('returns null when timeline does not change', function(assert) {
+  assert.ok(
+    timestampOffsetForSegment({
+      segmentTimeline: 0,
+      currentTimeline: 0,
+      startOfSegment: 3,
+      buffered: videojs.createTimeRanges([[1, 5], [7, 8]])
+    }) === null,
+    'returned null'
+  );
+
+  assert.ok(
+    timestampOffsetForSegment({
+      segmentTimeline: 1,
+      currentTimeline: 1,
+      startOfSegment: 3,
+      buffered: videojs.createTimeRanges([[1, 5], [7, 8]])
+    }) === null,
+    'returned null'
   );
 });
 


### PR DESCRIPTION
See https://github.com/videojs/http-streaming/pull/502

Added some modifications to make testing easier and better organize the code, but let me know if you disagree with those changes.