### PR TITLE
fix(segment-loader): resetEverything should remove through Infinity

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -775,7 +775,9 @@ export default class SegmentLoader extends videojs.EventTarget {
    * operation is complete
    */
   remove(start, end, done = () => {}) {
-    // clamp end to duration if we need to remove everything
+    // clamp end to duration if we need to remove everything.
+    // This is due to a browser bug that causes issues if we remove to Infinity.
+    // videojs/videojs-contrib-hls#1225
     if (end === Infinity) {
       end = this.duration_();
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -721,7 +721,11 @@ export default class SegmentLoader extends videojs.EventTarget {
       video: true
     };
     this.resetLoader();
-    this.remove(0, this.duration_(), done);
+
+    // remove from 0, the earliest point, to Infinity, to signify removal of everything.
+    // VTT Segment Loader doesn't need to do anything but in the regular SegmentLoader,
+    // we then clamp the value to duration if necessary.
+    this.remove(0, Infinity, done);
 
     // clears fmp4 captions
     if (this.captionParser_) {
@@ -771,6 +775,11 @@ export default class SegmentLoader extends videojs.EventTarget {
    * operation is complete
    */
   remove(start, end, done = () => {}) {
+    // clamp end to duration if we need to remove everything
+    if (end === Infinity) {
+      end = this.duration_();
+    }
+
     if (!this.sourceUpdater_ || !this.startingMedia_) {
       // nothing to remove if we haven't processed any media
       return;

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -154,6 +154,20 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @param {number} end - the end time of the region to remove from the buffer
    */
   remove(start, end) {
+    // If we only have "one" segment we likely have the all the captions in a single file,
+    // which is a common configuration for DASH and a possible one for HLS.
+    // It's possible that we have cues that end after the video duration, therefore,
+    // when removing from beginning to duration_(), we want to remove *all* the cues,
+    // and not just those through duration_().
+    // If we won't remove all the cues, checkBuffer_ will assume we're all set and we won't
+    // fill the buffer again with the missing cues.
+    if (this.playlist_ && this.playlist_.endList === true) {
+      const lastCue = this.subtitlesTrack_.cues[this.subtitlesTrack_.cues.length - 1];
+
+      if (end === this.duration_() && lastCue && lastCue.endTime > end) {
+        end = lastCue.endTime;
+      }
+    }
     removeCuesFromTrack(start, end, this.subtitlesTrack_);
   }
 

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -154,14 +154,18 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @param {number} end - the end time of the region to remove from the buffer
    */
   remove(start, end) {
-    // if we only have "one" segment we likely have the entire caption file in a single
-    // and in that case we shouldn't remove cues because they won't get re-added later on.
-    // Also, if we're live, we probably want to remove them still as more segments could be added.
-    if (this.playlist_ &&
-      this.playlist_.endList &&
-      this.playlist_.segments &&
-      this.playlist_.segments.length === 1) {
-      return;
+    // if we only have "one" segment we likely have the entire caption file in a single.
+    // It's possible that we have cues that end after the video duration, therefore,
+    // when removing from beginning to duration_(), we want to remove *all* the cues,
+    // and not just those through duration_().
+    // If we won't remove all the cues, checkBuffer_ will assume we're all set and we won't
+    // fill the buffer again with the missing cues.
+    if (this.playlist_ && this.playlist_.endList === true) {
+      const lastCue = this.subtitlesTrack_.cues[this.subtitlesTrack_.cues.length - 1];
+
+      if (end === this.duration_() && lastCue) {
+        end = lastCue.endTime;
+      }
     }
     removeCuesFromTrack(start, end, this.subtitlesTrack_);
   }

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -154,7 +154,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @param {number} end - the end time of the region to remove from the buffer
    */
   remove(start, end) {
-    // if we only have "one" segment we likely have the entire caption file in a single.
+    // If we only have "one" segment we likely have the all the captions in a single file,
+    // which is a common configuration for DASH and a possible one for HLS.
     // It's possible that we have cues that end after the video duration, therefore,
     // when removing from beginning to duration_(), we want to remove *all* the cues,
     // and not just those through duration_().
@@ -163,7 +164,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
     if (this.playlist_ && this.playlist_.endList === true) {
       const lastCue = this.subtitlesTrack_.cues[this.subtitlesTrack_.cues.length - 1];
 
-      if (end === this.duration_() && lastCue) {
+      if (end === this.duration_() && lastCue && lastCue.endTime > end) {
         end = lastCue.endTime;
       }
     }

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -154,6 +154,15 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @param {number} end - the end time of the region to remove from the buffer
    */
   remove(start, end) {
+    // if we only have "one" segment we likely have the entire caption file in a single
+    // and in that case we shouldn't remove cues because they won't get re-added later on.
+    // Also, if we're live, we probably want to remove them still as more segments could be added.
+    if (this.playlist_ &&
+      this.playlist_.endList &&
+      this.playlist_.segments &&
+      this.playlist_.segments.length === 1) {
+      return;
+    }
     removeCuesFromTrack(start, end, this.subtitlesTrack_);
   }
 

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -154,20 +154,6 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @param {number} end - the end time of the region to remove from the buffer
    */
   remove(start, end) {
-    // If we only have "one" segment we likely have the all the captions in a single file,
-    // which is a common configuration for DASH and a possible one for HLS.
-    // It's possible that we have cues that end after the video duration, therefore,
-    // when removing from beginning to duration_(), we want to remove *all* the cues,
-    // and not just those through duration_().
-    // If we won't remove all the cues, checkBuffer_ will assume we're all set and we won't
-    // fill the buffer again with the missing cues.
-    if (this.playlist_ && this.playlist_.endList === true) {
-      const lastCue = this.subtitlesTrack_.cues[this.subtitlesTrack_.cues.length - 1];
-
-      if (end === this.duration_() && lastCue && lastCue.endTime > end) {
-        end = lastCue.endTime;
-      }
-    }
     removeCuesFromTrack(start, end, this.subtitlesTrack_);
   }
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -501,13 +501,23 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
   };
 
   const origResetEverything = segmentLoader.resetEverything;
+  const origRemove = segmentLoader.remove;
 
   segmentLoader.resetEverything = () => {
     resets++;
     origResetEverything.call(segmentLoader);
   };
 
-  segmentLoader.remove = function(start, end) {
+  segmentLoader.remove = (start, end) => {
+    assert.equal(end, Infinity, 'on a remove all, end should be Infinity');
+
+    origRemove.call(segmentLoader, start, end);
+  };
+
+  segmentLoader.startingMedia_ = { hasVideo: true };
+  segmentLoader.audioDisabled_ = true;
+
+  segmentLoader.sourceUpdater_.removeVideo = function(start, end) {
     removeFuncArgs = {
       start,
       end


### PR DESCRIPTION
In DASH it's very common to provide the captions as one file rather than
having it be segmented VTT. It's possible to do the same in HLS, though,
it isn't common.

When we switch between tracks, we remove all the cues for the
duration of the video because the cues are no longer needed. Also, as we
re-download segments, the associated cues should be re-added.
Unfortunately, this the case of a single "segment", we don't get more
segments and the cues don't get re-added. Therefore, for non-live when
we have one segment, we shouldn't remove the cues.

This fixes the case both for turning the track on and off but also for
seeking.