### PR TITLE
chore: improvements to demo page options

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,13 @@
     label {
       display: block;
       width: 700px;
+      width: fit-content;
       margin-top: 4px;
+    }
+    .options label {
+      background-color: hsl(0, 0%, 90%);
+      padding: 0.25em;
+      margin: 0.25em;
     }
     input[type=url], select {
       min-width: 600px;
@@ -35,30 +41,32 @@
   </div>
   <h3>Options</h3>
 
-  <label>
-    <input id=minified type="checkbox">
-    Minified VHS (reloads player)
-  </label>
-  <label>
-    <input id=liveui type="checkbox">
-    Enable the live UI (reloads player)
-  </label>
-  <label>
-    <input id=debug type="checkbox">
-    Debug Logging
-  </label>
-  <label>
-    <input id=muted type="checkbox">
-    Muted
-  </label>
-  <label>
-    <input id=autoplay type="checkbox">
-    Autoplay
-  </label>
-  <label>
-    <input id=partial type="checkbox">
-    Handle Partial (reloads player)
-  </label>
+  <div class="options">
+    <label>
+      <input id=minified type="checkbox">
+      Minified VHS (reloads player)
+    </label>
+    <label>
+      <input id=liveui type="checkbox">
+      Enable the live UI (reloads player)
+    </label>
+    <label>
+      <input id=debug type="checkbox">
+      Debug Logging
+    </label>
+    <label>
+      <input id=muted type="checkbox">
+      Muted
+    </label>
+    <label>
+      <input id=autoplay type="checkbox">
+      Autoplay
+    </label>
+    <label>
+      <input id=partial type="checkbox">
+      Handle Partial (reloads player)
+    </label>
+  </div>
 
   <h3>Load a URL</h3>
   <label>Url:</label>


### PR DESCRIPTION
before:
![Screen Shot 2020-03-09 at 16 55 42](https://user-images.githubusercontent.com/535884/76256752-d9c3f980-6226-11ea-8d24-dee14ef8ab4f.png)

after:
![Screen Shot 2020-03-09 at 16 54 55](https://user-images.githubusercontent.com/535884/76256767-ddf01700-6226-11ea-9b0f-a9e3b176a766.png)


Also, it reduces the width of the label to the grey area so that the entire line isn't the target and you don't accidentally reload the player when clicking randomly on the page.