### PR TITLE
fix(segment-loader): resetEverything should remove through Infinity

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -628,7 +628,12 @@ export default class SegmentLoader extends videojs.EventTarget {
   resetEverything(done) {
     this.ended_ = false;
     this.resetLoader();
-    this.remove(0, this.duration_(), done);
+
+    // remove from 0, the earliest point, to Infinity, to signify removal of everything.
+    // VTT Segment Loader doesn't need to do anything but in the regular SegmentLoader,
+    // we then clamp the value to duration if necessary.
+    this.remove(0, Infinity, done);
+
     // clears fmp4 captions
     if (this.captionParser_) {
       this.captionParser_.clearAllCaptions();
@@ -665,6 +670,13 @@ export default class SegmentLoader extends videojs.EventTarget {
    * operation is complete
    */
   remove(start, end, done) {
+    // clamp end to duration if we need to remove everything.
+    // This is due to a browser bug that causes issues if we remove to Infinity.
+    // videojs/videojs-contrib-hls#1225
+    if (end === Infinity) {
+      end = this.duration_();
+    }
+
     if (this.sourceUpdater_) {
       this.sourceUpdater_.remove(start, end, done);
     }

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -415,6 +415,75 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
       this.env.log.warn.callCount = 0;
     });
 
+    QUnit.test(
+      'remove() removes all cues if duration_() === end and we have cues beyond duration',
+      function(assert) {
+        loader.dispose();
+
+        loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
+          duration() {
+            return 10;
+          },
+          loaderType: 'vtt'
+        }), {});
+
+        const playlist = playlistWithDuration(10);
+
+        window.WebVTT = oldVTT;
+
+        loader.playlist(playlist);
+        loader.track(this.track);
+        loader.load();
+
+        this.clock.tick(1);
+
+        const vttString = `
+          WEBVTT
+          X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:0
+
+          00:00:03.000 --> 00:00:05.000
+          first cue
+
+          00:00:05.000 --> 00:00:06.000
+          second cue
+
+          00:00:07.000 --> 00:00:10.000
+          third cue
+
+          00:00:11.000 --> 00:00:15.000
+          fourth cue
+
+          00:00:16.000 --> 00:00:20.000
+          fifth cue
+        `;
+
+        // state WAITING for segment response
+        this.requests[0].responseType = 'arraybuffer';
+        this.requests[0].response =
+          new Uint8Array(vttString.trim().split('').map(char => char.charCodeAt(0))).buffer;
+        this.requests.shift().respond(
+          200,
+          null,
+          ''
+        );
+
+        this.clock.tick(1);
+
+        assert.equal(
+          loader.subtitlesTrack_.cues.length,
+          5,
+          'appended 5 cues'
+        );
+
+        loader.resetEverything();
+        assert.equal(
+          loader.subtitlesTrack_.cues.length,
+          0,
+          'all 5 cues have been removed'
+        );
+      }
+    );
+
     QUnit.test('Cues that overlap segment boundaries',
     function(assert) {
       let playlist = playlistWithDuration(20);


### PR DESCRIPTION
In DASH it's very common to provide the captions as one file rather than
having it be segmented VTT. It's possible to do the same in HLS, though,
it isn't common.

When we switch between tracks, we remove all the cues for the
duration of the video because the cues are no longer needed. Also, as we
re-download segments, the associated cues should be re-added.
Unfortunately, this the case of a single "segment", we don't get more
segments and the cues don't get re-added. Therefore, for non-live when
we have one segment, we shouldn't remove the cues.

This fixes the case both for turning the track on and off but also for
seeking.

The fix here is to update resetEverything to call remove from `0` to `Infinity`. We then need to clamp the `end` value in the SegmentLoader due to issues in some older browsers.

Backported from #754.