### PR TITLE
fix: add native cues when using native text tracks

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -171,7 +171,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     this.subtitleSegmentLoader_ =
       new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
-        loaderType: 'vtt'
+        loaderType: 'vtt',
+        featuresNativeTextTracks: this.tech_.featuresNativeTextTracks
       }), options);
 
     this.setupSegmentLoaderListeners_();

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -34,6 +34,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.subtitlesTrack_ = null;
 
     this.loaderType_ = 'subtitle';
+
+    this.featuresNativeTextTracks_ = settings.featuresNativeTextTracks;
   }
 
   createTransmuxer_() {
@@ -361,7 +363,9 @@ export default class VTTSegmentLoader extends SegmentLoader {
     segmentInfo.cues.forEach((cue) => {
       // remove any overlapping cues to prevent doubling
       this.remove(cue.startTime, cue.endTime);
-      this.subtitlesTrack_.addCue(cue);
+      this.subtitlesTrack_.addCue(this.featuresNativeTextTracks_ ?
+        new window.VTTCue(cue.startTime, cue.endTime, cue.text) :
+        cue);
     });
 
     this.handleAppendsDone_();

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -627,8 +627,8 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
 
         this.clock.tick(1);
 
-        this.requests[0].response = new Uint8Array(10).buffer;
-        this.requests.shift().respond(200, null, '');
+        this.requests[0].responseType = 'arraybuffer';
+        this.requests.shift().respond(200, null, new Uint8Array(10).buffer);
 
         this.clock.tick(1);
 
@@ -639,8 +639,8 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
 
         this.clock.tick(1);
 
-        this.requests[0].response = new Uint8Array(10).buffer;
-        this.requests.shift().respond(200, null, '');
+        this.requests[0].responseType = 'arraybuffer';
+        this.requests.shift().respond(200, null, new Uint8Array(10).buffer);
 
         this.clock.tick(1);
 


### PR DESCRIPTION
This is a fixed up and rebased version of #719.
It technically requires a Video.js change as well (https://github.com/videojs/video.js/pull/6410) for the full feature to function but each PR can be merged separately.

Once this is  approved, I'll merge this manually to maintain authorship.