### PR TITLE
fix: add native cues when using native text tracks

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -151,7 +151,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     this.subtitleSegmentLoader_ =
       new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
-        loaderType: 'vtt'
+        loaderType: 'vtt',
+        featuresNativeTextTracks: this.tech_.featuresNativeTextTracks
       }), options);
 
     this.setupSegmentLoaderListeners_();

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -27,7 +27,10 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.mediaSource_ = null;
 
     this.subtitlesTrack_ = null;
+
+    this.featuresNativeTextTracks_ = settings.featuresNativeTextTracks;
   }
+
 
   /**
    * Indicates which time ranges are buffered
@@ -294,7 +297,9 @@ export default class VTTSegmentLoader extends SegmentLoader {
     }
 
     segmentInfo.cues.forEach((cue) => {
-      this.subtitlesTrack_.addCue(cue);
+      this.subtitlesTrack_.addCue(this.featuresNativeTextTracks_ ?
+        new window.VTTCue(cue.startTime, cue.endTime, cue.text) :
+        cue);
     });
 
     this.handleUpdateEnd_();

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -524,6 +524,54 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
       assert.equal(this.track.cues[2].startTime, 15, 'Third cue starttime should be 15');
     });
 
+    QUnit.test(
+      'adds native VTTCues when featuresNativeTextTracks option is enabled',
+      function(assert) {
+        loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
+          loaderType: 'vtt',
+          featuresNativeTextTracks: true
+        }), {});
+
+        this.track = new MockTextTrack();
+
+        const playlist = playlistWithDuration(20);
+
+        loader.parseVTTCues_ = (segmentInfo) => {
+          segmentInfo.cues = [{ startTime: 0, endTime: 5}, { startTime: 5, endTime: 15}];
+          segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
+        };
+
+        loader.playlist(playlist);
+        loader.track(this.track);
+        loader.load();
+
+        this.clock.tick(1);
+
+        this.requests[0].responseType = 'arraybuffer';
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+
+        this.clock.tick(1);
+
+        loader.parseVTTCues_ = (segmentInfo) => {
+          segmentInfo.cues = [{ startTime: 5, endTime: 15}, { startTime: 15, endTime: 20}];
+          segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
+        };
+
+        this.clock.tick(1);
+
+        this.requests[0].responseType = 'arraybuffer';
+        this.requests[0].response =  new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+
+        this.clock.tick(1);
+
+        assert.ok(loader.subtitlesTrack_.cues.every(c => c instanceof window.VTTCue), 'added native VTTCues');
+
+        this.env.log.warn.callCount = 0;
+      }
+    );
+
     QUnit.test('loader does not re-request segments that contain no subtitles',
     function(assert) {
       let playlist = playlistWithDuration(60);


### PR DESCRIPTION
When native text tracks are used, the cues added need to be native cues. It works on conjuction with videojs/video.js#6410.

Co-authored-by: Kevin Kipp <kevin.kipp@gmail.com>
Co-authored-by: Kyle Boutette <kyleveb@gmail.com>

This is a backport of #759 against 1.x