### PR TITLE
test(vtt-segment-loader): reset error log count

### DIFF
--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -569,6 +569,7 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
         assert.ok(loader.subtitlesTrack_.cues.every(c => c instanceof window.VTTCue), 'added native VTTCues');
 
         this.env.log.warn.callCount = 0;
+        this.env.log.error.callCount = 0;
       }
     );
 


### PR DESCRIPTION
The previous commit passed tests in PR but failing in the branch https://travis-ci.org/github/videojs/http-streaming/builds/663197151?utm_source=github_status&utm_medium=notification. This is likely because an error log count wasn't being reset in this test.