### PR TITLE
fix: Remove current sourceBuffer audio on disable

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -354,6 +354,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.audioDisabled_ = !enable;
     if (enable) {
       this.appendInitSegment_.audio = true;
+    } else {
+      // remove current track audio if it gets disabled
+      this.sourceUpdater_.removeAudio(0, this.duration_());
     }
   }
 


### PR DESCRIPTION
## Description
When switching to alternative audio and turning off audio on the main segment loader we are not removing the original audio data from the main segment loader. This means that we start adding new audio onto the old audio causing all kinds of issues.

