### PR TITLE
Revert "fix: Use middleware and a wrapped function for seeking instead of relying on unreliable 'seeking' events (#161)"

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -63,9 +63,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       useCueTags,
       blacklistDuration,
       enableLowInitialPlaylist,
-      sourceType,
-      seekTo,
-      cacheEncryptionKeys
+      cacheEncryptionKeys,
+      sourceType
     } = options;
 
     if (!url) {
@@ -77,7 +76,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.withCredentials = withCredentials;
     this.tech_ = tech;
     this.hls_ = tech.hls;
-    this.seekTo_ = seekTo;
     this.sourceType_ = sourceType;
     this.useCueTags_ = useCueTags;
     this.blacklistDuration = blacklistDuration;
@@ -574,7 +572,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     }
 
     if (this.tech_.ended()) {
-      this.seekTo_(0);
+      this.tech_.setCurrentTime(0);
     }
 
     if (this.hasPlayed_) {
@@ -587,7 +585,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // seek forward to the live point
     if (this.tech_.duration() === Infinity) {
       if (this.tech_.currentTime() < seekable.start(0)) {
-        return this.seekTo_(seekable.end(seekable.length - 1));
+        return this.tech_.setCurrentTime(seekable.end(seekable.length - 1));
       }
     }
   }
@@ -624,7 +622,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
         // readyState is 0, so it must be delayed until the tech fires loadedmetadata.
         this.tech_.one('loadedmetadata', () => {
           this.trigger('firstplay');
-          this.seekTo_(seekable.end(0));
+          this.tech_.setCurrentTime(seekable.end(0));
           this.hasPlayed_ = true;
         });
 
@@ -634,7 +632,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       // trigger firstplay to inform the source handler to ignore the next seek event
       this.trigger('firstplay');
       // seek to the live point
-      this.seekTo_(seekable.end(0));
+      this.tech_.setCurrentTime(seekable.end(0));
     }
 
     this.hasPlayed_ = true;

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -33,7 +33,6 @@ export default class PlaybackWatcher {
   constructor(options) {
     this.tech_ = options.tech;
     this.seekable = options.seekable;
-    this.seekTo = options.seekTo;
     this.allowSeeksWithinUnsafeLiveWindow = options.allowSeeksWithinUnsafeLiveWindow;
     this.media = options.media;
 
@@ -190,7 +189,7 @@ export default class PlaybackWatcher {
                   `seekable range ${Ranges.printableRange(seekable)}. Seeking to ` +
                   `${seekTo}.`);
 
-      this.seekTo(seekTo);
+      this.tech_.setCurrentTime(seekTo);
       return true;
     }
 
@@ -222,7 +221,7 @@ export default class PlaybackWatcher {
     // to avoid triggering an `unknownwaiting` event when the network is slow.
     if (currentRange.length && currentTime + 3 <= currentRange.end(0)) {
       this.cancelTimer_();
-      this.seekTo(currentTime);
+      this.tech_.setCurrentTime(currentTime);
 
       this.logger_(`Stopped at ${currentTime} while inside a buffered region ` +
         `[${currentRange.start(0)} -> ${currentRange.end(0)}]. Attempting to resume ` +
@@ -262,7 +261,7 @@ export default class PlaybackWatcher {
       this.logger_(`Fell out of live window at time ${currentTime}. Seeking to ` +
                    `live point (seekable end) ${livePoint}`);
       this.cancelTimer_();
-      this.seekTo(livePoint);
+      this.tech_.setCurrentTime(livePoint);
 
       // live window resyncs may be useful for monitoring QoS
       this.tech_.trigger({type: 'usage', name: 'hls-live-resync'});
@@ -278,7 +277,7 @@ export default class PlaybackWatcher {
       // allows the video to catch up to the audio position without losing any audio
       // (only suffering ~3 seconds of frozen video and a pause in audio playback).
       this.cancelTimer_();
-      this.seekTo(currentTime);
+      this.tech_.setCurrentTime(currentTime);
 
       // video underflow may be useful for monitoring QoS
       this.tech_.trigger({type: 'usage', name: 'hls-video-underflow'});
@@ -376,7 +375,7 @@ export default class PlaybackWatcher {
                  'nextRange start:', nextRange.start(0));
 
     // only seek if we still have not played
-    this.seekTo(nextRange.start(0) + Ranges.TIME_FUDGE_FACTOR);
+    this.tech_.setCurrentTime(nextRange.start(0) + Ranges.TIME_FUDGE_FACTOR);
 
     this.tech_.trigger({type: 'usage', name: 'hls-gap-skip'});
   }

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -509,6 +509,10 @@ class HlsHandler extends Component {
     this.options_.tech = this.tech_;
     this.options_.externHls = Hls;
     this.options_.sourceType = simpleTypeFromSourceType(type);
+    // Whenever we seek internally, we should update the tech
+    this.options_.seekTo = (time) => {
+      this.tech_.setCurrentTime(time);
+    };
 
     this.masterPlaylistController_ = new MasterPlaylistController(this.options_);
     this.playbackWatcher_ = new PlaybackWatcher(

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -581,12 +581,14 @@ function(assert) {
   playbackWatcher.tech_ = {
     off: () => {},
     seeking: () => seeking,
+    setCurrentTime: (time) => {
+      seeks.push(time);
+    },
     currentTime: () => currentTime,
     // mocked out
     paused: () => false,
     buffered: () => videojs.createTimeRanges()
   };
-  this.player.vhs.setCurrentTime = (time) => seeks.push(time);
 
   playbackWatcher.allowSeeksWithinUnsafeLiveWindow = true;
 

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -160,7 +160,9 @@ QUnit.test('skips over gap in Chrome due to video underflow', function(assert) {
 
   let seeks = [];
 
-  this.player.vhs.setCurrentTime = (time) => seeks.push(time);
+  this.player.tech_.setCurrentTime = (time) => {
+    seeks.push(time);
+  };
 
   this.player.tech_.trigger('waiting');
 
@@ -436,9 +438,11 @@ QUnit.test('fixes bad seeks', function(assert) {
   playbackWatcher.tech_ = {
     off: () => {},
     seeking: () => seeking,
+    setCurrentTime: (time) => {
+      seeks.push(time);
+    },
     currentTime: () => currentTime
   };
-  this.player.vhs.setCurrentTime = (time) => seeks.push(time);
 
   currentTime = 50;
   seekable = videojs.createTimeRanges([[1, 45]]);
@@ -487,12 +491,14 @@ QUnit.test('corrects seek outside of seekable', function(assert) {
   playbackWatcher.tech_ = {
     off: () => {},
     seeking: () => seeking,
+    setCurrentTime: (time) => {
+      seeks.push(time);
+    },
     currentTime: () => currentTime,
     // mocked out
     paused: () => false,
     buffered: () => videojs.createTimeRanges()
   };
-  this.player.vhs.setCurrentTime = (time) => seeks.push(time);
 
   // waiting
 


### PR DESCRIPTION
This reverts commit 6c68761b5d06d951d7ed20cbd5bb63f324ad2c47.

This helps address #378 and  videojs/video.js#6444.