### PR TITLE
fix: audio and video syncing for demuxed content with discontinuities

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -12,6 +12,7 @@ import * as Ranges from './ranges';
 import videojs from 'video.js';
 import { updateAdCues } from './ad-cue-tags';
 import SyncController from './sync-controller';
+import TimelineChangeController from './timeline-change-controller';
 import Decrypter from 'worker!./decrypter-worker.worker.js';
 import Config from './config';
 import {
@@ -143,7 +144,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       inbandTextTracks: this.inbandTextTracks_,
       cacheEncryptionKeys,
       handlePartialData,
-      sourceUpdater: this.sourceUpdater_
+      sourceUpdater: this.sourceUpdater_,
+      timelineChangeController: new TimelineChangeController()
     };
 
     // The source type check not only determines whether a special DASH playlist loader

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -127,6 +127,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.decrypter_ = new Decrypter();
     this.sourceUpdater_ = new SourceUpdater(this.mediaSource);
     this.inbandTextTracks_ = {};
+    this.timelineChangeController_ = new TimelineChangeController();
 
     const segmentLoaderSettings = {
       hls: this.hls_,
@@ -145,7 +146,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       cacheEncryptionKeys,
       handlePartialData,
       sourceUpdater: this.sourceUpdater_,
-      timelineChangeController: new TimelineChangeController()
+      timelineChangeController: this.timelineChangeController_
     };
 
     // The source type check not only determines whether a special DASH playlist loader
@@ -1148,6 +1149,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.audioSegmentLoader_.dispose();
     this.subtitleSegmentLoader_.dispose();
     this.sourceUpdater_.dispose();
+    this.timelineChangeController_.dispose();
     this.off();
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -241,7 +241,9 @@ export const timestampOffsetForSegment = ({
  * @param {('main'|'audio')} loaderType
  *        The loader type
  * @param {boolean} audioDisabled
- *        Whether the audio is disabled for the loader
+ *        Whether the audio is disabled for the loader. This should only be true when the
+ *        loader may have muxed audio in its segment, but should not append it, e.g., for
+ *        the main loader when an alternate audio playlist is active.
  *
  * @return {boolean}
  *         Whether the loader should wait for a timeline change from the timeline change

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -442,20 +442,13 @@ export default class SegmentLoader extends videojs.EventTarget {
     });
 
     this.sourceUpdater_.on('ready', () => {
-      if (this.loaderType_ === 'audio' &&
-          this.pendingSegment_ &&
-          this.hasEnoughInfoToLoad_()) {
-        this.processLoadQueue_();
-      }
       if (this.hasEnoughInfoToAppend_()) {
         this.processCallQueue_();
       }
     });
 
     this.timelineChangeController_.on('timelinechange', () => {
-      if (this.loaderType_ === 'audio' &&
-          this.pendingSegment_ &&
-          this.hasEnoughInfoToLoad_()) {
+      if (this.hasEnoughInfoToLoad_()) {
         this.processLoadQueue_();
       }
       if (this.hasEnoughInfoToAppend_()) {
@@ -1610,6 +1603,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     const segmentInfo = this.pendingSegment_;
+
+    // A fill buffer must have already run to establish a pending segment before there's
+    // enough info to load.
+    if (!segmentInfo) {
+      return false;
+    }
 
     // Always can load the first segment, and have to so that source buffers are created
     // together (before appending)

--- a/src/timeline-change-controller.js
+++ b/src/timeline-change-controller.js
@@ -1,0 +1,41 @@
+import videojs from 'video.js';
+
+/**
+ * The TimelineChangeController acts as a source for segment loaders to listen for and
+ * keep track of latest and pending timeline changes. This is useful to ensure proper
+ * sync, as each loader may need to make a consideration for what timeline the other
+ * loader is on before making changes which could impact the other loader's media.
+ *
+ * @class TimelineChangeController
+ * @extends videojs.EventTarget
+ */
+export default class TimelineChangeController extends videojs.EventTarget {
+  constructor() {
+    super();
+
+    this.pendingTimelineChanges_ = {};
+    this.lastTimelineChanges_ = {};
+  }
+
+  clearPendingTimelineChange(type) {
+    delete this.pendingTimelineChanges_[type];
+    this.trigger('timelinechange');
+  }
+
+  pendingTimelineChange({ type, from, to }) {
+    if (typeof from === 'number' && typeof to === 'number') {
+      this.pendingTimelineChanges_[type] = { type, from, to };
+      this.trigger('pendingtimelinechange');
+    }
+    return this.pendingTimelineChanges_[type];
+  }
+
+  lastTimelineChange({ type, from, to }) {
+    if (typeof from === 'number' && typeof to === 'number') {
+      this.lastTimelineChanges_[type] = { type, from, to };
+      delete this.pendingTimelineChanges_[type];
+      this.trigger('timelinechange');
+    }
+    return this.lastTimelineChanges_[type];
+  }
+}

--- a/src/timeline-change-controller.js
+++ b/src/timeline-change-controller.js
@@ -38,4 +38,9 @@ export default class TimelineChangeController extends videojs.EventTarget {
     }
     return this.lastTimelineChanges_[type];
   }
+
+  dispose() {
+    this.trigger('dispose');
+    this.off();
+  }
 }

--- a/src/timeline-change-controller.js
+++ b/src/timeline-change-controller.js
@@ -18,7 +18,7 @@ export default class TimelineChangeController extends videojs.EventTarget {
   }
 
   clearPendingTimelineChange(type) {
-    delete this.pendingTimelineChanges_[type];
+    this.pendingTimelineChanges_[type] = null;
     this.trigger('pendingtimelinechange');
   }
 
@@ -41,6 +41,8 @@ export default class TimelineChangeController extends videojs.EventTarget {
 
   dispose() {
     this.trigger('dispose');
+    this.pendingTimelineChanges_ = {};
+    this.lastTimelineChanges_ = {};
     this.off();
   }
 }

--- a/src/timeline-change-controller.js
+++ b/src/timeline-change-controller.js
@@ -19,7 +19,7 @@ export default class TimelineChangeController extends videojs.EventTarget {
 
   clearPendingTimelineChange(type) {
     delete this.pendingTimelineChanges_[type];
-    this.trigger('timelinechange');
+    this.trigger('pendingtimelinechange');
   }
 
   pendingTimelineChange({ type, from, to }) {

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -12,6 +12,7 @@ import {
 import { MasterPlaylistController } from '../src/master-playlist-controller';
 import SourceUpdater from '../src/source-updater';
 import SyncController from '../src/sync-controller';
+import TimelineChangeController from '../src/timeline-change-controller';
 import Decrypter from 'worker!../src/decrypter-worker.worker.js';
 import window from 'global/window';
 /* eslint-disable no-unused-vars */
@@ -59,6 +60,7 @@ export const LoaderCommonHooks = {
     this.sourceUpdater = new SourceUpdater(this.mediaSource);
     this.syncController = new SyncController();
     this.decrypter = new Decrypter();
+    this.timelineChangeController = new TimelineChangeController();
   },
   afterEach(assert) {
     this.env.restore();
@@ -89,7 +91,8 @@ export const LoaderCommonSettings = function(settings) {
     mediaSource: this.mediaSource,
     sourceUpdater: this.sourceUpdater,
     syncController: this.syncController,
-    decrypter: this.decrypter
+    decrypter: this.decrypter,
+    timelineChangeController: this.timelineChangeController
   }, settings);
 };
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -66,6 +66,7 @@ export const LoaderCommonHooks = {
     this.env.restore();
     this.decrypter.terminate();
     this.sourceUpdater.dispose();
+    this.timelineChangeController.dispose();
   }
 };
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -4133,3 +4133,15 @@ QUnit.test(
     assert.equal(mpc.mediaSource.duration, 11, 'media source duration set to 11');
   }
 );
+
+QUnit.test('disposes timeline change controller on dispose', function(assert) {
+  let disposes = 0;
+
+  this.masterPlaylistController.timelineChangeController_.on('dispose', () => {
+    disposes++;
+  });
+
+  this.masterPlaylistController.dispose();
+
+  assert.equal(disposes, 1, 'disposed timeline change controller');
+});

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1792,6 +1792,14 @@ QUnit.module('SegmentLoader', function(hooks) {
         loader.load();
         this.clock.tick(1);
 
+        // The main loader has to be the first to load a segment, so fake a main timeline
+        // change.
+        this.timelineChangeController.lastTimelineChange({
+          type: 'main',
+          from: -1,
+          to: 0
+        });
+
         // init
         standardXHRResponse(this.requests.shift(), mp4AudioInitSegment());
         // segment

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -379,7 +379,7 @@ QUnit.test('should not wait if main and pending audio timeline change matches se
         }
       }
     }),
-    'should wait'
+    'should not wait'
   );
 });
 
@@ -1232,58 +1232,6 @@ QUnit.module('SegmentLoader', function(hooks) {
           },
           'added last timeline change for audio'
         );
-      });
-    });
-
-    QUnit.test('audio loader checks to process append queue on timeline change', function(assert) {
-      const done = assert.async();
-
-      assert.expect(3);
-      loader.dispose();
-      loader = new SegmentLoader(LoaderCommonSettings.call(this, {
-        loaderType: 'audio'
-      }), {});
-
-      let ranFinish = false;
-
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
-        const origFinish = loader.segmentRequestFinished_.bind(loader);
-
-        // Although overriding the internal function isn't the cleanest way to test, it's
-        // difficult to try to catch the moment where the segment is finished and in the
-        // queue, but not yet processed and appending.
-        loader.segmentRequestFinished_ = (error, simpleSegment, result) => {
-          origFinish(error, simpleSegment, result);
-
-          // call queue should have an entry for this function, but only want to run
-          // through this logic once
-          if (ranFinish) {
-            return;
-          }
-
-          ranFinish = true;
-
-          // segment request finished, but the loader is waiting on main to have a
-          // timeline change
-          assert.equal(loader.state, 'WAITING', 'state is waiting');
-
-          // the timeline change should trigger an append
-          loader.on('appending', () => {
-            done();
-          });
-
-          this.timelineChangeController.lastTimelineChange({
-            type: 'main',
-            from: -1,
-            to: 0
-          });
-        };
-
-        loader.playlist(playlistWithDuration(20));
-        loader.load();
-        this.clock.tick(1);
-        // segment 0
-        standardXHRResponse(this.requests.shift(), audioSegment());
       });
     });
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -225,7 +225,7 @@ QUnit.test('should not wait if timelines are the same', function(assert) {
   );
 });
 
-QUnit.test('should wait if audio and no main timeline change', function(assert) {
+QUnit.test('audio loader waits if no main timeline change', function(assert) {
   assert.ok(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -241,7 +241,7 @@ QUnit.test('should wait if audio and no main timeline change', function(assert) 
   );
 });
 
-QUnit.test('should wait if audio and last main timeline change not audio segment\'s timeline', function(assert) {
+QUnit.test('audio loader waits if last main timeline change not on audio segment\'s timeline', function(assert) {
   assert.ok(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -259,7 +259,7 @@ QUnit.test('should wait if audio and last main timeline change not audio segment
   );
 });
 
-QUnit.test('should not wait if audio and last main timeline matches audio segment\'s timeline', function(assert) {
+QUnit.test('audio loader does not wait if last main timeline matches audio segment\'s timeline', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -277,7 +277,7 @@ QUnit.test('should not wait if audio and last main timeline matches audio segmen
   );
 });
 
-QUnit.test('should not wait if audio and last main timeline matches audio segment\'s timeline', function(assert) {
+QUnit.test('audio loader does not wait if last main timeline matches audio segment\'s timeline', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -295,7 +295,7 @@ QUnit.test('should not wait if audio and last main timeline matches audio segmen
   );
 });
 
-QUnit.test('should not wait if main and audio enabled', function(assert) {
+QUnit.test('main loader does not wait if audio enabled', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -306,7 +306,7 @@ QUnit.test('should not wait if main and audio enabled', function(assert) {
   );
 });
 
-QUnit.test('should not wait if main and no audio timeline change', function(assert) {
+QUnit.test('main loader does not wait if no audio timeline change', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -322,7 +322,7 @@ QUnit.test('should not wait if main and no audio timeline change', function(asse
   );
 });
 
-QUnit.test('should wait if main and no pending audio timeline change', function(assert) {
+QUnit.test('main loader waits if no pending audio timeline change', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -341,7 +341,7 @@ QUnit.test('should wait if main and no pending audio timeline change', function(
   );
 });
 
-QUnit.test('should wait if main and pending audio timeline change doesn\'t match segment timeline', function(assert) {
+QUnit.test('main loader waits if pending audio timeline change doesn\'t match segment timeline', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,
@@ -362,7 +362,7 @@ QUnit.test('should wait if main and pending audio timeline change doesn\'t match
   );
 });
 
-QUnit.test('should not wait if main and pending audio timeline change matches segment timeline', function(assert) {
+QUnit.test('main loader does not wait if pending audio timeline change matches segment timeline', function(assert) {
   assert.notOk(
     shouldWaitForTimelineChange({
       currentTimeline: 1,

--- a/test/timeline-change-controller.test.js
+++ b/test/timeline-change-controller.test.js
@@ -1,0 +1,244 @@
+import QUnit from 'qunit';
+import TimelineChangeController from '../src/timeline-change-controller';
+
+QUnit.module('Timeline Change Controller', {
+  beforeEach(assert) {
+    this.timelineChangeController = new TimelineChangeController();
+  }
+});
+
+QUnit.test('saves last timeline changes from different types', function(assert) {
+  assert.notOk(
+    this.timelineChangeController.lastTimelineChange({ type: 'main' }),
+    'starts without any main timeline change'
+  );
+  assert.notOk(
+    this.timelineChangeController.lastTimelineChange({ type: 'audio' }),
+    'starts without any audio timeline change'
+  );
+
+  this.timelineChangeController.lastTimelineChange({
+    type: 'main',
+    from: 1,
+    to: 2
+  });
+
+  assert.deepEqual(
+    this.timelineChangeController.lastTimelineChange({ type: 'main' }),
+    {
+      type: 'main',
+      from: 1,
+      to: 2
+    },
+    'records main timeline change'
+  );
+  assert.notOk(
+    this.timelineChangeController.lastTimelineChange({ type: 'audio' }),
+    'no audio timeline change'
+  );
+
+  this.timelineChangeController.lastTimelineChange({
+    type: 'audio',
+    from: 2,
+    to: 3
+  });
+
+  assert.deepEqual(
+    this.timelineChangeController.lastTimelineChange({ type: 'main' }),
+    {
+      type: 'main',
+      from: 1,
+      to: 2
+    },
+    'still has main timeline change'
+  );
+  assert.deepEqual(
+    this.timelineChangeController.lastTimelineChange({ type: 'audio' }),
+    {
+      type: 'audio',
+      from: 2,
+      to: 3
+    },
+    'records audio timeline change'
+  );
+});
+
+QUnit.test('saves pending timeline changes from different types', function(assert) {
+  assert.notOk(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    'starts without any main pending timeline change'
+  );
+  assert.notOk(
+    this.timelineChangeController.pendingTimelineChange({ type: 'audio' }),
+    'starts without any audio pending timeline change'
+  );
+
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'main',
+    from: 1,
+    to: 2
+  });
+
+  assert.deepEqual(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    {
+      type: 'main',
+      from: 1,
+      to: 2
+    },
+    'records main pending timeline change'
+  );
+  assert.notOk(
+    this.timelineChangeController.pendingTimelineChange({ type: 'audio' }),
+    'no audio pending timeline change'
+  );
+
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'audio',
+    from: 2,
+    to: 3
+  });
+
+  assert.deepEqual(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    {
+      type: 'main',
+      from: 1,
+      to: 2
+    },
+    'still has main pending timeline change'
+  );
+  assert.deepEqual(
+    this.timelineChangeController.pendingTimelineChange({ type: 'audio' }),
+    {
+      type: 'audio',
+      from: 2,
+      to: 3
+    },
+    'records audio pending timeline change'
+  );
+});
+
+QUnit.test('triggers timelinechange event on timeline change', function(assert) {
+  let timelineChanges = 0;
+
+  this.timelineChangeController.on('timelinechange', () => timelineChanges++);
+  this.timelineChangeController.lastTimelineChange({
+    type: 'main',
+    from: 1,
+    to: 2
+  });
+
+  assert.equal(timelineChanges, 1, 'triggered timelinechange event');
+
+  this.timelineChangeController.lastTimelineChange({
+    type: 'audio',
+    from: 2,
+    to: 3
+  });
+
+  assert.equal(timelineChanges, 2, 'triggered timelinechange event');
+
+  this.timelineChangeController.lastTimelineChange({
+    type: 'audio',
+    from: 3,
+    to: 4
+  });
+
+  assert.equal(timelineChanges, 3, 'triggered timelinechange event');
+});
+
+QUnit.test('triggers pendingtimelinechange event on timeline change', function(assert) {
+  let pendingTimelineChanges = 0;
+
+  this.timelineChangeController.on(
+    'pendingtimelinechange',
+    () => pendingTimelineChanges++
+  );
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'main',
+    from: 1,
+    to: 2
+  });
+
+  assert.equal(pendingTimelineChanges, 1, 'triggered pendingtimelinechange event');
+
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'audio',
+    from: 2,
+    to: 3
+  });
+
+  assert.equal(pendingTimelineChanges, 2, 'triggered pendingtimelinechange event');
+
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'audio',
+    from: 3,
+    to: 4
+  });
+
+  assert.equal(pendingTimelineChanges, 3, 'triggered pendingtimelinechange event');
+});
+
+QUnit.test('timeline change deletes pending timeline change', function(assert) {
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'main',
+    from: 1,
+    to: 2
+  });
+
+  assert.deepEqual(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    {
+      type: 'main',
+      from: 1,
+      to: 2
+    },
+    'saved pending timeline change'
+  );
+
+  this.timelineChangeController.lastTimelineChange({
+    type: 'main',
+    from: 2,
+    to: 3
+  });
+
+  assert.notOk(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    'deleted pending timeline change'
+  );
+});
+
+QUnit.test('clear pending deletes and triggers timelinechange', function(assert) {
+  let pendingTimelineChanges = 0;
+
+  this.timelineChangeController.on(
+    'pendingtimelinechange',
+    () => pendingTimelineChanges++
+  );
+
+  this.timelineChangeController.pendingTimelineChange({
+    type: 'main',
+    from: 1,
+    to: 2
+  });
+
+  assert.equal(pendingTimelineChanges, 1, 'triggered pendingtimelinechange event');
+  assert.deepEqual(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    {
+      type: 'main',
+      from: 1,
+      to: 2
+    },
+    'saved pending timeline change'
+  );
+
+  this.timelineChangeController.clearPendingTimelineChange('main');
+
+  assert.equal(pendingTimelineChanges, 2, 'triggered pendingtimelinechange event');
+  assert.notOk(
+    this.timelineChangeController.pendingTimelineChange({ type: 'main' }),
+    'deleted pending timeline change'
+  );
+});

--- a/test/timeline-change-controller.test.js
+++ b/test/timeline-change-controller.test.js
@@ -119,7 +119,7 @@ QUnit.test('saves pending timeline changes from different types', function(asser
   );
 });
 
-QUnit.test('triggers timelinechange event on timeline change', function(assert) {
+QUnit.test('triggers timelinechange event on timeline changes', function(assert) {
   let timelineChanges = 0;
 
   this.timelineChangeController.on('timelinechange', () => timelineChanges++);
@@ -148,7 +148,7 @@ QUnit.test('triggers timelinechange event on timeline change', function(assert) 
   assert.equal(timelineChanges, 3, 'triggered timelinechange event');
 });
 
-QUnit.test('triggers pendingtimelinechange event on timeline change', function(assert) {
+QUnit.test('triggers pendingtimelinechange event on pending timeline changes', function(assert) {
   let pendingTimelineChanges = 0;
 
   this.timelineChangeController.on(
@@ -209,7 +209,7 @@ QUnit.test('timeline change deletes pending timeline change', function(assert) {
   );
 });
 
-QUnit.test('clear pending deletes and triggers timelinechange', function(assert) {
+QUnit.test('clear pending deletes and triggers pendingtimelinechange', function(assert) {
   let pendingTimelineChanges = 0;
 
   this.timelineChangeController.on(


### PR DESCRIPTION
In order to properly sync audio and video for demuxed content when there are discontinuities, one of the streams must follow the timing of the other. For VHS, video was chosen (historically) to be the source of truth for media timing, and audio was manipulated to fit the media timing.

In order to properly fit audio to the video timeline, audio must know the timing information of video before it is appended, and video must wait for audio to cross a discontinuity before it crosses, so as not to set the timestamp offset or other associated timing information for audio before audio is done with appends along its current timeline.

As such, a TimelineChangeController object was added, in order to facilitate discontinuity crossings where audio and video streams each wait until the other is ready to cross before they make the move over to a new timeline. This allows both to remain in sync, as they cross a discontinuity together, and keep appropriate video timing information for each timeline.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
