### PR TITLE
fix: put devicePixelRatio behind useDevicePixelRatio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ This setting is `false` by default.
 * Type: `boolean`
 * can be used as an initialization option
 
+##### useDevicePixelRatio
+* Type: `boolean`
+* can be used as an initialization option.
+
+If true, this will take the device pixel ratio into account when doing rendition switching. This means that if you have a player with the width of `540px` in a high density display with a device pixel ratio of 2, a rendition of `1080p` will be allowed.
+This setting is `false` by default.
+
 When `limitRenditionByPlayerDimensions` is set to true, rendition
 selection logic will take into account the player size and rendition
 resolutions when making a decision.

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -297,13 +297,14 @@ export const lastBandwidthSelector = function() {
  */
 export const movingAverageBandwidthSelector = function(decay) {
   let average = -1;
-  const pixelRatio = this.useDevicePixelRatio ? window.devicePixelRatio || 1 : 1;
 
   if (decay < 0 || decay > 1) {
     throw new Error('Moving average bandwidth decay must be between 0 and 1.');
   }
 
   return function() {
+    const pixelRatio = this.useDevicePixelRatio ? window.devicePixelRatio || 1 : 1;
+
     if (average < 0) {
       average = this.systemBandwidth;
     }

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -272,7 +272,7 @@ export const simpleSelector = function(master,
  * bandwidth variance
  */
 export const lastBandwidthSelector = function() {
-  const pixelRatio = window.devicePixelRatio || 1;
+  const pixelRatio = this.useDevicePixelRatio ? window.devicePixelRatio || 1 : 1;
 
   return simpleSelector(this.playlists.master,
                         this.systemBandwidth,
@@ -297,7 +297,7 @@ export const lastBandwidthSelector = function() {
  */
 export const movingAverageBandwidthSelector = function(decay) {
   let average = -1;
-  const pixelRatio = window.devicePixelRatio || 1;
+  const pixelRatio = this.useDevicePixelRatio ? window.devicePixelRatio || 1 : 1;
 
   if (decay < 0 || decay > 1) {
     throw new Error('Moving average bandwidth decay must be between 0 and 1.');

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -436,6 +436,7 @@ class HlsHandler extends Component {
     this.options_.withCredentials = this.options_.withCredentials || false;
     this.options_.handleManifestRedirects = this.options_.handleManifestRedirects || false;
     this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions === false ? false : true;
+    this.options_.useDevicePixelRatio = this.options_.useDevicePixelRatio || false;
     this.options_.smoothQualityChange = this.options_.smoothQualityChange || false;
     this.options_.useBandwidthFromLocalStorage =
       typeof this.source_.useBandwidthFromLocalStorage !== 'undefined' ?
@@ -478,6 +479,7 @@ class HlsHandler extends Component {
     // grab options passed to player.src
     [
       'withCredentials',
+      'useDevicePixelRatio',
       'limitRenditionByPlayerDimensions',
       'bandwidth',
       'smoothQualityChange',
@@ -492,6 +494,7 @@ class HlsHandler extends Component {
     });
 
     this.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions;
+    this.useDevicePixelRatio = this.options_.useDevicePixelRatio;
   }
   /**
    * called when player.src gets called, handle a new source

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -29,6 +29,11 @@ const options = [{
   test: false,
   alt: false
 }, {
+  name: 'useDevicePixelRatio',
+  default: false,
+  test: true,
+  alt: false
+}, {
   name: 'bandwidth',
   default: 4194304,
   test: 5,


### PR DESCRIPTION
Due to the Covid-19 pandemic, we are turning this into an option instead of enabling it by default to limit the amount of bandwidth used. We may make this be set to true by default in a future update.