### PR TITLE
test: Set devicePixelRatio to 1

### DIFF
--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -52,8 +52,10 @@ QUnit.module('MasterPlaylistController', {
     this.requests = this.env.requests;
     this.mse = useFakeMediaSource();
 
-    this.oldDevicePixelRatio = window.devicePixelRatio;
-    window.devicePixelRatio = 1;
+    if (!videojs.browser.IE_VERSION) {
+      this.oldDevicePixelRatio = window.devicePixelRatio;
+      window.devicePixelRatio = 1;
+    }
 
     // force the HLS tech to run
     this.origSupportsNativeHls = videojs.Hls.supportsNativeHls;
@@ -87,7 +89,9 @@ QUnit.module('MasterPlaylistController', {
     this.mse.restore();
     videojs.Hls.supportsNativeHls = this.origSupportsNativeHls;
     window.localStorage.clear();
-    window.devicePixelRatio = this.oldDevicePixelRatio;
+    if (this.hasOwnProperty('oldDevicePixelRatio')) {
+      window.devicePixelRatio = this.oldDevicePixelRatio;
+    }
     videojs.browser = this.oldBrowser;
     this.player.dispose();
   }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -52,6 +52,9 @@ QUnit.module('MasterPlaylistController', {
     this.requests = this.env.requests;
     this.mse = useFakeMediaSource();
 
+    this.oldDevicePixelRatio = window.devicePixelRatio;
+    window.devicePixelRatio = 1;
+
     // force the HLS tech to run
     this.origSupportsNativeHls = videojs.Hls.supportsNativeHls;
     videojs.Hls.supportsNativeHls = false;
@@ -84,6 +87,7 @@ QUnit.module('MasterPlaylistController', {
     this.mse.restore();
     videojs.Hls.supportsNativeHls = this.origSupportsNativeHls;
     window.localStorage.clear();
+    window.devicePixelRatio = this.oldDevicePixelRatio;
     videojs.browser = this.oldBrowser;
     this.player.dispose();
   }

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -67,6 +67,8 @@ QUnit.module('HLS', {
     this.mse = useFakeMediaSource();
     this.clock = this.env.clock;
     this.old = {};
+    this.old.devicePixelRatio = window.devicePixelRatio;
+    window.devicePixelRatio = 1;
 
     // store functionality that some tests need to mock
     this.old.GlobalOptions = videojs.mergeOptions(videojs.options);
@@ -102,6 +104,8 @@ QUnit.module('HLS', {
   afterEach() {
     this.env.restore();
     this.mse.restore();
+
+    window.devicePixelRatio = this.old.devicePixelRatio;
 
     merge(videojs.options, this.old.GlobalOptions);
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -67,9 +67,10 @@ QUnit.module('HLS', {
     this.mse = useFakeMediaSource();
     this.clock = this.env.clock;
     this.old = {};
-    this.old.devicePixelRatio = window.devicePixelRatio;
-    window.devicePixelRatio = 1;
-
+    if (!videojs.browser.IE_VERSION) {
+      this.old.devicePixelRatio = window.devicePixelRatio;
+      window.devicePixelRatio = 1;
+    }
     // store functionality that some tests need to mock
     this.old.GlobalOptions = videojs.mergeOptions(videojs.options);
 
@@ -105,7 +106,9 @@ QUnit.module('HLS', {
     this.env.restore();
     this.mse.restore();
 
-    window.devicePixelRatio = this.old.devicePixelRatio;
+    if (this.old.hasOwnProperty('devicePixelRatio')) {
+      window.devicePixelRatio = this.old.devicePixelRatio;
+    }
 
     merge(videojs.options, this.old.GlobalOptions);
 


### PR DESCRIPTION
Since my `devicePixelRatio` is `2` by default tests are failing for me right now. This pull request fixes that by setting `window.devicePixelRatio` to `1` during testing and resets it to the native value afterward.