### PR TITLE
test: dispose objects to prevent web worker leaks

### DIFF
--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -217,6 +217,8 @@ QUnit.test('creates appropriate PlaylistLoader for sourceType', function(assert)
     mpc.masterPlaylistLoader_ instanceof PlaylistLoader,
     'created a standard playlist loader for vhs-json source type'
   );
+
+  mpc.dispose();
 });
 
 QUnit.test('passes options to SegmentLoader', function(assert) {
@@ -3960,6 +3962,7 @@ QUnit.test(
   function(assert) {
     this.requests.length = 0;
     // must recreate player for new mock media source to open
+    this.player.dispose();
     this.player = createPlayer();
 
     const manifestObject = parseManifest({ manifestString: manifests.media });
@@ -3995,6 +3998,7 @@ QUnit.test(
   function(assert) {
     this.requests.length = 0;
     // must recreate player for new mock media source to open
+    this.player.dispose();
     this.player = createPlayer();
 
     const manifestObject = parseManifest({ manifestString: manifests.master });
@@ -4039,6 +4043,7 @@ QUnit.test(
   function(assert) {
     this.requests.length = 0;
     // must recreate player for new mock media source to open
+    this.player.dispose();
     this.player = createPlayer();
 
     const manifestObject = parseManifest({ manifestString: manifests.master });

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -2085,6 +2085,7 @@ QUnit.test(
     videojs.options.hls = {
       withCredentials: true
     };
+    this.player.dispose();
     this.player = createPlayer();
     this.player.src({
       src: 'http://example.com/media.m3u8',
@@ -4145,6 +4146,7 @@ QUnit[testOrSkip](
 QUnit[testOrSkip](
   'does not store bandwidth and throughput in localStorage by default',
   function(assert) {
+    this.player.dispose();
     this.player = createPlayer();
     this.player.src({
       src: 'manifest/master.m3u8',
@@ -4185,6 +4187,7 @@ QUnit[testOrSkip]('retrieves bandwidth and throughput from localStorage', functi
   };
 
   // values must be stored before player is created, otherwise defaults are provided
+  this.player.dispose();
   this.player = createPlayer();
   this.player.tech_.on('usage', usageListener);
   this.player.src({
@@ -4211,6 +4214,7 @@ QUnit[testOrSkip]('retrieves bandwidth and throughput from localStorage', functi
   videojs.options.hls = {
     useBandwidthFromLocalStorage: true
   };
+  this.player.dispose();
   this.player = createPlayer();
   this.player.tech_.on('usage', usageListener);
   this.player.src({
@@ -4909,6 +4913,7 @@ QUnit.test('blacklists playlist if key requests fail', function(assert) {
     'playlist blacklisted'
   );
   assert.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
+  hls.dispose();
 });
 
 QUnit.test(
@@ -4967,6 +4972,7 @@ QUnit.test(
     // verify stats
     assert.equal(hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
     assert.equal(hls.stats.mediaRequests, 1, '1 request');
+    hls.dispose();
   }
 );
 


### PR DESCRIPTION
Noticed that we were leaking web workers in a few places and cleaned it up.
