### PR TITLE
fix: use presence of starting media rather than timestamp offset in l…

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1637,7 +1637,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // created together (before appending). Source buffer creation uses the presence of
     // audio and video data to determine whether to create audio/video source buffers, and
     // uses processed (transmuxed or parsed) media to determine the types required.
-    if (segmentInfo.timestampOffset === 0) {
+    if (!this.startingMedia_) {
       return true;
     }
 


### PR DESCRIPTION
…oader readiness check

Using a `timestampOffset` of 0 as the check for the first load doesn't work for live
content. `startingMedia`, on the other hand, should be falsey until the first segment has
been loaded.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
