### PR TITLE
fix: update media references in DASH playlist loader to ensure they are from master

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -716,10 +716,8 @@ export default class DashPlaylistLoader extends EventTarget {
             );
           }
         } else {
+
           this.master = updatedMaster;
-          if (this.media_) {
-            this.media_ = this.master.playlists[this.media_.id];
-          }
         }
       }
 
@@ -770,7 +768,7 @@ export default class DashPlaylistLoader extends EventTarget {
       }
       this.media_ = updatedMaster.playlists[mediaID];
     } else {
-      this.media_ = oldMaster.playlists[mediaID];
+      this.media_ = newMaster.playlists[mediaID];
       this.trigger('playlistunchanged');
     }
 

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -716,8 +716,10 @@ export default class DashPlaylistLoader extends EventTarget {
             );
           }
         } else {
-
           this.master = updatedMaster;
+          if (this.media_) {
+            this.media_ = this.master.playlists[this.media_.id];
+          }
         }
       }
 
@@ -768,7 +770,7 @@ export default class DashPlaylistLoader extends EventTarget {
       }
       this.media_ = updatedMaster.playlists[mediaID];
     } else {
-      this.media_ = newMaster.playlists[mediaID];
+      this.media_ = oldMaster.playlists[mediaID];
       this.trigger('playlistunchanged');
     }
 

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -1369,12 +1369,6 @@ QUnit.test('refreshMedia: triggers playlistunchanged for master loader' +
 
   assert.equal(master, newMaster, 'master is unchanged');
   assert.equal(media, newMedia, 'media is unchanged');
-  /*
-  assert.ok(
-    newMaster.playlists.indexOf(newMedia.id) > -1,
-    'new master contains new media'
-  );
-  */
 });
 
 QUnit.test('refreshMedia: updates master and media playlists for child loader', function(assert) {

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -1357,9 +1357,24 @@ QUnit.test('refreshMedia: triggers playlistunchanged for master loader' +
     playlistUnchanged++;
   });
 
+  const master = loader.master;
+  const media = loader.media();
+
   loader.refreshMedia_(loader.media().id);
   assert.strictEqual(loadedPlaylists, 1, 'one loadedplaylists');
   assert.strictEqual(playlistUnchanged, 1, 'one playlistunchanged');
+
+  const newMaster = loader.master;
+  const newMedia = loader.media();
+
+  assert.equal(master, newMaster, 'master is unchanged');
+  assert.equal(media, newMedia, 'media is unchanged');
+  /*
+  assert.ok(
+    newMaster.playlists.indexOf(newMedia.id) > -1,
+    'new master contains new media'
+  );
+  */
 });
 
 QUnit.test('refreshMedia: updates master and media playlists for child loader', function(assert) {
@@ -1498,6 +1513,37 @@ QUnit.test('refreshXml_: requests the sidx if it changed', function(assert) {
       length: 200
     },
     'the sidx byterange has changed to reflect the new manifest'
+  );
+});
+
+QUnit.test('refreshXml_: updates media playlist reference if master changed', function(assert) {
+  const loader = new DashPlaylistLoader('dash.mpd', this.fakeHls);
+
+  loader.load();
+  this.standardXHRResponse(this.requests.shift());
+
+  const oldMaster = loader.master;
+  const oldMedia = loader.media();
+  const newMasterXml = loader.masterXml_.replace(
+    'mediaPresentationDuration="PT4S"',
+    'mediaPresentationDuration="PT5S"'
+  );
+
+  loader.refreshXml_();
+
+  assert.strictEqual(this.requests.length, 1, 'manifest is being requested');
+
+  this.requests.shift().respond(200, null, newMasterXml);
+
+  const newMaster = loader.master;
+  const newMedia = loader.media();
+
+  assert.notEqual(newMaster, oldMaster, 'master changed');
+  assert.notEqual(newMedia, oldMedia, 'media changed');
+  assert.equal(
+    newMedia,
+    newMaster.playlists[newMedia.id],
+    'media from updated master'
   );
 });
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1021,8 +1021,6 @@ QUnit.test('waits for both main and audio loaders to finish before calling endOf
   // audio media
   this.standardXHRResponse(this.requests.shift(), audioMedia);
 
-  this.clock.tick(1);
-
   return requestAndAppendSegment({
     request: this.requests.shift(),
     segment: videoSegment(),

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1021,6 +1021,8 @@ QUnit.test('waits for both main and audio loaders to finish before calling endOf
   // audio media
   this.standardXHRResponse(this.requests.shift(), audioMedia);
 
+  this.clock.tick(1);
+
   return requestAndAppendSegment({
     request: this.requests.shift(),
     segment: videoSegment(),


### PR DESCRIPTION
Previously, some media references in the DASH playlist loader weren't properly updated,
meaning that they were references from the old master. This broke blacklisting, where the
old playlist was blacklisted, but the playlist selector, using the newer playlist
references, could select the same playlist (but a new reference).

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
