### PR TITLE
chore(demo): new sources, generate selection list from a JSON file

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,11 @@
       <option value="https://d2zihajmogu5jn.cloudfront.net/CoitTower/master_ts_segtimes.m3u8">Coit Tower drone footage - 4 8 second segment</option>
       <option value="https://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8">Disney's Oceans trailer - HLSe, ts Encrypted</option>
       <option value="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8">Sintel - ts with audio/subs and a 4k rendtion</option>
+      <option value="https://d2zihajmogu5jn.cloudfront.net/hls-webvtt/master.m3u8">Boat Ipsum Subs - HLS + subtitles</option>
+      <option value="https://d2zihajmogu5jn.cloudfront.net/video-only/out.m3u8">Boat Video Only</option>
+      <option value="https://d2zihajmogu5jn.cloudfront.net/audio-only/out.m3u8">Boat Audio Only</option>
+      <option value="https://d2zihajmogu5jn.cloudfront.net/4k-hls/out.m3u8">Boat 4K</option>
+      <option value="https://d2zihajmogu5jn.cloudfront.net/misaligned-playlists/master.m3u8">Boat Misaligned - 3, 5, 7, second segment playlists</option>
       <option value="https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths-hls/hls.m3u8">BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4</option>
     </optgroup>
     <optgroup label="dash">

--- a/index.html
+++ b/index.html
@@ -79,42 +79,12 @@
   <h3>Load a Source</h3>
   <select id=load-source>
     <optgroup label="hls">
-      <option value="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8">Bipbop - Muxed TS with 1 alt Audio, 5 captions</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/ts-fmp4/index.m3u8">FMP4 and ts both muxed</option>
-      <option value="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8">Advanced Bipbop - ts and captions muxed</option>
-      <option value="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8">Advanced Bipbop - FMP4 and captions muxed</option>
-      <option value="https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8">Advanced Bipbop - FMP4 hevc, demuxed</option>
-      <option value="https://storage.googleapis.com/shaka-demo-assets/angel-one-hls/hls.m3u8">Angel One - FMP4 demuxed, many audio/captions</option>
-      <option value="https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8">Parkour - FMP4 demuxed</option>
-      <option value="https://s3.amazonaws.com/qa.jwplayer.com/~alex/121628/new_master.m3u8">Song - ts Audio only</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/CoitTower/master_ts_segtimes.m3u8">Coit Tower drone footage - 4 8 second segment</option>
-      <option value="https://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8">Disney's Oceans trailer - HLSe, ts Encrypted</option>
-      <option value="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8">Sintel - ts with audio/subs and a 4k rendtion</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/hls-webvtt/master.m3u8">Boat Ipsum Subs - HLS + subtitles</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/video-only/out.m3u8">Boat Video Only</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/audio-only/out.m3u8">Boat Audio Only</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/4k-hls/out.m3u8">Boat 4K</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/misaligned-playlists/master.m3u8">Boat Misaligned - 3, 5, 7, second segment playlists</option>
-      <option value="https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths-hls/hls.m3u8">BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4</option>
     </optgroup>
     <optgroup label="dash">
-      <option value="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd">Big Buck Bunny - demuxed audio/video, includes 4K, burns in frame, pts, resolution, bitrate values</option>
-      <option value="https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd">Angel One - fmp4, webm, subs, alternate audio tracks</option>
-      <option value="https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths/dash.mpd">BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4</option>
-      <option value="https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd">SIDX demuxed, 2 audio</option>
-      <option value="https://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-mpd-AV.mpd">SIDX bipbop-like</option>
-      <option value="https://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-manifest.mpd">Google self-driving car - SIDX</option>
-      <option value="https://d2zihajmogu5jn.cloudfront.net/sintel_dash/sintel_vod.mpd">Sintel - single rendition</option>
     </optgroup>
     <optgroup label="live">
-      <option value="https://akamai-axtest.akamaized.net/routes/lapd-v1-acceptance/www_c4/Manifest.m3u8">HLS - Live - Axinom live stream, may not always be available</option>
-      <option value="https://akamai-axtest.akamaized.net/routes/lapd-v1-acceptance/www_c4/Manifest.mpd">DASH - Live - Axinom live stream, may not always be available</option>
-      <option value="https://vm2.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd">DASH - Live simulated DASH from DASH IF</option>
-      <option value="https://storage.googleapis.com/shaka-live-assets/player-source.mpd">DASH - Shaka Player Source Simulated Live</option>
     </optgroup>
     <optgroup label="low latency live">
-      <option value="https://ll-hls-test.apple.com/master.m3u8">Apple's LL-HLS test stream</option>
-      <option value="https://ll-hls-test.apple.com/cmaf/master.m3u8">Apple's LL-HLS test stream, cmaf, fmp4</option>
     </optgroup>
   </select>
   <h3>Navigation</h3>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
       <option value="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd">Big Buck Bunny - demuxed audio/video, includes 4K, burns in frame, pts, resolution, bitrate values</option>
       <option value="https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd">Angel One - fmp4, webm, subs, alternate audio tracks</option>
       <option value="https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths/dash.mpd">BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4</option>
-value="https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd">SIDX demuxed, 2 audio</option>
+      <option value="https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd">SIDX demuxed, 2 audio</option>
       <option value="https://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-mpd-AV.mpd">SIDX bipbop-like</option>
       <option value="https://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-manifest.mpd">Google self-driving car - SIDX</option>
       <option value="https://d2zihajmogu5jn.cloudfront.net/sintel_dash/sintel_vod.mpd">Sintel - single rendition</option>

--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -10,18 +10,18 @@
   // get the sources list squared away
   var xhr = new window.XMLHttpRequest();
 
-  xhr.addEventListener('load', () => {
+  xhr.addEventListener('load', function() {
     var sources = JSON.parse(xhr.responseText);
 
-    sources.forEach((source) => {
+    sources.forEach(function(source) {
       const option = document.createElement('option');
 
       option.innerText = source.name;
       option.value = source.uri;
 
-      if (source.features.includes('low-latency')) {
+      if (source.features.indexOf('low-latency') !== -1) {
         llliveOptGroup.appendChild(option);
-      } else if (source.features.includes('live')) {
+      } else if (source.features.indexOf('live') !== -1) {
         liveOptGroup.appendChild(option);
       } else if (source.mimetype === 'application/x-mpegurl') {
         hlsOptGroup.appendChild(option);

--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -1,6 +1,34 @@
 /* global window document */
-/* eslint-disable no-var, object-shorthand, no-console */
+/* eslint-disable vars-on-top, no-var, object-shorthand, no-console */
 (function(window) {
+
+  const hlsOptGroup = document.querySelector('[label="hls"]');
+  const dashOptGroup = document.querySelector('[label="dash"]');
+  const liveOptGroup = document.querySelector('[label="live"]');
+  const llliveOptGroup = document.querySelector('[label="low latency live"]');
+
+  // get the sources list squared away
+  window.fetch('./scripts/sources.json')
+    .then((res) => res.json())
+    .then((sources) => {
+      sources.forEach((source) => {
+        const option = document.createElement('option');
+
+        option.innerText = source.name;
+        option.value = source.uri;
+
+        if (source.features.includes('low-latency')) {
+          llliveOptGroup.appendChild(option);
+        } else if (source.features.includes('live')) {
+          liveOptGroup.appendChild(option);
+        } else if (source.mimetype === 'application/x-mpegurl') {
+          hlsOptGroup.appendChild(option);
+        } else if (source.mimetype === 'application/dash+xml') {
+          dashOptGroup.appendChild(option);
+        }
+      });
+    });
+
   // all relevant elements
   var urlButton = document.getElementById('load-url');
   var sources = document.getElementById('load-source');

--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -2,32 +2,36 @@
 /* eslint-disable vars-on-top, no-var, object-shorthand, no-console */
 (function(window) {
 
-  const hlsOptGroup = document.querySelector('[label="hls"]');
-  const dashOptGroup = document.querySelector('[label="dash"]');
-  const liveOptGroup = document.querySelector('[label="live"]');
-  const llliveOptGroup = document.querySelector('[label="low latency live"]');
+  var hlsOptGroup = document.querySelector('[label="hls"]');
+  var dashOptGroup = document.querySelector('[label="dash"]');
+  var liveOptGroup = document.querySelector('[label="live"]');
+  var llliveOptGroup = document.querySelector('[label="low latency live"]');
 
   // get the sources list squared away
-  window.fetch('./scripts/sources.json')
-    .then((res) => res.json())
-    .then((sources) => {
-      sources.forEach((source) => {
-        const option = document.createElement('option');
+  var xhr = new window.XMLHttpRequest();
 
-        option.innerText = source.name;
-        option.value = source.uri;
+  xhr.addEventListener('load', () => {
+    var sources = JSON.parse(xhr.responseText);
 
-        if (source.features.includes('low-latency')) {
-          llliveOptGroup.appendChild(option);
-        } else if (source.features.includes('live')) {
-          liveOptGroup.appendChild(option);
-        } else if (source.mimetype === 'application/x-mpegurl') {
-          hlsOptGroup.appendChild(option);
-        } else if (source.mimetype === 'application/dash+xml') {
-          dashOptGroup.appendChild(option);
-        }
-      });
+    sources.forEach((source) => {
+      const option = document.createElement('option');
+
+      option.innerText = source.name;
+      option.value = source.uri;
+
+      if (source.features.includes('low-latency')) {
+        llliveOptGroup.appendChild(option);
+      } else if (source.features.includes('live')) {
+        liveOptGroup.appendChild(option);
+      } else if (source.mimetype === 'application/x-mpegurl') {
+        hlsOptGroup.appendChild(option);
+      } else if (source.mimetype === 'application/dash+xml') {
+        dashOptGroup.appendChild(option);
+      }
     });
+  });
+  xhr.open('GET', './scripts/sources.json');
+  xhr.send();
 
   // all relevant elements
   var urlButton = document.getElementById('load-url');

--- a/scripts/netlify.js
+++ b/scripts/netlify.js
@@ -15,6 +15,7 @@ const files = [
   'node_modules/videojs-http-source-selector/dist/videojs-http-source-selector.min.js',
   'node_modules/d3/d3.min.js',
   'logo.svg',
+  'scripts/sources.json',
   'scripts/index-demo-page.js'
 ];
 

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "Bipbop - Muxed TS with 1 alt Audio, 5 captions",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "FMP4 and ts both muxed",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/ts-fmp4/index.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Advanced Bipbop - ts and captions muxed",
+    "uri": "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Advanced Bipbop - FMP4 and captions muxed",
+    "uri": "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Advanced Bipbop - FMP4 hevc, demuxed",
+    "uri": "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Angel One - FMP4 demuxed, many audio/captions",
+    "uri": "https://storage.googleapis.com/shaka-demo-assets/angel-one-hls/hls.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Parkour - FMP4 demuxed",
+    "uri": "https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Song - ts Audio only",
+    "uri": "https://s3.amazonaws.com/qa.jwplayer.com/~alex/121628/new_master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Coit Tower drone footage - 4 8 second segment",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/CoitTower/master_ts_segtimes.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Disney's Oceans trailer - HLSe, ts Encrypted",
+    "uri": "https://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Sintel - ts with audio/subs and a 4k rendtion",
+    "uri": "https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Boat Ipsum Subs - HLS + subtitles",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/hls-webvtt/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Boat Video Only",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/video-only/out.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Boat Audio Only",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/audio-only/out.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Boat 4K",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/4k-hls/out.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Boat Misaligned - 3, 5, 7, second segment playlists",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/misaligned-playlists/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4",
+    "uri": "https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths-hls/hls.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Big Buck Bunny - demuxed audio/video, includes 4K, burns in frame, pts, resolution, bitrate values",
+    "uri": "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Angel One - fmp4, webm, subs, alternate audio tracks",
+    "uri": "https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4",
+    "uri": "https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths/dash.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "SIDX demuxed, 2 audio",
+    "uri": "https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "SIDX bipbop-like",
+    "uri": "https://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-mpd-AV.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Google self-driving car - SIDX",
+    "uri": "https://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-manifest.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Sintel - single rendition",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/sintel_dash/sintel_vod.mpd",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "HLS - Live - Axinom live stream, may not always be available",
+    "uri": "https://akamai-axtest.akamaized.net/routes/lapd-v1-acceptance/www_c4/Manifest.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": ["live"]
+  },
+  {
+    "name": "DASH - Live - Axinom live stream, may not always be available",
+    "uri": "https://akamai-axtest.akamaized.net/routes/lapd-v1-acceptance/www_c4/Manifest.mpd",
+    "mimetype": "application/dash+xml",
+    "features": ["live"]
+  },
+  {
+    "name": "DASH - Live simulated DASH from DASH IF",
+    "uri": "https://vm2.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd",
+    "mimetype": "application/dash+xml",
+    "features": ["live"]
+  },
+  {
+    "name": "DASH - Shaka Player Source Simulated Live",
+    "uri": "https://storage.googleapis.com/shaka-live-assets/player-source.mpd",
+    "mimetype": "application/dash+xml",
+    "features": ["live"]
+  },
+  {
+    "name": "Apple's LL-HLS test stream",
+    "uri": "https://ll-hls-test.apple.com/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": ["live", "low-latency"]
+  },
+  {
+    "name": "Apple's LL-HLS test stream, cmaf, fmp4",
+    "uri": "https://ll-hls-test.apple.com/cmaf/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": ["live", "low-latency"]
+  }
+]

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -104,43 +104,43 @@
   {
     "name": "Big Buck Bunny - demuxed audio/video, includes 4K, burns in frame, pts, resolution, bitrate values",
     "uri": "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {
     "name": "Angel One - fmp4, webm, subs, alternate audio tracks",
     "uri": "https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {
     "name": "BBB-CMIF: Big Buck Bunny Dark Truths - demuxed, fmp4",
     "uri": "https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths/dash.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {
     "name": "SIDX demuxed, 2 audio",
     "uri": "https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {
     "name": "SIDX bipbop-like",
     "uri": "https://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-mpd-AV.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {
     "name": "Google self-driving car - SIDX",
     "uri": "https://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-manifest.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {
     "name": "Sintel - single rendition",
     "uri": "https://d2zihajmogu5jn.cloudfront.net/sintel_dash/sintel_vod.mpd",
-    "mimetype": "application/x-mpegurl",
+    "mimetype": "application/dash+xml",
     "features": []
   },
   {


### PR DESCRIPTION
Move sources into a JSON file that we can use to populate the list. Eventually, we could have the features for each item be in the JSON file and then have a better UI on the demo page that would allow filtering by those features. Though, currently, the features are only used for the live and low-latency streams to move them into the live and low latency opt groups.