### PR TITLE
fix: Prevent switching to alternative audio causing infinite buffering

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -538,9 +538,9 @@ export default class SegmentLoader extends videojs.EventTarget {
 
   setAudio(enable) {
     this.audioDisabled_ = !enable;
-    if (enable) {
-      this.appendInitSegment_.audio = true;
-    } else {
+    this.appendInitSegment_.audio = enable;
+
+    if (!enable) {
       // remove current track audio if it gets disabled
       this.sourceUpdater_.removeAudio(0, this.duration_());
     }


### PR DESCRIPTION
## Description
Switching to alternative audio right now sometimes causes us to infinite buffer and the duration of the video doubles. This seems to be a fix for it. Tested using `Bipbop - Muxed TS with 1 alt Audio, 5 captions`
