### PR TITLE
fix: an issue with infinite playlist fetching/blacklisting

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -306,10 +306,10 @@ export default class PlaylistLoader extends EventTarget {
     const update = updateMaster(this.master, parser.manifest);
 
     this.targetDuration = parser.manifest.targetDuration;
+    this.media_ = this.master.playlists[id];
 
     if (update) {
       this.master = update;
-      this.media_ = this.master.playlists[id];
     } else {
       this.trigger('playlistunchanged');
     }


### PR DESCRIPTION
## Description
Pre-requisites:
Live stream that has no new segments (bad connection, stream suddenly ended without being marked as VOD) and multiple qualities. Example stream that can be used: https://playlists.mycujoo.football/staging/ec0a679a056f4921b1fe13469ecbeb67/master.m3u8
[See example](https://jsbin.com/dahajoruwi/1/edit?html,output)

Issue:
If no new segments are available the current playlist is blacklisted and then infinite switches of playlists is started, which creates tons of network requests causing big CPU spikes and browser crashes.

## Specific Changes proposed
Solution we found you can observe in this PR, please point me in a right direction if this solution is not correct or can cause other issues. With this change playlist switch/blacklist cycle happens once per second.

## Requirements Checklist
- [x] Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed (no tests are affected)
  - [ ] Docs/guides updated
  - [x] [Example created](https://jsbin.com/dahajoruwi/1/edit?html,output)
- [ ] Reviewed by Two Core Contributors
