### PR TITLE
fix: don't save segment timing info in sync controller for VTT segments

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -354,6 +354,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.state_ = 'INIT';
     this.handlePartialData_ = settings.handlePartialData;
     this.timelineChangeController_ = settings.timelineChangeController;
+    this.shouldSaveSegmentTimingInfo_ = true;
 
     // private instance variables
     this.checkBufferTimeout_ = null;
@@ -2477,7 +2478,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     // best to wait until all appends are done so we're sure that the primary media is
     // finished (and we have its end time).
     this.updateTimingInfoEnd_(segmentInfo);
-    this.syncController_.saveSegmentTimingInfo(segmentInfo);
+    if (this.shouldSaveSegmentTimingInfo_) {
+      this.syncController_.saveSegmentTimingInfo(segmentInfo);
+    }
 
     this.logger_(segmentInfoString(segmentInfo));
 

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -36,6 +36,10 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.loaderType_ = 'subtitle';
 
     this.featuresNativeTextTracks_ = settings.featuresNativeTextTracks;
+
+    // The VTT segment will have its own time mappings. Saving VTT segment timing info in
+    // the sync controller leads to improper behavior.
+    this.shouldSaveSegmentTimingInfo_ = false;
   }
 
   createTransmuxer_() {

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -772,5 +772,30 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
       assert.equal(errors, 1, 'loader triggered error when vtt.js load triggers error');
     });
 
+    QUnit.test('does not save segment timing info', function(assert) {
+      const playlist = playlistWithDuration(20);
+      const syncController = loader.syncController_;
+      let saveSegmentTimingInfoCalls = 0;
+      const origSaveSegmentTimingInfo =
+        syncController.saveSegmentTimingInfo.bind(syncController);
+
+      syncController.saveSegmentTimingInfo = (segmentInfo) => {
+        saveSegmentTimingInfoCalls++;
+        origSaveSegmentTimingInfo(segmentInfo);
+      };
+
+      loader.playlist(playlist);
+      loader.track(this.track);
+      loader.load();
+
+      this.clock.tick(1);
+
+      this.requests[0].responseType = 'arraybuffer';
+      this.requests.shift().respond(200, null, new Uint8Array(10).buffer);
+
+      this.clock.tick(1);
+
+      assert.equal(saveSegmentTimingInfoCalls, 0, 'no calls to save timing info');
+    });
   });
 });


### PR DESCRIPTION
The VTT loader maintains its own time mappings. Saving the timing info
on the segments and in the sync controller can negatively impact stream
sync, especially for VTT.

Prior to transmux before append, this timing info wasn't saved. It was
inadvertently added as the segment loader methods were refactored.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
