### PR TITLE
fix: #826 depends on existence of DOM/document

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -265,6 +265,10 @@ const expandDataUri = (dataUri) => {
  * Whether the browser has built-in HLS support.
  */
 Hls.supportsNativeHls = (function() {
+  if (!document || !document.createElement) {
+    return false;
+  }
+  
   const video = document.createElement('video');
 
   // native HLS is definitely not supported if HTML5 video isn't
@@ -294,7 +298,7 @@ Hls.supportsNativeHls = (function() {
 }());
 
 Hls.supportsNativeDash = (function() {
-  if (!videojs.getTech('Html5').isSupported()) {
+  if (!document || !document.createElement || !videojs.getTech('Html5').isSupported()) {
     return false;
   }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -268,7 +268,7 @@ Hls.supportsNativeHls = (function() {
   if (!document || !document.createElement) {
     return false;
   }
-  
+
   const video = document.createElement('video');
 
   // native HLS is definitely not supported if HTML5 video isn't


### PR DESCRIPTION
## Description
Remove assumption that this library is starting up inside of a DOM environment. Many circumstances involve including a library like this one including pre-rendering of a subset of routes, etc., that may not actually activate the library itself.

Fixes #826 

## Specific Changes proposed
- Returns `false` for support checks on video formats when the DOM itself does not exist.

Code change is trivial so tests were not implemented (also, `document` cannot exist for the test to occur).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
