### PR TITLE
feat: Use playback watcher to watch when progress isn't being made

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -233,7 +233,7 @@ export default class PlaybackWatcher {
     // TODO: should we exclude audio tracks rather than main tracks
     // when type is audio?
     mpc.blacklistCurrentPlaylist({
-      message: `Infinite ${type} segment downloading detected.`
+      message: `Excessive ${type} segment downloading detected.`
     }, Infinity);
   }
 

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -11,6 +11,7 @@
 import window from 'global/window';
 import * as Ranges from './ranges';
 import logger from './util/logger';
+import videojs from 'video.js';
 
 // Set of events that reset the playback-watcher time check logic and clear the timeout
 const timerCancelEvents = [
@@ -71,6 +72,7 @@ export default class PlaybackWatcher {
    * @param {Object} options an object that includes the tech and settings
    */
   constructor(options) {
+    this.masterPlaylistController_ = options.masterPlaylistController;
     this.tech_ = options.tech;
     this.seekable = options.seekable;
     this.seekTo = options.seekTo;
@@ -90,6 +92,22 @@ export default class PlaybackWatcher {
     const cancelTimerHandler = () => this.cancelTimer_();
     const fixesBadSeeksHandler = () => this.fixesBadSeeks_();
 
+    const mpc = this.masterPlaylistController_;
+
+    const loaderTypes = ['main', 'subtitle', 'audio'];
+    const loaderChecks = {};
+
+    loaderTypes.forEach((type) => {
+      loaderChecks[type] = {
+        reset: () => this.resetSegmentDownloads_(type),
+        updateend: () => this.checkSegmentDownloads_(type)
+      };
+
+      mpc[`${type}SegmentLoader_`].on('updateend', loaderChecks[type].updateend);
+      mpc[`${type}SegmentLoader_`].on('playlist-update', loaderChecks[type].reset);
+      this.tech_.on(['seeked', 'seeking'], loaderChecks[type].reset);
+    });
+
     this.tech_.on('seekablechanged', fixesBadSeeksHandler);
     this.tech_.on('waiting', waitingHandler);
     this.tech_.on(timerCancelEvents, cancelTimerHandler);
@@ -102,6 +120,12 @@ export default class PlaybackWatcher {
       this.tech_.off('waiting', waitingHandler);
       this.tech_.off(timerCancelEvents, cancelTimerHandler);
       this.tech_.off('canplay', canPlayHandler);
+
+      loaderTypes.forEach((type) => {
+        mpc[`${type}SegmentLoader_`].off('updateend', loaderChecks[type].updateend);
+        mpc[`${type}SegmentLoader_`].off('playlist-update', loaderChecks[type].reset);
+        this.tech_.off(['seeked', 'seeking'], loaderChecks[type].reset);
+      });
       if (this.checkCurrentTimeTimeout_) {
         window.clearTimeout(this.checkCurrentTimeTimeout_);
       }
@@ -124,6 +148,75 @@ export default class PlaybackWatcher {
     // 42 = 24 fps // 250 is what Webkit uses // FF uses 15
     this.checkCurrentTimeTimeout_ =
       window.setTimeout(this.monitorCurrentTime_.bind(this), 250);
+  }
+
+  /**
+   * Reset stalled download stats for a specific type of loader
+   *
+   * @param {string} type
+   *        Whether to check the audio or main segment loader.
+   */
+  resetSegmentDownloads_(type) {
+    const loader = this.masterPlaylistController_[`${type}SegmentLoader_`];
+
+    if (this[`${type}StalledDownloads_`] > 0) {
+      this.logger_(`reseting stalled downloads for ${type} loader`);
+    }
+    this[`${type}StalledDownloads_`] = 0;
+    this[`${type}Buffered_`] = loader.buffered_();
+  }
+
+  /**
+   * Checks on every main/audio segment `appended` to see
+   * if segment appends are making progress. If they are not
+   * and we are still downloading bytes. We blacklist the playlist.
+   *
+   * @param {string} type
+   *        Whether to check the audio or main segment loader.
+   */
+  checkSegmentDownloads_(type) {
+    const mpc = this.masterPlaylistController_;
+    const loader = mpc[`${type}SegmentLoader_`];
+    const buffered = loader.buffered_();
+    const isBufferedDifferent = Ranges.isRangeDifferent(this[`${type}Buffered_`], buffered);
+
+    this[`${type}Buffered_`] = buffered;
+
+    // if another watcher is going to fix the issue or
+    // the buffered value for this loader changed
+    // appends are working
+    if (isBufferedDifferent) {
+      this.resetSegmentDownloads_(type);
+      return;
+    }
+
+    this[`${type}StalledDownloads_`]++;
+
+    this.logger_(`found stalled download #${this[`${type}StalledDownloads_`]} for ${type} loader`);
+    // We will technically get past this on the fourth bad append
+    // rather than the third. As the first will almost always cause
+    // buffered to change which means that StalledDownloads_ will
+    // not be incremented
+    if (this[`${type}StalledDownloads_`] < 3) {
+      return;
+    }
+
+    this.logger_(`${type} loader download exclusion`);
+    this.resetSegmentDownloads_(type);
+    this.tech_.trigger({type: 'usage', name: `vhs-${type}-download-exclusion`});
+
+    if (type !== 'subtitle') {
+      mpc.blacklistCurrentPlaylist({
+        message: `Infinite ${type} segment downloading detected.`
+      }, Infinity);
+    } else {
+      const track = loader.track();
+      const label = track.label || track.language || 'Unknown';
+
+      videojs.log.warn(`Text track "${label}" is not working correctly. It will be disabled and excluded.`);
+      track.mode = 'disabled';
+      this.tech_.textTracks().removeTrack(track);
+    }
   }
 
   /**
@@ -351,6 +444,8 @@ export default class PlaybackWatcher {
 
       this.logger_(`Stopped at ${currentTime}, setting timer for ${difference}, seeking ` +
         `to ${nextRange.start(0)}`);
+
+      this.cancelTimer_();
 
       this.timer_ = setTimeout(
         this.skipTheGap_.bind(this),

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -396,3 +396,44 @@ export const timeRangesToArray = (timeRanges) => {
 
   return timeRangesList;
 };
+
+/**
+ * Determines if two time range objects are different.
+ *
+ * @param {TimeRange} a
+ *        the first buffered object to check
+ *
+ * @param {TimeRange} b
+ *        the second buffered object to check
+ *
+ * @return {Boolean}
+ *         Whether the time range objects differ
+ */
+
+export const isRangeDifferent = function(a, b) {
+  // same object
+  if (a === b) {
+    return false;
+  }
+
+  // one or the other is undefined
+  if (!a && b || (!b && a)) {
+    return true;
+  }
+
+  // length is different
+  if (a.length !== b.length) {
+    return true;
+  }
+
+  // see if any start/end pair is different
+  for (let i = 0; i < a.length; i++) {
+    if (a.start(i) !== b.start(i) || a.end(i) !== b.end(i)) {
+      return true;
+    }
+  }
+
+  // if the length and every pair is the same
+  // this is the same buffered
+  return false;
+};

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -401,10 +401,10 @@ export const timeRangesToArray = (timeRanges) => {
  * Determines if two time range objects are different.
  *
  * @param {TimeRange} a
- *        the first buffered object to check
+ *        the first time range object to check
  *
  * @param {TimeRange} b
- *        the second buffered object to check
+ *        the second time range object to check
  *
  * @return {Boolean}
  *         Whether the time range objects differ
@@ -434,6 +434,6 @@ export const isRangeDifferent = function(a, b) {
   }
 
   // if the length and every pair is the same
-  // this is the same buffered
+  // this is the same time range
   return false;
 };

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -833,6 +833,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (!oldPlaylist || oldPlaylist.uri !== newPlaylist.uri) {
+      this.trigger('playlist-update');
       if (this.mediaIndex !== null || this.handlePartialData_) {
         // we must "resync" the segment loader when we switch renditions and
         // the segment loader is already synced to the previous rendition
@@ -2470,6 +2471,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
   handleAppendsDone_() {
+    this.trigger('updateend');
     if (!this.pendingSegment_) {
       this.state = 'READY';
       // TODO should this move into this.checkForAbort to speed up requests post abort in

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -833,7 +833,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (!oldPlaylist || oldPlaylist.uri !== newPlaylist.uri) {
-      this.trigger('playlist-update');
+      this.trigger('playlistupdate');
       if (this.mediaIndex !== null || this.handlePartialData_) {
         // we must "resync" the segment loader when we switch renditions and
         // the segment loader is already synced to the previous rendition
@@ -2471,7 +2471,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
   handleAppendsDone_() {
-    this.trigger('updateend');
+    this.trigger('appendsdone');
     if (!this.pendingSegment_) {
       this.state = 'READY';
       // TODO should this move into this.checkForAbort to speed up requests post abort in

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -511,7 +511,8 @@ class HlsHandler extends Component {
     this.masterPlaylistController_ = new MasterPlaylistController(this.options_);
     this.playbackWatcher_ = new PlaybackWatcher(videojs.mergeOptions(this.options_, {
       seekable: () => this.seekable(),
-      media: () => this.masterPlaylistController_.media()
+      media: () => this.masterPlaylistController_.media(),
+      masterPlaylistController: this.masterPlaylistController_
     }));
 
     this.masterPlaylistController_.on('error', () => {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -517,8 +517,15 @@ class HlsHandler extends Component {
 
     this.masterPlaylistController_.on('error', () => {
       const player = videojs.players[this.tech_.options_.playerId];
+      let error = this.masterPlaylistController_.error;
 
-      player.error(this.masterPlaylistController_.error);
+      if (typeof error === 'object' && !error.code) {
+        error.code = 3;
+      } else if (typeof error === 'string') {
+        error = {message: error, code: 3};
+      }
+
+      player.error(error);
     });
 
     // `this` in selectPlaylist should be the HlsHandler for backwards

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -910,7 +910,7 @@ loaderTypes.forEach(function(type) {
 
         if (otherPlaylistsLeft) {
           const message = `Problem encountered with playlist ${oldPlaylist.id}.` +
-            ` Infinite ${type} segment downloading detected.` +
+            ` Excessive ${type} segment downloading detected.` +
             ` Switching to playlist ${this.mpc.media().id}.`;
 
           assert.equal(this.mpcErrors, 0, 'no mpc error');

--- a/test/ranges.test.js
+++ b/test/ranges.test.js
@@ -47,6 +47,41 @@ QUnit.test('finds overlapping time ranges when off by SAFE_TIME_DELTA', function
   assert.equal(range.end(0), 12, 'inside the second buffered region');
 });
 
+QUnit.test('detects when time ranges differ', function(assert) {
+  const isDifferent = Ranges.isRangeDifferent;
+  const same = createTimeRanges([[0, 1]]);
+
+  assert.notOk(isDifferent(same, same), 'same object is not different');
+  assert.notOk(
+    isDifferent(null, null),
+    'null and null are not different'
+  );
+  assert.ok(
+    isDifferent(createTimeRanges([[0, 1], [1, 2]]), null),
+    'valid and null are different'
+  );
+
+  assert.ok(
+    isDifferent(createTimeRanges([[0, 1]]), createTimeRanges([[0, 1], [1, 2]])),
+    'objects with different length are different'
+  );
+
+  assert.ok(
+    isDifferent(createTimeRanges([[1, 2], [1, 2]]), createTimeRanges([[0, 1], [1, 2]])),
+    'objects with different values are different'
+  );
+
+  assert.ok(
+    isDifferent(null, createTimeRanges([[0, 1], [1, 2]])),
+    'null object and valid are different'
+  );
+
+  assert.ok(
+    isDifferent(createTimeRanges([[0, 1], [1, 2]]), null),
+    'valid and null are different'
+  );
+});
+
 QUnit.module('Buffer Inpsection');
 
 QUnit.test('detects time range end-point changed by updates', function(assert) {


### PR DESCRIPTION
## Description
Tested using the issue from #823. I also tested that this code does not blacklist playlists with large content on slow network connections. IE throttle network to 10mb/s in chrome and select the 4k boat source.

## Testing
1. `npm install mux.js@5.5.3` and use `https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8`. Skip to the middle of the video and change audio tracks. Before we would infinite download audio, now we blacklist until everything stops.
2. comment out `this.shouldSaveSegmentTimingInfo = false` in `vtt-segment-loader.js`. Run the axiom live stream, not that the text track is excluded after some time as it isn't making any progress.
3. Test with a playlist that has gaps to verify that nothing is excluded. 
4. Tested with a playlist that has one vtt for the entire video and make sure nothing is excluded.