### PR TITLE
chore(package): update muxjs to 5.6.1 to fix small 708 caption issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6852,9 +6852,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.0.tgz",
-      "integrity": "sha512-Au4Ch/wVK3FgOAeGXflO0As/mE063pqF9h+AgndeD/bo2MEDKW0A9U+Cr+t2id1dOy4mWADrg1pAYsl06et0Uw=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.1.tgz",
+      "integrity": "sha512-iIE3EJURbrPZ9Y4i9ADKTIvxGUcAEBOFhwWUOZGCiKlpXDZrqDgcJLDrOa0PenLhw6WYkOyl18kHFEvwm9JSpg=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "global": "^4.3.2",
     "m3u8-parser": "4.4.2",
     "mpd-parser": "0.10.1",
-    "mux.js": "5.6.0",
+    "mux.js": "5.6.1",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Saw an issue when running tests manually, caused by a bug in muxjs. This update fixes it.
