### PR TITLE
chore(mpd): add comment with full name of loader stats methods

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -222,6 +222,12 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.setupSegmentLoaderListeners_();
 
     // Create SegmentLoader stat-getters
+    // mediaRequests_
+    // mediaRequestsAborted_
+    // mediaRequestsTimedout_
+    // mediaRequestsErrored_
+    // mediaTransferDuration_
+    // mediaBytesTransferred_
     loaderStats.forEach((stat) => {
       this[stat + '_'] = sumLoaderStat.bind(this, stat);
     });


### PR DESCRIPTION
It's hard to find where loader stats methods are created because we do
it dynamically.

Add a comment with the full name of the loader stats methods so that
they can be searched directly.