### PR TITLE
fix: only save timeline mappings for main loader

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -2479,7 +2479,27 @@ export default class SegmentLoader extends videojs.EventTarget {
     // finished (and we have its end time).
     this.updateTimingInfoEnd_(segmentInfo);
     if (this.shouldSaveSegmentTimingInfo_) {
-      this.syncController_.saveSegmentTimingInfo(segmentInfo);
+      // Timeline mappings should only be saved for the main loader. This is for multiple
+      // reasons:
+      //
+      // 1) Only one mapping is saved per timeline, meaning that if both the audio loader
+      //    and the main loader try to save the timeline mapping, whichever comes later
+      //    will overwrite the first. In theory this is OK, as the mappings should be the
+      //    same, however, it breaks for (2)
+      // 2) In the event of a live stream, the initial live point will make for a somewhat
+      //    arbitrary mapping. If audio and video streams are not perfectly in-sync, then
+      //    the mapping will be off for one of the streams, dependent on which one was
+      //    first saved (see (1)).
+      // 3) Primary timing goes by video in VHS, so the mapping should be video.
+      //
+      // Since the audio loader will wait for the main loader to load the first segment,
+      // the main loader will save the first timeline mapping, and ensure that there won't
+      // be a case where audio loads two segments without saving a mapping (thus leading
+      // to missing segment timing info).
+      this.syncController_.saveSegmentTimingInfo({
+        segmentInfo,
+        shouldSaveTimelineMapping: this.loaderType_ === 'main'
+      });
     }
 
     this.logger_(segmentInfoString(segmentInfo));

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -286,7 +286,7 @@ QUnit.test('saves segment timing info', function(assert) {
   };
 
   updateTimingInfo(segmentInfo);
-  syncCon.saveSegmentTimingInfo(segmentInfo);
+  syncCon.saveSegmentTimingInfo({ segmentInfo, shouldSaveTimelineMapping: true });
   assert.ok(syncCon.timelines[0], 'created mapping object for timeline 0');
   assert.deepEqual(
     syncCon.timelines[0], { time: 0, mapping: -5 },
@@ -307,7 +307,7 @@ QUnit.test('saves segment timing info', function(assert) {
   segmentInfo.segment = segment;
 
   updateTimingInfo(segmentInfo);
-  syncCon.saveSegmentTimingInfo(segmentInfo);
+  syncCon.saveSegmentTimingInfo({ segmentInfo, shouldSaveTimelineMapping: true });
   assert.equal(segment.start, 10, 'correctly calculated segment start');
   assert.equal(segment.end, 20, 'correctly calculated segment end');
   assert.deepEqual(
@@ -323,7 +323,7 @@ QUnit.test('saves segment timing info', function(assert) {
   segmentInfo.segment = segment;
 
   updateTimingInfo(segmentInfo);
-  syncCon.saveSegmentTimingInfo(segmentInfo);
+  syncCon.saveSegmentTimingInfo({ segmentInfo, shouldSaveTimelineMapping: true });
   assert.ok(syncCon.timelines[1], 'created mapping object for timeline 1');
   assert.deepEqual(
     syncCon.timelines[1], { time: 30, mapping: -11 },

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -779,9 +779,12 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
       const origSaveSegmentTimingInfo =
         syncController.saveSegmentTimingInfo.bind(syncController);
 
-      syncController.saveSegmentTimingInfo = (segmentInfo) => {
+      syncController.saveSegmentTimingInfo = ({
+        segmentInfo,
+        shouldSaveTimelineMapping
+      }) => {
         saveSegmentTimingInfoCalls++;
-        origSaveSegmentTimingInfo(segmentInfo);
+        origSaveSegmentTimingInfo({ segmentInfo, shouldSaveTimelineMapping });
       };
 
       loader.playlist(playlist);


### PR DESCRIPTION
## Description
Timeline mappings should only be saved for the main loader. This is for multiple
reasons:

1) Only one mapping is saved per timeline, meaning that if both the audio loader
   and the main loader try to save the timeline mapping, whichever comes later
   will overwrite the first. In theory this is OK, as the mappings should be the
   same, however, it breaks for (2)
2) In the event of a live stream, the initial live point will make for a somewhat
   arbitrary mapping. If audio and video streams are not perfectly in-sync, then
   the mapping will be off for one of the streams, dependent on which one was
   first saved (see (1)).
3) Primary timing goes by video in VHS, so the mapping should be video.

Since the audio loader will wait for the main loader to load the first segment,
the main loader will save the first timeline mapping, and ensure that there won't
be a case where audio loads two segments without saving a mapping (thus leading
to missing segment timing info).

In addition, this PR adds a playback watcher check to correct cases where seek point ends up just before content. If audio and video streams are not perfectly aligned, a seek can result in the buffer starting just after the seek position. In that event, playback watcher should seek into the buffered contents to resume playback.

Source used for these changes was the Axinom HLS live stream: https://akamai-axtest.akamaized.net/routes/lapd-v1-acceptance/www_c4/Manifest.m3u8

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
