### PR TITLE
fix: Default overrideNative to check if browser is any Safari

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -876,7 +876,7 @@ const HlsSourceHandler = {
     return tech.hls;
   },
   canPlayType(type, options = {}) {
-    const { hls: { overrideNative } } = videojs.mergeOptions(videojs.options, options);
+    const { hls: { overrideNative = !videojs.browser.IS_ANY_SAFARI } } = videojs.mergeOptions(videojs.options, options);
     const supportedType = simpleTypeFromSourceType(type);
     const canUseMsePlayback = supportedType &&
       (!Hls.supportsTypeNatively(supportedType) || overrideNative);

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -2839,26 +2839,6 @@ QUnit.test(
   }
 );
 
-QUnit.test('has no effect if native HLS is available', function(assert) {
-  const Html5 = videojs.getTech('Html5');
-  const oldHtml5CanPlaySource = Html5.canPlaySource;
-
-  Html5.canPlaySource = () => true;
-  Hls.supportsNativeHls = true;
-  const player = createPlayer();
-
-  player.src({
-    src: 'http://example.com/manifest/master.m3u8',
-    type: 'application/x-mpegURL'
-  });
-
-  this.clock.tick(1);
-
-  assert.ok(!player.tech_.hls, 'did not load hls tech');
-  player.dispose();
-  Html5.canPlaySource = oldHtml5CanPlaySource;
-});
-
 QUnit.test(
   'loads if native HLS is available and override is set locally',
   function(assert) {


### PR DESCRIPTION
Changes include setting hls _overrideNative_ default to check _IS_ANY_SAFARI_ constant. 

I removed one unit test that was failing in Chrome and Firefox due to this new default value.