### PR TITLE
fix: Use revokeObjectURL dispose for created MSE blob urls

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -746,7 +746,9 @@ class VhsHandler extends Component {
       return;
     }
 
-    this.tech_.src(window.URL.createObjectURL(this.masterPlaylistController_.mediaSource));
+    this.mediaSourceUrl_ = window.URL.createObjectURL(this.masterPlaylistController_.mediaSource);
+
+    this.tech_.src(this.mediaSourceUrl_);
   }
 
   /**
@@ -850,6 +852,11 @@ class VhsHandler extends Component {
     // don't check this.tech_.hls as it will log a deprecated warning
     if (this.tech_) {
       delete this.tech_.hls;
+    }
+
+    if (this.mediaSourceUrl_ && window.URL.revokeObjectURL) {
+      window.URL.revokeObjectURL(this.mediaSourceUrl_);
+      this.mediaSourceUrl_ = null;
     }
 
     super.dispose();


### PR DESCRIPTION
Prevents a memory leak that we have right now, caused by not revoking urls that we create.