### PR TITLE
feat: Easier manually playlist switching, add codecs to renditions

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -597,15 +597,15 @@ export class MasterPlaylistController extends videojs.EventTarget {
    *
    * @private
    */
-  smoothQualityChange_() {
-    const media = this.selectPlaylist();
-
-    if (media !== this.masterPlaylistLoader_.media()) {
-      this.masterPlaylistLoader_.media(media);
-
-      this.mainSegmentLoader_.resetLoader();
-      // don't need to reset audio as it is reset when media changes
+  smoothQualityChange_(media = this.selectPlaylist()) {
+    if (media === this.masterPlaylistLoader_.media()) {
+      return;
     }
+
+    this.masterPlaylistLoader_.media(media);
+
+    this.mainSegmentLoader_.resetLoader();
+    // don't need to reset audio as it is reset when media changes
   }
 
   /**
@@ -616,9 +616,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
    *
    * @private
    */
-  fastQualityChange_() {
-    const media = this.selectPlaylist();
-
+  fastQualityChange_(media = this.selectPlaylist()) {
     if (media === this.masterPlaylistLoader_.media()) {
       return;
     }

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -1,4 +1,5 @@
 import { isIncompatible, isEnabled } from './playlist.js';
+import { codecsForPlaylist } from './util/codecs.js';
 
 /**
  * Returns a function that acts as the Enable/disable playlist function.
@@ -66,9 +67,7 @@ class Representation {
 
     this.bandwidth = playlist.attributes.BANDWIDTH;
 
-    if (playlist.attributes.CODECS) {
-      this.codecs = playlist.attributes.CODECS;
-    }
+    this.codecs = codecsForPlaylist(mpc.master(), playlist);
 
     this.playlist = playlist;
 

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -66,6 +66,12 @@ class Representation {
 
     this.bandwidth = playlist.attributes.BANDWIDTH;
 
+    if (playlist.attributes.CODECS) {
+      this.codecs = playlist.attributes.CODECS;
+    }
+
+    this.playlist = playlist;
+
     // The id is simply the ordinality of the media playlist
     // within the master playlist
     this.id = id;

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -343,6 +343,33 @@ QUnit.test(
   }
 );
 
+QUnit.test('playlist is exposed on renditions', function(assert) {
+  const vhsHandler = makeMockVhsHandler([
+    {
+      bandwidth: 0,
+      uri: 'media0.m3u8',
+      codecs: 'mp4a.40.2'
+    },
+    {
+      bandwidth: 0,
+      uri: 'media1.m3u8',
+      codecs: 'mp4a.40.5'
+    },
+    {
+      bandwidth: 0,
+      uri: 'media2.m3u8'
+    }
+  ]);
+
+  RenditionMixin(vhsHandler);
+
+  const renditions = vhsHandler.representations();
+
+  assert.deepEqual(renditions[0].playlist, vhsHandler.playlists.master.playlists[0], 'rendition 1 has correct codec');
+  assert.deepEqual(renditions[1].playlist, vhsHandler.playlists.master.playlists[1], 'rendition 2 has correct codec');
+  assert.deepEqual(renditions[2].playlist, vhsHandler.playlists.master.playlists[2], 'rendition 3 has no codec');
+});
+
 QUnit.test('codecs attribute is exposed on renditions when available', function(assert) {
   const vhsHandler = makeMockVhsHandler([
     {
@@ -359,9 +386,7 @@ QUnit.test('codecs attribute is exposed on renditions when available', function(
       bandwidth: 0,
       uri: 'media2.m3u8'
     }
-  ], {
-    smoothQualityChange: true
-  });
+  ]);
 
   RenditionMixin(vhsHandler);
 
@@ -379,9 +404,7 @@ QUnit.test('codecs attribute gets codecs from master', function(assert) {
       uri: 'media0.m3u8',
       audio: 'a1'
     }
-  ], {
-    smoothQualityChange: true
-  });
+  ]);
   const mpc = vhsHandler.masterPlaylistController_;
 
   mpc.master = () => {

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -13,6 +13,14 @@ const makeMockPlaylist = function(options) {
 
   playlist.attributes.BANDWIDTH = options.bandwidth;
 
+  if ('codecs' in options) {
+    playlist.attributes.CODECS = options.codecs;
+  }
+
+  if ('audio' in options) {
+    playlist.attributes.AUDIO = options.audio;
+  }
+
   if ('width' in options) {
     playlist.attributes.RESOLUTION = playlist.attributes.RESOLUTION || {};
 
@@ -41,20 +49,23 @@ const makeMockPlaylist = function(options) {
 };
 
 const makeMockVhsHandler = function(playlistOptions, handlerOptions) {
-  const mcp = {
+  const mpc = {
     fastQualityChange_: () => {
-      mcp.fastQualityChange_.calls++;
+      mpc.fastQualityChange_.calls++;
     },
     smoothQualityChange_: () => {
-      mcp.smoothQualityChange_.calls++;
+      mpc.smoothQualityChange_.calls++;
+    },
+    master: () => {
+      return {};
     }
   };
 
-  mcp.fastQualityChange_.calls = 0;
-  mcp.smoothQualityChange_.calls = 0;
+  mpc.fastQualityChange_.calls = 0;
+  mpc.smoothQualityChange_.calls = 0;
 
   const vhsHandler = {
-    masterPlaylistController_: mcp,
+    masterPlaylistController_: mpc,
     options_: handlerOptions || {}
   };
 
@@ -331,3 +342,69 @@ QUnit.test(
     assert.equal(mpc.smoothQualityChange_.calls, 2, 'smoothQualityChange_ was called twice');
   }
 );
+
+QUnit.test('codecs attribute is exposed on renditions when available', function(assert) {
+  const vhsHandler = makeMockVhsHandler([
+    {
+      bandwidth: 0,
+      uri: 'media0.m3u8',
+      codecs: 'mp4a.40.2'
+    },
+    {
+      bandwidth: 0,
+      uri: 'media1.m3u8',
+      codecs: 'mp4a.40.5'
+    },
+    {
+      bandwidth: 0,
+      uri: 'media2.m3u8'
+    }
+  ], {
+    smoothQualityChange: true
+  });
+
+  RenditionMixin(vhsHandler);
+
+  const renditions = vhsHandler.representations();
+
+  assert.deepEqual(renditions[0].codecs, {audio: 'mp4a.40.2'}, 'rendition 1 has correct codec');
+  assert.deepEqual(renditions[1].codecs, {audio: 'mp4a.40.5'}, 'rendition 2 has correct codec');
+  assert.deepEqual(renditions[2].codecs, {}, 'rendition 3 has no codec');
+});
+
+QUnit.test('codecs attribute gets codecs from master', function(assert) {
+  const vhsHandler = makeMockVhsHandler([
+    {
+      bandwidth: 0,
+      uri: 'media0.m3u8',
+      audio: 'a1'
+    }
+  ], {
+    smoothQualityChange: true
+  });
+  const mpc = vhsHandler.masterPlaylistController_;
+
+  mpc.master = () => {
+    return {
+      mediaGroups: {
+        AUDIO: {
+          a1: {
+            eng: {
+              default: true,
+              uri: 'audio.m3u8',
+              playlists: [
+                {attributes: {CODECS: 'mp4a.40.2'}}
+              ]
+            }
+          }
+        }
+      }
+    };
+  };
+
+  RenditionMixin(vhsHandler);
+
+  const renditions = vhsHandler.representations();
+
+  assert.deepEqual(renditions[0].codecs, {audio: 'mp4a.40.2'}, 'rendition 1 has correct codec');
+});

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -365,9 +365,9 @@ QUnit.test('playlist is exposed on renditions', function(assert) {
 
   const renditions = vhsHandler.representations();
 
-  assert.deepEqual(renditions[0].playlist, vhsHandler.playlists.master.playlists[0], 'rendition 1 has correct codec');
-  assert.deepEqual(renditions[1].playlist, vhsHandler.playlists.master.playlists[1], 'rendition 2 has correct codec');
-  assert.deepEqual(renditions[2].playlist, vhsHandler.playlists.master.playlists[2], 'rendition 3 has no codec');
+  assert.deepEqual(renditions[0].playlist, vhsHandler.playlists.master.playlists[0], 'rendition 1 has correct playlist');
+  assert.deepEqual(renditions[1].playlist, vhsHandler.playlists.master.playlists[1], 'rendition 2 has correct playlist');
+  assert.deepEqual(renditions[2].playlist, vhsHandler.playlists.master.playlists[2], 'rendition 3 has no playlist');
 });
 
 QUnit.test('codecs attribute is exposed on renditions when available', function(assert) {


### PR DESCRIPTION
Right now we don't have a great way to manually switch playlists without calling `blacklistCurrentPlaylist` and hoping for the best or using the renditions api to exclude all renditions that we don't want. This change allows us to pass a playlist into `smoothQualityChange_` and `fastQualityChange_` so that we can directly change to the playlist we want. It also adds playlist codecs to the rendition API.