### PR TITLE
chore: fix demo page on firefox, always use vhs on safari

### DIFF
--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -256,7 +256,7 @@
           liveui: stateEls.liveui.checked,
           html5: {
             hls: {
-              overrideNative: !window.videojs.browser.IS_SAFARI
+              overrideNative: true
             }
           }
         });
@@ -322,6 +322,10 @@
 
     sources.addEventListener('change', function(event) {
       var selectedOption = sources.options[sources.selectedIndex];
+
+      if (!selectedOption) {
+        return;
+      }
       var src = selectedOption.value;
 
       stateEls.url.value = src;


### PR DESCRIPTION
## Description
Fixes an issue the test page currently has on firefox, forces vhs to be used on the test page for safari. 
