### PR TITLE
fix: Fixed issue with MPEG-Dash MPD Playlist Finalisation during Live Play.

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -744,6 +744,8 @@ export default class DashPlaylistLoader extends EventTarget {
                 // update loader's sidxMapping with parsed sidx box
                 this.sidxMapping_[sidxKey].sidx = sidx;
 
+                // Clear & reset timeout with new minimumUpdatePeriod
+                window.clearTimeout(this.minimumUpdatePeriodTimeout_);
                 if (this.master.minimumUpdatePeriod) {
                   this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
                     this.trigger('minimumUpdatePeriod');
@@ -765,6 +767,8 @@ export default class DashPlaylistLoader extends EventTarget {
         }
       }
 
+      // Clear & reset timeout with new minimumUpdatePeriod
+      window.clearTimeout(this.minimumUpdatePeriodTimeout_);
       if (this.master.minimumUpdatePeriod) {
         this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
           this.trigger('minimumUpdatePeriod');

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -744,9 +744,11 @@ export default class DashPlaylistLoader extends EventTarget {
                 // update loader's sidxMapping with parsed sidx box
                 this.sidxMapping_[sidxKey].sidx = sidx;
 
-                this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
-                  this.trigger('minimumUpdatePeriod');
-                }, this.master.minimumUpdatePeriod);
+                if (this.master.minimumUpdatePeriod) {
+                  this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
+                    this.trigger('minimumUpdatePeriod');
+                  }, this.master.minimumUpdatePeriod);
+                }
 
                 // TODO: do we need to reload the current playlist?
                 this.refreshMedia_(this.media().id);
@@ -763,9 +765,11 @@ export default class DashPlaylistLoader extends EventTarget {
         }
       }
 
-      this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
-        this.trigger('minimumUpdatePeriod');
-      }, this.master.minimumUpdatePeriod);
+      if (this.master.minimumUpdatePeriod) {
+        this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
+          this.trigger('minimumUpdatePeriod');
+        }, this.master.minimumUpdatePeriod);
+      }
     });
   }
 


### PR DESCRIPTION
## Description
Fixed issue  (#873) with MPEG-Dash MPD Playlist Finalisation during Live Play.

## Specific Changes proposed
Stop `refreshXml_` if received `minimumUpdatePeriod` is equal to 0 (i.e. not present in updated mpd)

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
