### PR TITLE
fix: use TIME_FUDGE_FACTOR rather than rounding by decimal digits

### DIFF
--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -1226,6 +1226,98 @@ QUnit.test(
   }
 );
 
+QUnit.test('rounding down works', function(assert) {
+  const loader = new PlaylistLoader('media.m3u8', this.fakeVhs);
+
+  loader.load();
+
+  this.requests.shift().respond(
+    200, null,
+    '#EXTM3U\n' +
+    '#EXT-X-MEDIA-SEQUENCE:0\n' +
+    '#EXTINF:2,\n' +
+    '0.ts\n' +
+    '#EXTINF:2,\n' +
+    '1.ts\n' +
+    '#EXTINF:2,\n' +
+    '2.ts\n' +
+    '#EXTINF:2,\n' +
+    '3.ts\n' +
+    '#EXTINF:2,\n' +
+    '4.ts\n' +
+    '#EXTINF:2,\n' +
+    '5.ts\n' +
+    '#EXT-X-ENDLIST\n'
+  );
+
+  const media = loader.media();
+  const fn = Playlist.getMediaInfoForTime;
+
+  // 1 segment away
+  assert.equal(fn(media, 2.1, 0, 0).mediaIndex, 1, '1 away 2 is correct');
+  assert.equal(fn(media, 4.1, 1, 2).mediaIndex, 2, '1 away 3 is correct ');
+  assert.equal(fn(media, 6.1, 2, 4).mediaIndex, 3, '1 away 4 is correct');
+  assert.equal(fn(media, 8.1, 3, 6).mediaIndex, 4, '1 away 5 is correct');
+  assert.equal(fn(media, 10.1, 4, 8).mediaIndex, 5, '1 away 6 is correct');
+
+  // 2 segment away
+  assert.equal(fn(media, 4.1, 0, 0).mediaIndex, 2, '2 away 3 is correct ');
+  assert.equal(fn(media, 6.1, 1, 2).mediaIndex, 3, '2 away 4 is correct');
+  assert.equal(fn(media, 8.1, 2, 4).mediaIndex, 4, '2 away 5 is correct');
+  assert.equal(fn(media, 10.1, 3, 6).mediaIndex, 5, '2 away 6 is correct');
+
+  // 3 segments away
+  assert.equal(fn(media, 6.1, 0, 0).mediaIndex, 3, '3 away 4 is correct');
+  assert.equal(fn(media, 8.1, 1, 2).mediaIndex, 4, '3 away 5 is correct');
+  assert.equal(fn(media, 10.1, 2, 4).mediaIndex, 5, '3 away 6 is correct');
+});
+
+QUnit.test('rounding up works', function(assert) {
+  const loader = new PlaylistLoader('media.m3u8', this.fakeVhs);
+
+  loader.load();
+
+  this.requests.shift().respond(
+    200, null,
+    '#EXTM3U\n' +
+    '#EXT-X-MEDIA-SEQUENCE:0\n' +
+    '#EXTINF:2,\n' +
+    '0.ts\n' +
+    '#EXTINF:2,\n' +
+    '1.ts\n' +
+    '#EXTINF:2,\n' +
+    '2.ts\n' +
+    '#EXTINF:2,\n' +
+    '3.ts\n' +
+    '#EXTINF:2,\n' +
+    '4.ts\n' +
+    '#EXTINF:2,\n' +
+    '5.ts\n' +
+    '#EXT-X-ENDLIST\n'
+  );
+
+  const media = loader.media();
+  const fn = Playlist.getMediaInfoForTime;
+
+  // 1 segment away
+  assert.equal(fn(media, 0, 1, 2).mediaIndex, 0, '1 away 1 is correct');
+  assert.equal(fn(media, 2.1, 2, 4).mediaIndex, 1, '1 away 2 is correct');
+  assert.equal(fn(media, 4.1, 3, 6).mediaIndex, 2, '1 away 3 is correct');
+  assert.equal(fn(media, 6.1, 4, 8).mediaIndex, 3, '1 away 4 is correct');
+  assert.equal(fn(media, 8.1, 5, 10).mediaIndex, 4, '1 away 5 is correct');
+
+  // 2 segment away
+  assert.equal(fn(media, 0, 2, 4).mediaIndex, 0, '2 away 1 is correct');
+  assert.equal(fn(media, 2.1, 3, 6).mediaIndex, 1, '2 away 2 is correct');
+  assert.equal(fn(media, 4.1, 4, 8).mediaIndex, 2, '2 away 3 is correct');
+  assert.equal(fn(media, 6.1, 5, 10).mediaIndex, 3, '2 away 4 is correct');
+
+  // 3 segments away
+  assert.equal(fn(media, 0, 3, 6).mediaIndex, 0, '3 away 1 is correct');
+  assert.equal(fn(media, 2.1, 4, 8).mediaIndex, 1, '3 away 2 is correct');
+  assert.equal(fn(media, 4.1, 5, 10).mediaIndex, 2, '3 away 3 is correct');
+});
+
 QUnit.test(
   'returns the lower index when calculating for a segment boundary',
   function(assert) {


### PR DESCRIPTION
## Description
Currently we ran into an issue with `roundSignificantDigit` because it is rounding integer whole numbers when it seems like it was only made to round floats. This can cause us to download multiple duplicate segments on slow connections. Instead I propose that we only round by `TIME_FUDGE_FACTOR` here. This will prevent us from having to do any rounding at all.

## Why the current solution is bad:
Rounding a value of `2.111111` to `2.111112` is less than 1 milliseconds a very small change but rounding from `2.1` to `2.2` is 100ms. Both are possible with the current code.

## New solution
All numbers are rounded up or down by 33 milliseconds

 ## Possible Solutions:
1. Cap the rounding at `TIME_FUDGE_FACTOR` for all numbers, but round less for longer floats. Not sure this one really makes sense as longer floats are not necessarily more accurate.
2. Don't round for numbers less than 1 decimal digits, effectively caps rounding at 99ms, which is still very high.
3. Don't round for numbers less than 2 decimal digits, effectively caps rounding at 9ms, which might not be enough? It seems to have been working until now, or we didn't notice that it wasn't