### PR TITLE
chore: keep window vhs/mpc up to date on source switch

### DIFF
--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -277,10 +277,13 @@
         } else {
           sources.dispatchEvent(newEvent('change'));
         }
-        player.ready(() => {
+        player.on('loadedmetadata', () => {
           if (player.vhs) {
             window.vhs = player.tech_.vhs;
             window.mpc = player.tech_.vhs.masterPlaylistController_;
+          } else {
+            window.vhs = null;
+            window.mpc = null;
           }
         });
         cb(player);


### PR DESCRIPTION
Noticed that the globals were out of date on source switch.