### PR TITLE
docs: native*Tracks options are no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,7 @@ var player = videojs('playerId', {
   html5: {
     vhs: {
       overrideNative: true
-    },
-    nativeAudioTracks: false,
-    nativeVideoTracks: false
+    }
   }
 });
 ```


### PR DESCRIPTION
## Description
I believe using `native*Tracks: false` is no longer needed since #76, but this crept back into the docs.

## Specific Changes proposed
Remove `native*Tracks: false` from the `overrideNative` sections of the README.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
