### PR TITLE
fix: have reloadSourceOnError get src from player

### DIFF
--- a/src/reload-source-on-error.js
+++ b/src/reload-source-on-error.js
@@ -3,7 +3,10 @@ import videojs from 'video.js';
 const defaultOptions = {
   errorInterval: 30,
   getSource(next) {
-    return next(this.currentSource());
+    const tech = this.tech({ IWillNotUseThisInPlugins: true });
+    const sourceObj = tech.currentSource_ || this.currentSource();
+
+    return next(sourceObj);
   }
 };
 

--- a/src/reload-source-on-error.js
+++ b/src/reload-source-on-error.js
@@ -3,10 +3,7 @@ import videojs from 'video.js';
 const defaultOptions = {
   errorInterval: 30,
   getSource(next) {
-    const tech = this.tech({ IWillNotUseThisInPlugins: true });
-    const sourceObj = tech.currentSource_;
-
-    return next(sourceObj);
+    return next(this.currentSource());
   }
 };
 

--- a/test/reload-source-on-error.test.js
+++ b/test/reload-source-on-error.test.js
@@ -82,7 +82,7 @@ QUnit.test('triggers on player error', function(assert) {
   );
 });
 
-QUnit.test('triggers on player error, uses player.currentSource() is tech.currentSource_ is not set', function(assert) {
+QUnit.test('triggers on player error, uses player.currentSource() if tech.currentSource_ is not set', function(assert) {
   const oldsrc = this.tech.currentSource_;
   const src = {
     src: 'thisisanothersource.m3u8',

--- a/test/reload-source-on-error.test.js
+++ b/test/reload-source-on-error.test.js
@@ -78,7 +78,34 @@ QUnit.test('triggers on player error', function(assert) {
   assert.deepEqual(
     this.player.src.calledWith[0],
     this.tech.currentSource_,
+    'player.src was called with tech.currentSource_'
+  );
+});
+
+QUnit.test('triggers on player error, uses player.currentSource() is tech.currentSource_ is not set', function(assert) {
+  const oldsrc = this.tech.currentSource_;
+  const src = {
+    src: 'thisisanothersource.m3u8',
+    type: 'video/mp4'
+  };
+
+  this.tech.currentSource_ = null;
+  this.player.currentSource = () => src;
+
+  this.player.reloadSourceOnError();
+  this.player.trigger('error', -2);
+
+  assert.equal(this.player.src.calledWith.length, 1, 'player.src was only called once');
+  assert.deepEqual(
+    this.player.src.calledWith[0],
+    src,
     'player.src was called with player.currentSource'
+  );
+
+  assert.notDeepEqual(
+    this.player.src.calledWith[0],
+    oldsrc,
+    'player.src was called with player.currentSource() and not tech.currentSource_'
   );
 });
 


### PR DESCRIPTION
Previously, we were getting the source from tech.currentSource_. This
only gets set when a source handler like VHS is used. However, because
VHS is in Video.js by default and the plugin is global, some people are
using this plugin for other sources as well.

There isn't a reason why we should be relying on tech.currentSource_
over player.currentSource() when we have access to the player in the
plugin.

Fixes videojs/video.js#6744