### PR TITLE
fix: do not wait for audio appends for muxed segments

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -289,13 +289,13 @@ const transmuxAndNotify = ({
 
     if (probeResult) {
       trackInfoFn(segment, {
-        hasAudio: !isMuxed && probeResult.hasAudio,
+        hasAudio: probeResult.hasAudio,
         hasVideo: probeResult.hasVideo,
         isMuxed
       });
       trackInfoFn = null;
 
-      if (probeResult.hasAudio) {
+      if (probeResult.hasAudio && !isMuxed) {
         audioStartFn(probeResult.audioStart);
       }
       if (probeResult.hasVideo) {
@@ -321,7 +321,6 @@ const transmuxAndNotify = ({
       if (trackInfoFn) {
         if (isMuxed) {
           trackInfo.isMuxed = true;
-          trackInfo.hasAudio = false;
         }
         trackInfoFn(segment, trackInfo);
       }
@@ -412,7 +411,6 @@ const handleSegmentBytes = ({
 
     if (tracks.video && tracks.audio) {
       trackInfo.isMuxed = true;
-      trackInfo.hasAudio = false;
     }
 
     // since we don't support appending fmp4 data on progress, we know we have the full
@@ -426,7 +424,7 @@ const handleSegmentBytes = ({
     // decoding).
     const timingInfo = mp4probe.startTime(segment.map.timescales, bytesAsUint8Array);
 
-    if (trackInfo.hasAudio) {
+    if (trackInfo.hasAudio && !trackInfo.isMuxed) {
       timingInfoFn(segment, 'audio', 'start', timingInfo);
     }
 
@@ -439,7 +437,7 @@ const handleSegmentBytes = ({
       // for it to be audio only. See `tracks.video && tracks.audio` if statement
       // above.
       // we make sure to use segment.bytes here as that
-      dataFn(segment, {data: bytes, type: trackInfo.hasAudio ? 'audio' : 'video'});
+      dataFn(segment, {data: bytes, type: trackInfo.hasAudio && !trackInfo.isMuxed ? 'audio' : 'video'});
       if (captions && captions.length) {
         captionsFn(segment, captions);
       }

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -289,7 +289,7 @@ const transmuxAndNotify = ({
 
     if (probeResult) {
       trackInfoFn(segment, {
-        hasAudio: probeResult.hasAudio,
+        hasAudio: !isMuxed && probeResult.hasAudio,
         hasVideo: probeResult.hasVideo,
         isMuxed
       });
@@ -321,6 +321,7 @@ const transmuxAndNotify = ({
       if (trackInfoFn) {
         if (isMuxed) {
           trackInfo.isMuxed = true;
+          trackInfo.hasAudio = false;
         }
         trackInfoFn(segment, trackInfo);
       }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1690,6 +1690,7 @@ export default class SegmentLoader extends videojs.EventTarget {
         return false;
       }
 
+      // muxed content only relies on video timeing information for now.
       if (hasAudio && !this.audioDisabled_ && !isMuxed && !segmentInfo.audioTimingInfo) {
         return false;
       }
@@ -2340,6 +2341,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // complete.
     const {hasAudio, hasVideo, isMuxed} = this.startingMedia_;
     const waitForVideo = this.loaderType_ === 'main' && hasVideo;
+    // TODO: does this break partial support for muxed content?
     const waitForAudio = !this.audioDisabled_ && hasAudio && !isMuxed;
 
     segmentInfo.waitingOnAppends = 0;

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -637,9 +637,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (this.loaderType_ === 'main') {
-      const { hasAudio, hasVideo } = this.startingMedia_;
+      const { hasAudio, hasVideo, isMuxed } = this.startingMedia_;
 
-      if (hasVideo && hasAudio && !this.audioDisabled_) {
+      if (hasVideo && hasAudio && !this.audioDisabled_ && !isMuxed) {
         return this.sourceUpdater_.buffered();
       }
 
@@ -1684,11 +1684,13 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (!this.handlePartialData_) {
-      if (this.startingMedia_.hasVideo && !segmentInfo.videoTimingInfo) {
+      const {hasAudio, hasVideo, isMuxed} = this.startingMedia_;
+
+      if (hasVideo && !segmentInfo.videoTimingInfo) {
         return false;
       }
 
-      if (this.startingMedia_.hasAudio && !segmentInfo.audioTimingInfo) {
+      if (hasAudio && !this.audioDisabled_ && !isMuxed && !segmentInfo.audioTimingInfo) {
         return false;
       }
     }
@@ -2336,8 +2338,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Although transmuxing is done, appends may not yet be finished. Throw a marker
     // on each queue this loader is responsible for to ensure that the appends are
     // complete.
-    const waitForVideo = this.loaderType_ === 'main' && this.startingMedia_.hasVideo;
-    const waitForAudio = !this.audioDisabled_ && this.startingMedia_.hasAudio;
+    const {hasAudio, hasVideo, isMuxed} = this.startingMedia_;
+    const waitForVideo = this.loaderType_ === 'main' && hasVideo;
+    const waitForAudio = !this.audioDisabled_ && hasAudio && !isMuxed;
 
     segmentInfo.waitingOnAppends = 0;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1690,7 +1690,7 @@ export default class SegmentLoader extends videojs.EventTarget {
         return false;
       }
 
-      // muxed content only relies on video timeing information for now.
+      // muxed content only relies on video timing information for now.
       if (hasAudio && !this.audioDisabled_ && !isMuxed && !segmentInfo.audioTimingInfo) {
         return false;
       }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2930,7 +2930,7 @@ QUnit.test('parses codec from muxed fmp4 init segment', function(assert) {
       'parsed video codec'
     );
     assert.deepEqual(loader.startingMedia_, {
-      hasAudio: false,
+      hasAudio: true,
       hasVideo: true,
       videoCodec: 'avc1.42c00d',
       audioCodec: 'mp4a.40.2',


### PR DESCRIPTION
## Description
Noticed that our fmp4/ts mixed content is failing. This is happening because we fire `trackinfo` on a change when we did not before. The trackinfo that we fire for the ts segment causes us to stall palyback because we wait for `audio`, but only ever receiver `video`/`combined` back from the transmuxer. The [fix for muxed fmp4 was only reporting `hasVideo`](https://github.com/videojs/http-streaming/blob/e0e497f7ca00aa061147e4dd005d03cb802f9cec/src/media-segment-request.js#L412). The fix for ts is exactly the same, we should not report `hasAudio` if the audio and video are muxed together or else we will wait for audio appends that will never come.