### PR TITLE
fix: stop alt loaders on main mediachanging to prevent append race

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1346,9 +1346,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
     if (usingAudioLoader && unsupportedAudio && this.media().attributes.AUDIO) {
       const audioGroup = this.media().attributes.AUDIO;
 
-      this.mediaTypes_.AUDIO.activePlaylistLoader.pause();
-      this.audioSegmentLoader_.pause();
-      this.audioSegmentLoader_.abort();
       this.master().playlists.forEach(variant => {
         const variantAudioGroup = variant.attributes && variant.attributes.AUDIO;
 

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -105,7 +105,7 @@ export const onGroupChanged = (type, settings) => () => {
   startLoaders(activeGroup.playlistLoader, mediaType);
 };
 
-const onGroupChanging = (type, settings) => () => {
+export const onGroupChanging = (type, settings) => () => {
   const {
     segmentLoaders: {
       [type]: segmentLoader

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -105,6 +105,17 @@ export const onGroupChanged = (type, settings) => () => {
   startLoaders(activeGroup.playlistLoader, mediaType);
 };
 
+const onGroupChanging = (type, settings) => () => {
+  const {
+    segmentLoaders: {
+      [type]: segmentLoader
+    }
+  } = settings;
+
+  segmentLoader.abort();
+  segmentLoader.pause();
+};
+
 /**
  * Returns a function to be called when the media track changes. It performs a
  * destructive reset of the SegmentLoader to ensure we start loading as close to
@@ -730,6 +741,7 @@ export const setupMediaGroups = (settings) => {
     mediaTypes[type].activeGroup = activeGroup(type, settings);
     mediaTypes[type].activeTrack = activeTrack[type](type, settings);
     mediaTypes[type].onGroupChanged = onGroupChanged(type, settings);
+    mediaTypes[type].onGroupChanging = onGroupChanging(type, settings);
     mediaTypes[type].onTrackChanged = onTrackChanged(type, settings);
   });
 
@@ -746,6 +758,10 @@ export const setupMediaGroups = (settings) => {
 
   masterPlaylistLoader.on('mediachange', () => {
     ['AUDIO', 'SUBTITLES'].forEach(type => mediaTypes[type].onGroupChanged());
+  });
+
+  masterPlaylistLoader.on('mediachanging', () => {
+    ['AUDIO', 'SUBTITLES'].forEach(type => mediaTypes[type].onGroupChanging());
   });
 
   // custom audio track change event handler for usage event

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -340,6 +340,32 @@ QUnit.test('activeGroup returns the correct subtitle group', function(assert) {
   );
 });
 
+QUnit.test('onGroupChanging aborts and pauses segment loaders', function(assert) {
+  const calls = {
+    abort: 0,
+    pause: 0
+  };
+  const segmentLoader = {
+    abort: () => calls.abort++,
+    pause: () => calls.pause++
+  };
+
+  const settings = {
+    segmentLoaders: {
+      AUDIO: segmentLoader
+    }
+  };
+  const type = 'AUDIO';
+
+  const onGroupChanging = MediaGroups.onGroupChanging(type, settings);
+
+  assert.deepEqual(calls, {abort: 0, pause: 0}, 'no calls yet');
+
+  onGroupChanging();
+
+  assert.deepEqual(calls, {abort: 1, pause: 1}, 'one abort one pause');
+});
+
 QUnit.test(
   'onGroupChanged updates active playlist loader and resyncs segment loader',
   function(assert) {


### PR DESCRIPTION
## Description
This is most noticeable right now on safari on the hevc fmp4 stream that we have for testing. You can reproduce it in `main` by seeking around and force changing the representation to one with another codec:

```js
vhs.representations().forEach((r, i) => r.enabled(i ===49))
vhs.representations().forEach((r, i) => r.enabled(i ===53))
vhs.representations().forEach((r, i) => r.enabled(i ===20))
```
Usually it will fail with an append error, because we change the codec and then try to append old codec data. This happens because we previously waited until `mediachange` to `stopLoaders` for `audioLoader` but for the `mainLoader` we stop right away. This causes a race condition where old audio gets appended before the media has fully changed, but after codecs have. The fix here is to stop/pause  all segment loaders on `mediachanging`

## Why didn't we see it sooner
Its not an issue to append data of the same codec to a sourcebuffer even if it isn't relevant. That and we always reset when starting to load that data append never caused an issue. Now that we switch codecs such an append will throw an error.