### PR TITLE
fix: support aac data with id3 tags with mux.js@5.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6850,9 +6850,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.5.tgz",
-      "integrity": "sha512-9lcApL+FquDTpvBR8TIzouMirpzAf8tiOIp4hhogyE0U374sWQP0RTqFDXsU7TeubQy/GZu1UzvXrzcCuNyEww=="
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.6.tgz",
+      "integrity": "sha512-q5VIpqb28UVs5dKsOQkpHrPxqInMjiZ/f/4qW4gEBKlm2xeBasRjRJIokixFWj+r6PWfVSEygvPffXnG7aK99g=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "global": "^4.3.2",
     "m3u8-parser": "4.4.2",
     "mpd-parser": "0.10.1",
-    "mux.js": "5.6.5",
+    "mux.js": "5.6.6",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -256,7 +256,7 @@ QUnit.test('aac with id3 will make it to the transmuxer', function(assert) {
   this.options.doneFn = () => {
     assert.deepEqual(this.calls, {
       data: 1,
-      trackInfo: 48,
+      trackInfo: 1,
       progress: 1,
       timingInfo: 2,
       captions: 0,
@@ -272,7 +272,7 @@ QUnit.test('aac with id3 will make it to the transmuxer', function(assert) {
   this.standardXHRResponse(this.requests[0], aacWithId3Segment());
 });
 
-QUnit.skip('aac without id3 will make it to the transmuxer', function(assert) {
+QUnit.test('aac without id3 will make it to the transmuxer', function(assert) {
   const done = assert.async();
 
   this.options.segment.transmuxer = this.createTransmuxer();
@@ -280,7 +280,7 @@ QUnit.skip('aac without id3 will make it to the transmuxer', function(assert) {
   this.options.doneFn = () => {
     assert.deepEqual(this.calls, {
       data: 1,
-      trackInfo: 47,
+      trackInfo: 1,
       progress: 1,
       timingInfo: 2,
       captions: 0,
@@ -440,7 +440,7 @@ QUnit.test('aac with id3 will make it to the partial transmuxer', function(asser
   this.standardXHRResponse(this.requests[0], aacWithId3Segment());
 });
 
-QUnit.skip('aac without id3 will make it to the partial transmuxer', function(assert) {
+QUnit.test('aac without id3 will make it to the partial transmuxer', function(assert) {
   const done = assert.async();
 
   this.options.segment.transmuxer = this.createTransmuxer(true);


### PR DESCRIPTION
## Description
Noticed while generating some aac content for tests using ffmpeg that we do not support aac content that does not have ID3 tags. This was fixed with mux.js@5.6.6 as mux.js did not recognize aac content without id3 tags as aac content. 
