### PR TITLE
fix: pause/abort loaders before an exclude, prevent bad appends

### DIFF
--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -18,9 +18,10 @@
     var id = selectedOption.value;
 
     window.vhs.representations().forEach(function(rep) {
-      rep.enabled(rep.id === id);
+      rep.playlist.disabled = rep.id !== id;
     });
 
+    window.mpc.smoothQualityChange_();
   });
   var hlsOptGroup = document.querySelector('[label="hls"]');
   var dashOptGroup = document.querySelector('[label="dash"]');
@@ -331,9 +332,7 @@
           if (player.vhs) {
             window.vhs = player.tech_.vhs;
             window.mpc = player.tech_.vhs.masterPlaylistController_;
-            window.mpc.masterPlaylistLoader_.on('mediachange', function() {
-              regenerateRepresentations();
-            });
+            window.mpc.masterPlaylistLoader_.on('mediachange', regenerateRepresentations);
             regenerateRepresentations();
 
           } else {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -996,8 +996,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * @param {string} filter
    *        Filter loaders that should call fnNames using a string. Can be:
    *        * all - run on all loaders
-   *        * playlist - run on all playlist loaders
-   *        * segment - run on all segment loaders
    *        * audio - run on all audio loaders
    *        * subtitle - run on all subtitle loaders
    *        * main - run on the main/master loaders
@@ -1008,43 +1006,39 @@ export class MasterPlaylistController extends videojs.EventTarget {
   delegateLoaders_(filter, fnNames) {
     const loaders = [];
 
-    if (filter !== 'segment') {
-      const dontFilterPlaylist = filter === 'all' || filter === 'playlist';
+    const dontFilterPlaylist = filter === 'all';
 
-      if (dontFilterPlaylist || filter === 'main') {
-        loaders.push(this.masterPlaylistLoader_);
-      }
-
-      const mediaTypes = [];
-
-      if (dontFilterPlaylist || filter === 'audio') {
-        mediaTypes.push('AUDIO');
-      }
-
-      if (dontFilterPlaylist || filter === 'subtitle') {
-        mediaTypes.push('CLOSED-CAPTIONS');
-        mediaTypes.push('SUBTITLES');
-      }
-
-      mediaTypes.forEach((mediaType) => {
-        const loader = this.mediaTypes_[mediaType] &&
-                       this.mediaTypes_[mediaType].activePlaylistLoader;
-
-        if (loader) {
-          loaders.push(loader);
-        }
-      });
+    if (dontFilterPlaylist || filter === 'main') {
+      loaders.push(this.masterPlaylistLoader_);
     }
 
-    if (filter !== 'playlist') {
-      ['main', 'audio', 'subtitle'].forEach((name) => {
-        const loader = this[`${name}SegmentLoader_`];
+    const mediaTypes = [];
 
-        if (loader && (filter === name || filter === 'segment' || filter === 'all')) {
-          loaders.push(loader);
-        }
-      });
+    if (dontFilterPlaylist || filter === 'audio') {
+      mediaTypes.push('AUDIO');
     }
+
+    if (dontFilterPlaylist || filter === 'subtitle') {
+      mediaTypes.push('CLOSED-CAPTIONS');
+      mediaTypes.push('SUBTITLES');
+    }
+
+    mediaTypes.forEach((mediaType) => {
+      const loader = this.mediaTypes_[mediaType] &&
+        this.mediaTypes_[mediaType].activePlaylistLoader;
+
+      if (loader) {
+        loaders.push(loader);
+      }
+    });
+
+    ['main', 'audio', 'subtitle'].forEach((name) => {
+      const loader = this[`${name}SegmentLoader_`];
+
+      if (loader && (filter === name || filter === 'all')) {
+        loaders.push(loader);
+      }
+    });
 
     loaders.forEach((loader) => fnNames.forEach((fnName) => {
       if (typeof loader[fnName] === 'function') {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -948,6 +948,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.tech_.trigger({type: 'usage', name: 'vhs-rendition-blacklisted'});
     this.tech_.trigger({type: 'usage', name: 'hls-rendition-blacklisted'});
 
+    // Do not select another playlist if this playlist is not the one
+    // currently in use.
     if (currentPlaylist.id !== this.media().id) {
       return;
     }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1008,7 +1008,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
    *        A string or array of function names to call.
    */
   delegateLoaders_(filter, fnNames) {
-    this.logger_(`running ${fnNames.join(', ')} on ${filter} loaders`);
     const loaders = [];
 
     if (filter !== 'segment') {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -948,12 +948,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.tech_.trigger({type: 'usage', name: 'vhs-rendition-blacklisted'});
     this.tech_.trigger({type: 'usage', name: 'hls-rendition-blacklisted'});
 
-    // Do not select another playlist if this playlist is not the one
-    // currently in use.
-    if (currentPlaylist.id !== this.media().id) {
-      return;
-    }
-
+    // TODO: should we select a new playlist if this blacklist wasn't for the currentPlaylist?
+    // Would be something like media().id !=== currentPlaylist.id and we  would need something
+    // like `pendingMedia` in playlist loaders to check against that too. This will prevent us
+    // from loading a new playlist on any blacklist.
     // Select a new playlist
     const nextPlaylist = this.selectPlaylist();
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -5186,44 +5186,7 @@ QUnit.test('main & audio loader only trackinfo works as expected', function(asse
 
 QUnit.module('MasterPlaylistController - exclusion behavior', sharedHooks);
 
-QUnit.test('exclusions that dont change playlist do not abort/pause', function(assert) {
-  openMediaSource(this.player, this.clock);
-
-  this.player.tech_.vhs.bandwidth = 1;
-
-  // master
-  this.requests.shift()
-    .respond(
-      200, null,
-      '#EXTM3U\n' +
-      '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5"\n' +
-      'media.m3u8\n' +
-      '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
-      'media1.m3u8\n'
-    );
-
-  // media
-  this.standardXHRResponse(this.requests.shift());
-  const mpc = this.masterPlaylistController;
-  const delegateLoaders = [];
-
-  assert.equal(mpc.media(), mpc.master().playlists[0], 'selected first playlist');
-
-  mpc.delegateLoaders_ = (filter, fnNames) => {
-    delegateLoaders.push({filter, fnNames});
-  };
-
-  mpc.blacklistCurrentPlaylist({
-    internal: true,
-    playlist: mpc.master().playlists[1],
-    blacklistDuration: Infinity
-  });
-
-  assert.equal(mpc.master().playlists[1].excludeUntil, Infinity, 'exclusion happened');
-  assert.deepEqual(delegateLoaders, [], 'called delegateLoaders');
-});
-
-QUnit.test('exclusions that change playlist pause/abort main/master loaders', function(assert) {
+QUnit.test('exclusions always pause/abort main/master loaders', function(assert) {
   openMediaSource(this.player, this.clock);
 
   this.player.tech_.vhs.bandwidth = 1;

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -4386,47 +4386,42 @@ QUnit.test('disposes timeline change controller on dispose', function(assert) {
   assert.equal(disposes, 1, 'disposed timeline change controller');
 });
 
-QUnit.test('on error all segment and playlist loaders are paused', function(assert) {
-  const paused = {
-    audioSegment: false,
-    subtitleSegment: false,
-    mainSegment: false,
-    masterPlaylist: false
-  };
+QUnit.test('on error all segment and playlist loaders are paused and aborted', function(assert) {
+  const mpc = this.masterPlaylistController;
+  const calls = {};
+  const expected = {};
 
   Object.keys(this.masterPlaylistController.mediaTypes_).forEach((type) => {
     const key = `${type.toLowerCase()}Playlist`;
 
-    paused[key] = false;
+    calls[`${key}Abort`] = 0;
+    calls[`${key}Pause`] = 0;
+    expected[`${key}Abort`] = 1;
+    expected[`${key}Pause`] = 1;
 
     this.masterPlaylistController.mediaTypes_[type].activePlaylistLoader = {
-      pause() {
-        paused[key] = true;
-      }
+      pause: () => calls[`${key}Pause`]++,
+      abort: () => calls[`${key}Abort`]++
     };
   });
 
-  this.masterPlaylistController.audioSegmentLoader_.pause = () => {
-    paused.audioSegment = true;
-  };
-
-  this.masterPlaylistController.subtitleSegmentLoader_.pause = () => {
-    paused.subtitleSegment = true;
-  };
-
-  this.masterPlaylistController.mainSegmentLoader_.pause = () => {
-    paused.mainSegment = true;
-  };
-
-  this.masterPlaylistController.masterPlaylistLoader_.pause = () => {
-    paused.masterPlaylist = true;
-  };
+  [
+    'audioSegmentLoader',
+    'subtitleSegmentLoader',
+    'mainSegmentLoader',
+    'masterPlaylistLoader'
+  ].forEach(function(key) {
+    calls[`${key}Abort`] = 0;
+    calls[`${key}Pause`] = 0;
+    expected[`${key}Abort`] = 1;
+    expected[`${key}Pause`] = 1;
+    mpc[`${key}_`].pause = () => calls[`${key}Pause`]++;
+    mpc[`${key}_`].abort = () => calls[`${key}Abort`]++;
+  });
 
   this.masterPlaylistController.trigger('error');
 
-  Object.keys(paused).forEach(function(name) {
-    assert.ok(paused[name], `${name} was paused on error`);
-  });
+  assert.deepEqual(calls, expected, 'calls as expected');
 });
 
 QUnit.test('can pass or select a playlist for fastQualityChange', function(assert) {
@@ -5187,4 +5182,314 @@ QUnit.test('main & audio loader only trackinfo works as expected', function(asse
 
   assert.equal(createBuffers, 1, 'createBuffers not called');
   assert.equal(switchBuffers, 2, 'addOrChangeSourceBuffers called');
+});
+
+QUnit.module('MasterPlaylistController - exclusion behavior', sharedHooks);
+
+QUnit.test('exclusions that dont change playlist do not abort/pause', function(assert) {
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.bandwidth = 1;
+
+  // master
+  this.requests.shift()
+    .respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5"\n' +
+      'media.m3u8\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+      'media1.m3u8\n'
+    );
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+  const mpc = this.masterPlaylistController;
+  const delegateLoaders = [];
+
+  assert.equal(mpc.media(), mpc.master().playlists[0], 'selected first playlist');
+
+  mpc.delegateLoaders_ = (filter, fnNames) => {
+    delegateLoaders.push({filter, fnNames});
+  };
+
+  mpc.blacklistCurrentPlaylist({
+    internal: true,
+    playlist: mpc.master().playlists[1],
+    blacklistDuration: Infinity
+  });
+
+  assert.equal(mpc.master().playlists[1].excludeUntil, Infinity, 'exclusion happened');
+  assert.deepEqual(delegateLoaders, [], 'called delegateLoaders');
+});
+
+QUnit.test('exclusions that change playlist pause/abort main/master loaders', function(assert) {
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.bandwidth = 1;
+
+  // master
+  this.requests.shift()
+    .respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5"\n' +
+      'media.m3u8\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+      'media1.m3u8\n'
+    );
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+  const mpc = this.masterPlaylistController;
+  const delegateLoaders = [];
+
+  assert.equal(mpc.media(), mpc.master().playlists[0], 'selected first playlist');
+
+  mpc.delegateLoaders_ = (filter, fnNames) => {
+    delegateLoaders.push({filter, fnNames});
+  };
+
+  mpc.blacklistCurrentPlaylist({
+    internal: true,
+    playlist: mpc.master().playlists[0],
+    blacklistDuration: Infinity
+  });
+
+  assert.equal(mpc.master().playlists[0].excludeUntil, Infinity, 'exclusion happened');
+  assert.deepEqual(delegateLoaders, [
+    {filter: 'main', fnNames: ['abort', 'pause']}
+  ], 'called delegateLoaders');
+});
+
+QUnit.test('exclusions that change audio group abort/pause main/audio loaders', function(assert) {
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.bandwidth = 1;
+
+  // master
+  this.requests.shift()
+    .respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5",AUDIO="foo"\n' +
+      'media.m3u8\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+      'media1.m3u8\n'
+    );
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+  const mpc = this.masterPlaylistController;
+  const delegateLoaders = [];
+
+  assert.equal(mpc.media(), mpc.master().playlists[0], 'selected first playlist');
+
+  mpc.delegateLoaders_ = (filter, fnNames) => {
+    delegateLoaders.push({filter, fnNames});
+  };
+
+  mpc.blacklistCurrentPlaylist({
+    internal: true,
+    playlist: mpc.master().playlists[0],
+    blacklistDuration: Infinity
+  });
+
+  assert.equal(mpc.master().playlists[0].excludeUntil, Infinity, 'exclusion happened');
+  assert.deepEqual(delegateLoaders, [
+    {filter: 'audio', fnNames: ['abort', 'pause']},
+    {filter: 'main', fnNames: ['abort', 'pause']}
+  ], 'called delegateLoaders');
+});
+
+QUnit.test('exclusions that change subtitle group abort/pause main/subtitle loaders', function(assert) {
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.bandwidth = 1;
+
+  // master
+  this.requests.shift()
+    .respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5",SUBTITLES="foo"\n' +
+      'media.m3u8\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+      'media1.m3u8\n'
+    );
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+  const mpc = this.masterPlaylistController;
+  const delegateLoaders = [];
+
+  assert.equal(mpc.media(), mpc.master().playlists[0], 'selected first playlist');
+
+  mpc.delegateLoaders_ = (filter, fnNames) => {
+    delegateLoaders.push({filter, fnNames});
+  };
+
+  mpc.blacklistCurrentPlaylist({
+    internal: true,
+    playlist: mpc.master().playlists[0],
+    blacklistDuration: Infinity
+  });
+
+  assert.equal(mpc.master().playlists[0].excludeUntil, Infinity, 'exclusion happened');
+  assert.deepEqual(delegateLoaders, [
+    {filter: 'subtitle', fnNames: ['abort', 'pause']},
+    {filter: 'main', fnNames: ['abort', 'pause']}
+  ], 'called delegateLoaders');
+});
+
+QUnit.test('exclusions that change all groups abort/pause main/subtitle loaders', function(assert) {
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.bandwidth = 1;
+
+  // master
+  this.requests.shift()
+    .respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5",AUDIO="foo",SUBTITLES="bar"\n' +
+      'media.m3u8\n' +
+      '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+      'media1.m3u8\n'
+    );
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+  const mpc = this.masterPlaylistController;
+  const delegateLoaders = [];
+
+  assert.equal(mpc.media(), mpc.master().playlists[0], 'selected first playlist');
+
+  mpc.delegateLoaders_ = (filter, fnNames) => {
+    delegateLoaders.push({filter, fnNames});
+  };
+
+  mpc.blacklistCurrentPlaylist({
+    internal: true,
+    playlist: mpc.master().playlists[0],
+    blacklistDuration: Infinity
+  });
+
+  assert.equal(mpc.master().playlists[0].excludeUntil, Infinity, 'exclusion happened');
+  assert.deepEqual(delegateLoaders, [
+    {filter: 'audio', fnNames: ['abort', 'pause']},
+    {filter: 'subtitle', fnNames: ['abort', 'pause']},
+    {filter: 'main', fnNames: ['abort', 'pause']}
+  ], 'called delegateLoaders');
+});
+
+QUnit.module('MasterPlaylistController delegate loaders', {
+  beforeEach(assert) {
+    sharedHooks.beforeEach.call(this, assert);
+
+    this.mpc = this.masterPlaylistController;
+    this.calls = {};
+    this.expected = {};
+
+    Object.keys(this.mpc.mediaTypes_).forEach((type) => {
+      const key = `${type.toLowerCase()}Playlist`;
+
+      this.calls[`${key}Abort`] = 0;
+      this.calls[`${key}Pause`] = 0;
+      this.expected[`${key}Abort`] = 0;
+      this.expected[`${key}Pause`] = 0;
+
+      this.mpc.mediaTypes_[type].activePlaylistLoader = {
+        abort: () => this.calls[`${key}Abort`]++,
+        pause: () => this.calls[`${key}Pause`]++
+      };
+    });
+
+    [
+      'audioSegmentLoader',
+      'subtitleSegmentLoader',
+      'mainSegmentLoader',
+      'masterPlaylistLoader'
+    ].forEach((key) => {
+      this.calls[`${key}Abort`] = 0;
+      this.calls[`${key}Pause`] = 0;
+      this.expected[`${key}Abort`] = 0;
+      this.expected[`${key}Pause`] = 0;
+      this.mpc[`${key}_`].abort = () => this.calls[`${key}Abort`]++;
+      this.mpc[`${key}_`].pause = () => this.calls[`${key}Pause`]++;
+    });
+  },
+  afterEach(assert) {
+    sharedHooks.afterEach.call(this, assert);
+  }
+});
+
+QUnit.test('filter all works', function(assert) {
+  this.mpc.delegateLoaders_('all', ['abort', 'pause']);
+
+  Object.keys(this.expected).forEach((key) => {
+    this.expected[key] = 1;
+  });
+
+  assert.deepEqual(this.calls, this.expected, 'calls as expected');
+});
+
+QUnit.test('filter segment works', function(assert) {
+  this.mpc.delegateLoaders_('segment', ['abort', 'pause']);
+
+  Object.keys(this.expected).forEach((key) => {
+    if ((/Segment/).test(key)) {
+      this.expected[key] = 1;
+    }
+  });
+
+  assert.deepEqual(this.calls, this.expected, 'calls as expected');
+});
+
+QUnit.test('filter playlist works', function(assert) {
+  this.mpc.delegateLoaders_('playlist', ['abort', 'pause']);
+
+  Object.keys(this.expected).forEach((key) => {
+    if ((/Playlist/).test(key)) {
+      this.expected[key] = 1;
+    }
+  });
+
+  assert.deepEqual(this.calls, this.expected, 'calls as expected');
+});
+
+QUnit.test('filter main works', function(assert) {
+  this.mpc.delegateLoaders_('main', ['abort', 'pause']);
+
+  Object.keys(this.expected).forEach((key) => {
+    if ((/^(master|main)/).test(key)) {
+      this.expected[key] = 1;
+    }
+  });
+
+  assert.deepEqual(this.calls, this.expected, 'calls as expected');
+});
+
+QUnit.test('filter audio works', function(assert) {
+  this.mpc.delegateLoaders_('audio', ['abort', 'pause']);
+
+  Object.keys(this.expected).forEach((key) => {
+    if ((/^audio/).test(key)) {
+      this.expected[key] = 1;
+    }
+  });
+
+  assert.deepEqual(this.calls, this.expected, 'calls as expected');
+});
+
+QUnit.test('filter subtitle works', function(assert) {
+  this.mpc.delegateLoaders_('subtitle', ['abort', 'pause']);
+
+  Object.keys(this.expected).forEach((key) => {
+    if ((/^(subtitle|closed-captions)/).test(key)) {
+      this.expected[key] = 1;
+    }
+  });
+
+  assert.deepEqual(this.calls, this.expected, 'calls as expected');
 });


### PR DESCRIPTION
## Description
1. Pause loading needs to call abort as well, or else we seem to still be able to continue requesting segments after an error. All of the segments will fail to append, but we will waste a lot of bandwidth.
2. We call pauseLoading after an exclusion to prevent the excluded playlist from appending a bad segment. 


## Why didn't this come up sooner
1. When appending same-codec content appends don't really error, different codec content though does.

## Testing
1. Go to the index page in main change renditions to the hevc renditions as fast as possible and notice an append error.
2. Try the same on this branch