### PR TITLE
feat: exclude all incompatable browser/muxer codecs

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -304,7 +304,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       let updatedPlaylist = this.masterPlaylistLoader_.media();
 
       if (!updatedPlaylist) {
-        // blacklist any variants that are not supported by the browser before selecting
+        // exclude any variants that are not supported by the browser before selecting
         // an initial media as the playlist selectors do not consider browser support
         this.excludeUnsupportedVariants_();
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -304,6 +304,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
       let updatedPlaylist = this.masterPlaylistLoader_.media();
 
       if (!updatedPlaylist) {
+        // blacklist any variants that are not supported by the browser before selecting
+        // an initial media as the playlist selectors do not consider browser support
+        this.excludeUnsupportedVariants_();
+
         let selectedMedia;
 
         if (this.enableLowInitialPlaylist) {
@@ -1434,6 +1438,23 @@ export class MasterPlaylistController extends videojs.EventTarget {
     const codecString = [codecs.video, codecs.audio].filter(Boolean).join(',');
 
     this.excludeIncompatibleVariants_(codecString);
+  }
+
+  /**
+   * Blacklists playlists with codecs that are unsupported by the muxer and browser.
+   */
+  excludeUnsupportedVariants_() {
+    this.master().playlists.forEach(variant => {
+      const codecs = codecsForPlaylist(this.master, variant);
+
+      if (codecs.audio && !muxerSupportsCodec(codecs.audio) && !browserSupportsCodec(codecs.audio)) {
+        variant.excludeUntil = Infinity;
+      }
+
+      if (codecs.video && !muxerSupportsCodec(codecs.video) && !browserSupportsCodec(codecs.video)) {
+        variant.excludeUntil = Infinity;
+      }
+    });
   }
 
   /**

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1441,7 +1441,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
   }
 
   /**
-   * Blacklists playlists with codecs that are unsupported by the muxer and browser.
+   * Excludes playlists with codecs that are unsupported by the muxer and browser.
    */
   excludeUnsupportedVariants_() {
     this.master().playlists.forEach(variant => {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1352,6 +1352,13 @@ QUnit.test('blacklists switching between playlists with different codecs', funct
 
   this.player.tech_.vhs.bandwidth = 1;
 
+  const mpc = this.masterPlaylistController;
+
+  // don't exclude unsupported variants now so we can
+  // keep them until until later on.
+  mpc.excludeUnsupportedVariants_ = () => {};
+  mpc.sourceUpdater_.canChangeType = () => false;
+
   // master
   this.requests.shift()
     .respond(
@@ -1380,10 +1387,6 @@ QUnit.test('blacklists switching between playlists with different codecs', funct
     this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0],
     'selected HE-AAC stream'
   );
-
-  const mpc = this.masterPlaylistController;
-
-  mpc.sourceUpdater_.canChangeType = () => false;
 
   let debugLogs = [];
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -897,6 +897,31 @@ QUnit.test(
   }
 );
 
+QUnit.test('excludes playlists with unsupported codecs before initial selection', function(assert) {
+  this.masterPlaylistController.selectPlaylist = () => {
+    assert.equal(
+      this.masterPlaylistController.master().playlists[0].excludeUntil,
+      Infinity,
+      'excludes unsupported playlist before initial selection'
+    );
+  };
+
+  openMediaSource(this.player, this.clock);
+
+  // master
+  this.requests.shift().respond(
+    200, null,
+    '#EXTM3U\n' +
+    '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="theora,mp4a.40.5"\n' +
+    'media.m3u8\n' +
+    '#EXT-X-STREAM-INF:BANDWIDTH=10000,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+    'media1.m3u8\n'
+  );
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+});
+
 QUnit.test(
   'updates the combined segment loader on live playlist refreshes',
   function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1839,13 +1839,17 @@ QUnit.test('blacklists fmp4 playlists by browser support', function(assert) {
     '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.2"\n' +
     'media1.m3u8\n';
 
+  const mpc = this.player.tech_.vhs.masterPlaylistController_;
+
+  // do not exclude incompatible so that we can run this test.
+  mpc.excludeUnsupportedVariants_ = () => {};
+
   // master
   this.requests.shift().respond(200, null, playlistString);
 
   // media
   this.standardXHRResponse(this.requests.shift());
 
-  const mpc = this.player.tech_.vhs.masterPlaylistController_;
   const playlistLoader = mpc.masterPlaylistLoader_;
   const loader = mpc.mainSegmentLoader_;
   const master = this.player.tech_.vhs.playlists.master;


### PR DESCRIPTION
## Description
Brings back code from 1.x where we exclude incompatible codecs. This time though we exclude by browser/muxer, rather than just browser.