### PR TITLE
fix: do not use remove source buffer on ie 11

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -413,7 +413,7 @@ export default class SourceUpdater extends videojs.EventTarget {
    *          if removeSourceBuffer can be called.
    */
   canRemoveSourceBuffer() {
-    return !videojs.IE_VERSION && window.MediaSource &&
+    return !videojs.browser.IE_VERSION && window.MediaSource &&
       window.MediaSource.prototype &&
       typeof window.MediaSource.prototype.removeSourceBuffer === 'function';
   }

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -413,7 +413,7 @@ export default class SourceUpdater extends videojs.EventTarget {
    *          if removeSourceBuffer can be called.
    */
   canRemoveSourceBuffer() {
-    return window.MediaSource &&
+    return !videojs.IE_VERSION && window.MediaSource &&
       window.MediaSource.prototype &&
       typeof window.MediaSource.prototype.removeSourceBuffer === 'function';
   }

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -413,7 +413,7 @@ export default class SourceUpdater extends videojs.EventTarget {
    *          if removeSourceBuffer can be called.
    */
   canRemoveSourceBuffer() {
-    // IE reports that is supports removeSourceBuffer, but often throws
+    // IE reports that it supports removeSourceBuffer, but often throws
     // errors when attempting to use the function. So we report that it
     // does not support removeSourceBuffer.
     return !videojs.browser.IE_VERSION && window.MediaSource &&

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -413,6 +413,9 @@ export default class SourceUpdater extends videojs.EventTarget {
    *          if removeSourceBuffer can be called.
    */
   canRemoveSourceBuffer() {
+    // IE reports that is supports removeSourceBuffer, but often throws
+    // errors when attempting to use the function. So we report that it
+    // does not support removeSourceBuffer.
     return !videojs.browser.IE_VERSION && window.MediaSource &&
       window.MediaSource.prototype &&
       typeof window.MediaSource.prototype.removeSourceBuffer === 'function';

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -803,7 +803,7 @@ QUnit.module('SegmentLoader', function(hooks) {
             return;
           }
 
-          assert.notOk(appendsdone, 'appendsdone triggered');
+          assert.notOk(appendsdone, 'appendsdone not triggered');
           done();
         };
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -767,36 +767,14 @@ QUnit.module('SegmentLoader', function(hooks) {
       const done = assert.async();
 
       return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
-        let appendsdone = false;
-
         loader.playlist(playlistWithDuration(20));
         loader.load();
         this.clock.tick(1);
 
         standardXHRResponse(this.requests.shift(), muxedSegment());
         loader.one('appendsdone', () => {
-          appendsdone = true;
-        });
-
-        let appends = 0;
-
-        const finish = function() {
-          appends++;
-
-          if (appends < 2) {
-            return;
-          }
-
-          assert.ok(appendsdone, 'appendsdone triggered');
+          assert.ok(true, 'appendsdone triggered');
           done();
-        };
-
-        loader.sourceUpdater_.videoBuffer.addEventListener('updateend', () => {
-          loader.sourceUpdater_.videoQueueCallback(finish);
-        });
-
-        loader.sourceUpdater_.audioBuffer.addEventListener('updateend', () => {
-          loader.sourceUpdater_.audioQueueCallback(finish);
         });
       });
     });
@@ -816,10 +794,6 @@ QUnit.module('SegmentLoader', function(hooks) {
           appendsdone = true;
         });
 
-        loader.one('appending', () => {
-          loader.abort();
-        });
-
         let appends = 0;
 
         const finish = function() {
@@ -833,7 +807,8 @@ QUnit.module('SegmentLoader', function(hooks) {
           done();
         };
 
-        loader.sourceUpdater_.videoBuffer.addEventListener('updateend', () => {
+        loader.one('appending', () => {
+          loader.abort();
           loader.sourceUpdater_.videoQueueCallback(finish);
           loader.sourceUpdater_.audioQueueCallback(finish);
         });


### PR DESCRIPTION
## Description
It seems like ie 11 likes to error when using removeSourceBuffer, let's just say that it isn't supported and not use it.