### PR TITLE
fix: always append init segment after trackinfo change

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1914,7 +1914,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.sourceUpdater_.appendBuffer({segmentInfo, type, bytes}, (error) => {
       if (error) {
-        this.error(`append of ${bytes.length} failed for ${type} data of segment #${segmentInfo.mediaIndex} for playlist ${segmentInfo.playlist.id}`);
+        this.error(`${type} append of ${bytes.length}b failed for segment #${segmentInfo.mediaIndex} in playlist ${segmentInfo.playlist.id}`);
         // If an append errors, we can't recover.
         // (see https://w3c.github.io/media-source/#sourcebuffer-append-error).
         // Trigger a special error so that it can be handled separately from normal,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1463,7 +1463,8 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.trigger('trackinfo');
     }
 
-    // trackinfo may cause an abort
+    // trackinfo may cause an abort if the trackinfo
+    // causes a codec change to an unsupported codec.
     if (this.checkForAbort_(simpleSegment.requestId) ||
         this.abortRequestEarly_(simpleSegment.stats)) {
       return;
@@ -1697,8 +1698,10 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     const segmentInfo = this.pendingSegment_;
 
+    // no segment to append any data for or
+    // we do not have information on this specific
+    // segment yet
     if (!segmentInfo || !segmentInfo.trackInfo) {
-      // no segment to append any data for
       return false;
     }
 


### PR DESCRIPTION
This pull request does three things:

1. Always append an init segment after a `trackinfo` update. We do this because if the `trackinfo` causes a `changeType` we **have** to append an init segment or chrome will media error decode.
2. Check for individual segment trackinfo before appending and allow appending after trackinfo
3. Check for an abort after a trackinfo event is triggered, in the case where the type we are changing to is not supported.