### PR TITLE
chore: fix tears of steal playready on the demo page

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -261,7 +261,7 @@
     "mimetype": "application/dash+xml",
     "features": [],
     "keySystems": {
-      "com.widevine.alpha": "https://test.playready.microsoft.com/service/rightsmanager.asmx"
+      "com.microsoft.playready": "https://test.playready.microsoft.com/service/rightsmanager.asmx"
     }
   },
   {


### PR DESCRIPTION
We put `com.widevine.alpha` instead of `com.microsoft.playready` 