### PR TITLE
chore: update DASH stream urls

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -166,7 +166,7 @@
   },
   {
     "name": "DASH - Live simulated DASH from DASH IF",
-    "uri": "https://vm2.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd",
+    "uri": "https://livesim.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd",
     "mimetype": "application/dash+xml",
     "features": ["live"]
   },

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -232,7 +232,7 @@ QUnit[testFn]('Live DASH', function(assert) {
   });
 
   player.src({
-    src: 'https://vm2.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd',
+    src: 'https://livesim.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd',
     type: 'application/dash+xml'
   });
 });


### PR DESCRIPTION
The previous URL was https://vm2.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd. It seems like `vm2` was an old simulated livestream domain that's been deprecated for a while. The new version is http://livesim.dashif.org/.