### PR TITLE
feat: support MPD.Location

### DIFF
--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -151,7 +151,6 @@ simply take on their default values (in the case where they have valid defaults)
   * @maxSegmentDuration
   * @maxSubsegmentDuration
   * ProgramInformation
-  * Location
   * Metrics
 * Period
   * @xlink:href

--- a/package-lock.json
+++ b/package-lock.json
@@ -6815,9 +6815,9 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.10.1.tgz",
-      "integrity": "sha512-8o3r4kdnhkDCjwHieWfVyZHfHfWT1X17n1qeZsqahwMCPpSGGAmbTZKyXkIPWqmENrsfNMYSK80AFOYqlx7m8A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.11.0.tgz",
+      "integrity": "sha512-z9DIs++G+dRopPT5ROQgNdnDbby+j/9dkGoCC20Hd/3swyR8YxTxM8jOtl3zO9cnhjoikVFJuMbH+V8SE0/f5Q==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@videojs/vhs-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "aes-decrypter": "3.0.1",
     "global": "^4.3.2",
     "m3u8-parser": "4.4.2",
-    "mpd-parser": "0.10.1",
+    "mpd-parser": "0.11.0",
     "mux.js": "5.6.6",
     "video.js": "^6 || ^7"
   },

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -678,7 +678,7 @@ export default class DashPlaylistLoader extends EventTarget {
   updateMainManifest_(updatedManifest) {
     this.master = updatedManifest;
 
-    // if locations isn't set or is an empty array, exits early
+    // if locations isn't set or is an empty array, exit early
     if (!this.master.locations || !this.master.locations.length) {
       return;
     }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -629,12 +629,12 @@ export default class DashPlaylistLoader extends EventTarget {
     this.mediaRequest_ = null;
 
     if (!this.masterPlaylistLoader_) {
-      this.master = parseMasterXml({
+      this.updateMaster_(parseMasterXml({
         masterXml: this.masterXml_,
         srcUrl: this.srcUrl,
         clientOffset: this.clientOffset_,
         sidxMapping: this.sidxMapping_
-      });
+      }));
       // We have the master playlist at this point, so
       // trigger this to allow MasterPlaylistController
       // to make an initial playlist selection
@@ -667,6 +667,18 @@ export default class DashPlaylistLoader extends EventTarget {
       this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
       }, this.master.minimumUpdatePeriod);
+    }
+  }
+
+  /**
+   * Given a new manifest, update our pointer to it and update the srcUrl based on the location element of the manifest, if exists.
+   *
+   * @param {Object} updatedMaster the manifest to update to
+   */
+  updateMaster_(updatedMaster) {
+    this.master = updatedMaster;
+    if (this.master.location && this.master.location !== this.srcUrl) {
+      this.srcUrl = this.master.location;
     }
   }
 
@@ -760,7 +772,7 @@ export default class DashPlaylistLoader extends EventTarget {
             );
           }
         } else {
-          this.master = updatedMaster;
+          this.updateMaster_(updatedMaster);
           if (this.media_) {
             this.media_ = this.master.playlists[this.media_.id];
           }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -678,7 +678,7 @@ export default class DashPlaylistLoader extends EventTarget {
   updateMainManifest_(updatedManifest) {
     this.master = updatedManifest;
 
-    // if locations isn't set or is an empty array, exist early
+    // if locations isn't set or is an empty array, exits early
     if (!this.master.locations || this.master.locations && !this.master.locations.length) {
       return;
     }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -679,7 +679,7 @@ export default class DashPlaylistLoader extends EventTarget {
     this.master = updatedManifest;
 
     // if locations isn't set or is an empty array, exits early
-    if (!this.master.locations || this.master.locations && !this.master.locations.length) {
+    if (!this.master.locations || !this.master.locations.length) {
       return;
     }
 

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -629,7 +629,7 @@ export default class DashPlaylistLoader extends EventTarget {
     this.mediaRequest_ = null;
 
     if (!this.masterPlaylistLoader_) {
-      this.updateMaster_(parseMasterXml({
+      this.updateMainManifest_(parseMasterXml({
         masterXml: this.masterXml_,
         srcUrl: this.srcUrl,
         clientOffset: this.clientOffset_,
@@ -671,14 +671,22 @@ export default class DashPlaylistLoader extends EventTarget {
   }
 
   /**
-   * Given a new manifest, update our pointer to it and update the srcUrl based on the location element of the manifest, if exists.
+   * Given a new manifest, update our pointer to it and update the srcUrl based on the location elements of the manifest, if they exist.
    *
-   * @param {Object} updatedMaster the manifest to update to
+   * @param {Object} updatedManifest the manifest to update to
    */
-  updateMaster_(updatedMaster) {
-    this.master = updatedMaster;
-    if (this.master.location && this.master.location !== this.srcUrl) {
-      this.srcUrl = this.master.location;
+  updateMainManifest_(updatedManifest) {
+    this.master = updatedManifest;
+
+    // if locations isn't set or is an empty array, exist early
+    if (!this.master.locations || this.master.locations && !this.master.locations.length) {
+      return;
+    }
+
+    const location = this.master.locations[0];
+
+    if (location !== this.srcUrl) {
+      this.srcUrl = location;
     }
   }
 
@@ -772,7 +780,7 @@ export default class DashPlaylistLoader extends EventTarget {
             );
           }
         } else {
-          this.updateMaster_(updatedMaster);
+          this.updateMainManifest_(updatedMaster);
           if (this.media_) {
             this.media_ = this.master.playlists[this.media_.id];
           }

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -2293,6 +2293,18 @@ QUnit.test(
   }
 );
 
+QUnit.test('use MPD.Location when refreshing the xml', function(assert) {
+  const loader = new DashPlaylistLoader('location.mpd', this.fakeVhs);
+
+  loader.load();
+  this.standardXHRResponse(this.requests.shift());
+
+  this.clock.tick(4 * 1000);
+
+  assert.equal(this.requests.length, 1, 'refreshed manifest');
+  assert.equal(this.requests[0].uri, 'newlocation/', 'refreshed manifest');
+});
+
 QUnit.test('refreshes the xml if there is a minimumUpdatePeriod', function(assert) {
   const loader = new DashPlaylistLoader('dash-live.mpd', this.fakeVhs);
   let minimumUpdatePeriods = 0;

--- a/test/manifests/location.mpd
+++ b/test/manifests/location.mpd
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:full:2011" minBufferTime="1.5" mediaPresentationDuration="PT4S" minimumUpdatePeriod="PT4S">
+  <Location>newlocation/</Location>
+  <Period>
+    <BaseURL>main/</BaseURL>
+    <AdaptationSet mimeType="video/mp4">
+      <BaseURL>video/</BaseURL>
+      <Representation id="1080p" bandwidth="6800000" width="1920" height="1080" codecs="avc1.420015">
+        <BaseURL>1080/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$-segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="10" startNumber="0" />
+      </Representation>
+      <Representation id="720p" bandwidth="2400000" width="1280" height="720" codecs="avc1.420015">
+        <BaseURL>720/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$-segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="10" startNumber="0" />
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4">
+      <BaseURL>audio/</BaseURL>
+      <Representation id="audio" bandwidth="128000" codecs="mp4a.40.2">
+        <BaseURL>720/</BaseURL>
+        <SegmentTemplate media="segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="10" startNumber="0" />
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
Depends on https://github.com/videojs/mpd-parser/pull/102
With it, I can see that we properly update the srcUrl internally based on the location, for example with a stream like https://livesim.dashif.org/livesim/startrel_-20/stoprel_20/timeoffset_0/testpic_2s/Manifest.mpd

TODO
- [x] Add some tests
- [x] Make sure that a more streams with Location that don't also do a 302 redirect on the main manifest function properly
- [x] update mpd-parser