### PR TITLE
feat: default handleManfiestRedirect to true

### DIFF
--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -21,7 +21,10 @@ export const resolveManifestRedirect = (handleManifestRedirect, url, req) => {
   // To understand how the responseURL below is set and generated:
   // - https://fetch.spec.whatwg.org/#concept-response-url
   // - https://fetch.spec.whatwg.org/#atomic-http-redirect-handling
-  if (handleManifestRedirect && req.responseURL &&
+  if (
+    handleManifestRedirect &&
+    req &&
+    req.responseURL &&
     url !== req.responseURL
   ) {
     return req.responseURL;

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -530,7 +530,7 @@ class VhsHandler extends Component {
   setOptions_() {
     // defaults
     this.options_.withCredentials = this.options_.withCredentials || false;
-    this.options_.handleManifestRedirects = this.options_.handleManifestRedirects || false;
+    this.options_.handleManifestRedirects = this.options_.handleManifestRedirects === false ? false : true;
     this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions === false ? false : true;
     this.options_.useDevicePixelRatio = this.options_.useDevicePixelRatio || false;
     this.options_.smoothQualityChange = this.options_.smoothQualityChange || false;


### PR DESCRIPTION
This makes it so that users don't need to specify handleManifestRedirect themselves. It was originally defaulted to false because the option doesn't work on IE11 but it works everywhere else.
Makes streams like https://livesim.dashif.org/livesim/startrel_-60/stoprel_-20/timeoffset_0/testpic_2s/Manifest.mpd work without extra configuration.