### PR TITLE
Request variable missing in function call

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -194,7 +194,7 @@ export const filterChangedSidxMappings = (masterXml, srcUrl, clientOffset, oldSi
 export const requestSidx_ = (loader, sidxRange, playlist, xhr, options, finishProcessingFn) => {
   const sidxInfo = {
     // resolve the segment URL relative to the playlist
-    uri: resolveManifestRedirect(options.handleManifestRedirects, sidxRange.resolvedUri),
+    uri: resolveManifestRedirect(options.handleManifestRedirects, sidxRange.resolvedUri, xhr),
     // resolvedUri: sidxRange.resolvedUri,
     byterange: sidxRange.byterange,
     // the segment's playlist


### PR DESCRIPTION
## Description
When setting the option handleManifestRedirects to true, this call fails because the req variable in the function definition is null

## Specific Changes proposed
Please, add the xhr variable at the function call.

