### PR TITLE
rfc: Handle a stall case when moving window moves to fast, and mediaIndex …

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1261,7 +1261,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return null;
     }
     // if media index is negative, it means the segment loader is trying to
-    // load an item expired (abs(mediaIndex) * segment duration) ago. So it might 
+    // load an item expired (abs(mediaIndex) * segment duration) ago. So it might
     // be worthwhile to skip to the first item on the playlist
     mediaIndex = Math.max(0, mediaIndex);
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1257,9 +1257,13 @@ export default class SegmentLoader extends videojs.EventTarget {
   }
 
   generateSegmentInfo_(playlist, mediaIndex, startOfSegment, isSyncRequest) {
-    if (mediaIndex < 0 || mediaIndex >= playlist.segments.length) {
+    if (mediaIndex >= playlist.segments.length) {
       return null;
     }
+    // if media index is negative, it means the segment loader is trying to
+    // load an item expired (abs(mediaIndex) * segment duration) ago. So it might 
+    // be worthwhile to skip to the first item on the playlist
+    mediaIndex = Math.max(0, mediaIndex);
 
     const segment = playlist.segments[mediaIndex];
     const audioBuffered = this.sourceUpdater_.audioBuffered();


### PR DESCRIPTION
…becomes negative

## Description
Please describe the change as necessary.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.
Link to bug
https://github.com/videojs/http-streaming/issues/931
In summary, when the HLS window moves too fast, the mediaIndex could become negative.
The segment-loader ceases to fillBuffer_() because segmentInfo is null.

## Specific Changes proposed
At generateSegmentInfo_() in segment-loader.js, allow negative mediaIndex to go through, and return the segmentInfo of the first item on the playlist.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
