### PR TITLE
rfc: Improve computing buffered time in segment-loader

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -109,21 +109,22 @@ const segmentInfoString = (segmentInfo) => {
 };
 
 /**
- * Returns the buffered time beyond current time 
+ * Returns the buffered time beyond current time
  *
  * @param {TimeRange[]} buffered
  *        The loader's buffer
- * @param {number} currentTime 
- *        The player's currentTime 
+ * @param {number} currentTime
+ *        The player's currentTime
  *
  * @return {number}
- *        A number representing the amount buffered 
+ *        A number representing the amount buffered
  */
 const bufferedTimeBeyondCurrentTime = (buffered, currentTime) => {
   if (!buffered || !buffered.length || isNaN(currentTime)) {
     return 0;
   }
   let totalBufferedTime = 0;
+
   for (let i = 0; i < buffered.length; i++) {
     // case where currentTime falls within the buffered interval
     if (buffered.start(i) <= currentTime && currentTime <= buffered.end(i)) {
@@ -1182,6 +1183,10 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (!playlist.segments.length) {
       return null;
+    }
+
+    if (buffered.length) {
+      lastBufferedEnd = buffered.end(buffered.length - 1);
     }
 
     const bufferedTime = bufferedTimeBeyondCurrentTime(buffered, currentTime);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -108,6 +108,8 @@ const segmentInfoString = (segmentInfo) => {
   ].join(' ');
 };
 
+const timingInfoPropertyForMedia = (mediaType) => `${mediaType}TimingInfo`;
+
 /**
  * Returns the buffered time beyond current time
  *

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -119,7 +119,7 @@ const segmentInfoString = (segmentInfo) => {
  * @return {number}
  *        A number representing the amount buffered 
  */
-const bufferedTimeBeyondCurrentTime = (buffered, currentTime) = {
+const bufferedTimeBeyondCurrentTime = (buffered, currentTime) => {
   if (!buffered || !buffered.length || isNaN(currentTime)) {
     return 0;
   }
@@ -134,7 +134,7 @@ const bufferedTimeBeyondCurrentTime = (buffered, currentTime) = {
     }
   }
   return Math.max(0, totalBufferedTime);
-}
+};
 
 /**
  * Returns the timestamp offset to use for the segment.
@@ -1184,7 +1184,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return null;
     }
 
-    const bufferedTime = bufferedTimeBeyondCurrentTime(buffered, currentTime)
+    const bufferedTime = bufferedTimeBeyondCurrentTime(buffered, currentTime);
     // if there is plenty of content buffered, and the video has
     // been played before relax for awhile
     if (bufferedTime >= this.goalBufferLength_()) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1190,6 +1190,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     const bufferedTime = bufferedTimeBeyondCurrentTime(buffered, currentTime);
+
     // if there is plenty of content buffered, and the video has
     // been played before relax for awhile
     if (bufferedTime >= this.goalBufferLength_()) {


### PR DESCRIPTION
## Description
The current checkBuffer_() in segment-loader.js tends to over-estimate the amount buffered.
For example, if we have buffered:
[0 => 21, 79 => 80]
At currentTime == 20, checkBuffer_() would think it has buffered 80 - 20 == 60 seconds worth of data.
But the reality is, we have only buffered 2 seconds worth of data.

## Specific Changes proposed
Adding up individual intervals in buffered

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
