### PR TITLE
fix: Throw a player error when trying to play DRM content without eme

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -243,13 +243,12 @@ const setupEmeOptions = ({
   audioMedia,
   mainPlaylists
 }) => {
-  if (!player.eme) {
-    return;
-  }
-
   const sourceOptions = emeKeySystems(sourceKeySystems, media, audioMedia);
 
-  if (!sourceOptions) {
+  if (!player.eme || !sourceOptions) {
+    if (sourceOptions) {
+      player.error({code: 5, message: 'DRM encrypted source cannot be decrypted without DRM plugin'});
+    }
     return;
   }
 
@@ -825,7 +824,8 @@ class VhsHandler extends Component {
 
       setupEmeOptions({
         player: this.player_,
-        sourceKeySystems: this.source_.keySystems,
+        // eslint-disable-next-line
+        sourceKeySystems: this.source_.keySystems || this.source_.key_systems,
         media: this.playlists.media(),
         audioMedia: audioPlaylistLoader && audioPlaylistLoader.media(),
         mainPlaylists: this.playlists.master.playlists

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -247,8 +247,7 @@ const setupEmeOptions = ({
 
   if (!player.eme || !sourceOptions) {
     if (sourceOptions) {
-      videojs.log.error('DRM encrypted source cannot be decrypted without a DRM plugin');
-      player.error({code: 5});
+      videojs.log.warn('DRM encrypted source cannot be decrypted without a DRM plugin');
     }
     return;
   }
@@ -825,8 +824,7 @@ class VhsHandler extends Component {
 
       setupEmeOptions({
         player: this.player_,
-        // eslint-disable-next-line
-        sourceKeySystems: this.source_.keySystems || this.source_.key_systems,
+        sourceKeySystems: this.source_.keySystems,
         media: this.playlists.media(),
         audioMedia: audioPlaylistLoader && audioPlaylistLoader.media(),
         mainPlaylists: this.playlists.master.playlists

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -247,7 +247,8 @@ const setupEmeOptions = ({
 
   if (!player.eme || !sourceOptions) {
     if (sourceOptions) {
-      player.error({code: 5, message: 'DRM encrypted source cannot be decrypted without DRM plugin'});
+      videojs.log.error('DRM encrypted source cannot be decrypted without a DRM plugin');
+      player.error({code: 5});
     }
     return;
   }

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -245,14 +245,18 @@ const setupEmeOptions = ({
 }) => {
   const sourceOptions = emeKeySystems(sourceKeySystems, media, audioMedia);
 
-  if (!player.eme || !sourceOptions) {
-    if (sourceOptions) {
-      videojs.log.warn('DRM encrypted source cannot be decrypted without a DRM plugin');
-    }
+  if (!sourceOptions) {
     return;
   }
 
   player.currentSource().keySystems = sourceOptions;
+
+  // eme handles the rest of the setup, so if it is missing
+  // do nothing.
+  if (sourceOptions && !player.eme) {
+    videojs.log.warn('DRM encrypted source cannot be decrypted without a DRM plugin');
+    return;
+  }
 
   // works around https://bugs.chromium.org/p/chromium/issues/detail?id=895449
   // in non-IE11 browsers. In IE11 this is too early to initialize media keys

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -136,7 +136,7 @@ const emeKeySystems = (keySystemOptions, videoPlaylist, audioPlaylist) => {
     audio: audioPlaylist && audioPlaylist.attributes && audioPlaylist.attributes.CODECS
   };
 
-  if (!codecs.audio && codecs.video.split(',').length > 1) {
+  if (!codecs.audio && codecs.video && codecs.video.split(',').length > 1) {
     codecs.video.split(',').forEach(function(codec) {
       codec = codec.trim();
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -5765,9 +5765,9 @@ QUnit.module('setupEmeOptions', {
   }
 });
 
-QUnit.test('no error if no eme', function(assert) {
-  const player = {error: () => {}};
-  const sourceKeySystems = {};
+QUnit.test('no error if no eme and no key systems', function(assert) {
+  const player = {};
+  const sourceKeySystems = null;
   const media = {};
   const audioMedia = {};
   const mainPlaylists = [];
@@ -5775,6 +5775,32 @@ QUnit.test('no error if no eme', function(assert) {
   setupEmeOptions({ player, sourceKeySystems, media, audioMedia, mainPlaylists });
 
   assert.ok(true, 'no exception');
+});
+
+QUnit.test('player and log error if no eme and we have key systems', function(assert) {
+  let playerError;
+  let logError;
+  const player = {error: (err) => {
+    playerError = err;
+  }};
+  const sourceKeySystems = {};
+  const media = {};
+  const audioMedia = {};
+  const mainPlaylists = [];
+
+  const origError = videojs.log.error;
+
+  videojs.log.error = (err) => {
+    logError = err;
+  };
+
+  setupEmeOptions({ player, sourceKeySystems, media, audioMedia, mainPlaylists });
+
+  assert.ok(true, 'no exception');
+  assert.equal(logError, 'DRM encrypted source cannot be decrypted without a DRM plugin', 'logs expected error');
+  assert.equal(playerError.code, 5, 'drm decryption error');
+
+  videojs.log.error = origError;
 });
 
 QUnit.test('no initialize calls if no source key systems', function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -5778,29 +5778,25 @@ QUnit.test('no error if no eme and no key systems', function(assert) {
 });
 
 QUnit.test('player and log error if no eme and we have key systems', function(assert) {
-  let playerError;
-  let logError;
-  const player = {error: (err) => {
-    playerError = err;
-  }};
+  const player = {};
   const sourceKeySystems = {};
   const media = {};
   const audioMedia = {};
   const mainPlaylists = [];
 
-  const origError = videojs.log.error;
+  let logWarn;
+  const origWarn = videojs.log.warn;
 
-  videojs.log.error = (err) => {
-    logError = err;
+  videojs.log.warn = (line) => {
+    logWarn = line;
   };
 
   setupEmeOptions({ player, sourceKeySystems, media, audioMedia, mainPlaylists });
 
   assert.ok(true, 'no exception');
-  assert.equal(logError, 'DRM encrypted source cannot be decrypted without a DRM plugin', 'logs expected error');
-  assert.equal(playerError.code, 5, 'drm decryption error');
+  assert.equal(logWarn, 'DRM encrypted source cannot be decrypted without a DRM plugin', 'logs expected error');
 
-  videojs.log.error = origError;
+  videojs.log.warn = origWarn;
 });
 
 QUnit.test('no initialize calls if no source key systems', function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -5778,11 +5778,12 @@ QUnit.test('no error if no eme and no key systems', function(assert) {
 });
 
 QUnit.test('log error if no eme and we have key systems', function(assert) {
-  const player = {};
   const sourceKeySystems = {};
   const media = {};
   const audioMedia = {};
   const mainPlaylists = [];
+  const src = {};
+  const player = {currentSource: () => src};
 
   let logWarn;
   const origWarn = videojs.log.warn;
@@ -5794,6 +5795,7 @@ QUnit.test('log error if no eme and we have key systems', function(assert) {
   setupEmeOptions({ player, sourceKeySystems, media, audioMedia, mainPlaylists });
 
   assert.equal(logWarn, 'DRM encrypted source cannot be decrypted without a DRM plugin', 'logs expected error');
+  assert.ok(src.hasOwnProperty('keySystems'), 'source key systems was set');
 
   videojs.log.warn = origWarn;
 });

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -5766,7 +5766,7 @@ QUnit.module('setupEmeOptions', {
 });
 
 QUnit.test('no error if no eme', function(assert) {
-  const player = {};
+  const player = {error: () => {}};
   const sourceKeySystems = {};
   const media = {};
   const audioMedia = {};

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -5777,7 +5777,7 @@ QUnit.test('no error if no eme and no key systems', function(assert) {
   assert.ok(true, 'no exception');
 });
 
-QUnit.test('player and log error if no eme and we have key systems', function(assert) {
+QUnit.test('log error if no eme and we have key systems', function(assert) {
   const player = {};
   const sourceKeySystems = {};
   const media = {};
@@ -5793,7 +5793,6 @@ QUnit.test('player and log error if no eme and we have key systems', function(as
 
   setupEmeOptions({ player, sourceKeySystems, media, audioMedia, mainPlaylists });
 
-  assert.ok(true, 'no exception');
   assert.equal(logWarn, 'DRM encrypted source cannot be decrypted without a DRM plugin', 'logs expected error');
 
   videojs.log.warn = origWarn;


### PR DESCRIPTION
## Description
I run into issues where I am trying to play drm content but do not have the eme plugin. This causes the video buffer to increase but playback will never start because drm was never initialized. I propose that we trigger a player error in this case. If we don't want to go that far though we can just make this a warning. 