### PR TITLE
feat: Update minimumUpdatePeriod handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6815,9 +6815,9 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.10.1.tgz",
-      "integrity": "sha512-8o3r4kdnhkDCjwHieWfVyZHfHfWT1X17n1qeZsqahwMCPpSGGAmbTZKyXkIPWqmENrsfNMYSK80AFOYqlx7m8A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.12.0.tgz",
+      "integrity": "sha512-Ov5Oz9bw5X/G8V/6PlO+rHuqKywYYjQ6USyv8fqFMs413HkrzlpDjgUKSBD7C+/J19ID5mWtxzrpMf4Yp++iZg==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@videojs/vhs-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "aes-decrypter": "3.0.1",
     "global": "^4.3.2",
     "m3u8-parser": "4.4.2",
-    "mpd-parser": "0.10.1",
+    "mpd-parser": "0.12.0",
     "mux.js": "5.6.6",
     "video.js": "^6 || ^7"
   },

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -94,6 +94,10 @@ export const updateMaster = (oldMaster, newMaster) => {
     }
   });
 
+  if (newMaster.minimumUpdatePeriod !== oldMaster.minimumUpdatePeriod) {
+    noChanges = false;
+  }
+
   if (noChanges) {
     return null;
   }
@@ -657,16 +661,10 @@ export default class DashPlaylistLoader extends EventTarget {
       this.media(this.master.playlists[0]);
     }
 
-    // TODO: minimumUpdatePeriod can have a value of 0. Currently the manifest will not
-    // be refreshed when this is the case. The inter-op guide says that when the
-    // minimumUpdatePeriod is 0, the manifest should outline all currently available
-    // segments, but future segments may require an update. I think a good solution
-    // would be to update the manifest at the same rate that the media playlists
-    // are "refreshed", i.e. every targetDuration.
-    if (this.master && this.master.minimumUpdatePeriod) {
+    if (this.master && this.master.minimumUpdatePeriod >= 0) {
       this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
-      }, this.master.minimumUpdatePeriod);
+      }, this.master.minimumUpdatePeriod || this.media().targetDuration * 1000);
     }
   }
 
@@ -746,10 +744,11 @@ export default class DashPlaylistLoader extends EventTarget {
 
                 // Clear & reset timeout with new minimumUpdatePeriod
                 window.clearTimeout(this.minimumUpdatePeriodTimeout_);
-                if (this.master.minimumUpdatePeriod) {
+
+                if (this.master.minimumUpdatePeriod >= 0) {
                   this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
                     this.trigger('minimumUpdatePeriod');
-                  }, this.master.minimumUpdatePeriod);
+                  }, this.master.minimumUpdatePeriod || playlist.targetDuration * 1000);
                 }
 
                 // TODO: do we need to reload the current playlist?
@@ -769,10 +768,11 @@ export default class DashPlaylistLoader extends EventTarget {
 
       // Clear & reset timeout with new minimumUpdatePeriod
       window.clearTimeout(this.minimumUpdatePeriodTimeout_);
-      if (this.master.minimumUpdatePeriod) {
+
+      if (this.master.minimumUpdatePeriod >= 0) {
         this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
           this.trigger('minimumUpdatePeriod');
-        }, this.master.minimumUpdatePeriod);
+        }, this.master.minimumUpdatePeriod || this.media().targetDuration * 1000);
       }
     });
   }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -650,6 +650,16 @@ export default class DashPlaylistLoader extends EventTarget {
     }
   }
 
+  updateMinimumUpdatePeriodTimeout_() {
+    const minimumUpdatePeriod = this.master && this.master.minimumUpdatePeriod;
+
+    if (minimumUpdatePeriod >= 0) {
+      this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
+        this.trigger('minimumUpdatePeriod');
+      }, minimumUpdatePeriod || this.media().targetDuration * 1000);
+    }
+  }
+
   /**
    * Handler for after client/server clock synchronization has happened. Sets up
    * xml refresh timer if specificed by the manifest.
@@ -661,11 +671,7 @@ export default class DashPlaylistLoader extends EventTarget {
       this.media(this.master.playlists[0]);
     }
 
-    if (this.master && this.master.minimumUpdatePeriod >= 0) {
-      this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
-        this.trigger('minimumUpdatePeriod');
-      }, this.master.minimumUpdatePeriod || this.media().targetDuration * 1000);
-    }
+    this.updateMinimumUpdatePeriodTimeout_();
   }
 
   /**
@@ -765,11 +771,7 @@ export default class DashPlaylistLoader extends EventTarget {
                 // Clear & reset timeout with new minimumUpdatePeriod
                 window.clearTimeout(this.minimumUpdatePeriodTimeout_);
 
-                if (this.master.minimumUpdatePeriod >= 0) {
-                  this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
-                    this.trigger('minimumUpdatePeriod');
-                  }, this.master.minimumUpdatePeriod || playlist.targetDuration * 1000);
-                }
+                this.updateMinimumUpdatePeriodTimeout_();
 
                 // TODO: do we need to reload the current playlist?
                 this.refreshMedia_(this.media().id);
@@ -789,11 +791,7 @@ export default class DashPlaylistLoader extends EventTarget {
       // Clear & reset timeout with new minimumUpdatePeriod
       window.clearTimeout(this.minimumUpdatePeriodTimeout_);
 
-      if (this.master.minimumUpdatePeriod >= 0) {
-        this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
-          this.trigger('minimumUpdatePeriod');
-        }, this.master.minimumUpdatePeriod || this.media().targetDuration * 1000);
-      }
+      this.updateMinimumUpdatePeriodTimeout_();
     });
   }
 

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -651,11 +651,17 @@ export default class DashPlaylistLoader extends EventTarget {
   }
 
   updateMinimumUpdatePeriodTimeout_() {
+    // Clear existing timeout
+    window.clearTimeout(this.minimumUpdatePeriodTimeout_);
+
     const minimumUpdatePeriod = this.master && this.master.minimumUpdatePeriod;
 
     if (minimumUpdatePeriod >= 0) {
       this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
+      // We use the target duration here because a minimumUpdatePeriod value of 0
+      // indicates that the current MPD has no future validity, so a new one will
+      // need to be acquired when new media segments are to be made available
       }, minimumUpdatePeriod || this.media().targetDuration * 1000);
     }
   }
@@ -768,9 +774,6 @@ export default class DashPlaylistLoader extends EventTarget {
                 // update loader's sidxMapping with parsed sidx box
                 this.sidxMapping_[sidxKey].sidx = sidx;
 
-                // Clear & reset timeout with new minimumUpdatePeriod
-                window.clearTimeout(this.minimumUpdatePeriodTimeout_);
-
                 this.updateMinimumUpdatePeriodTimeout_();
 
                 // TODO: do we need to reload the current playlist?
@@ -787,9 +790,6 @@ export default class DashPlaylistLoader extends EventTarget {
           }
         }
       }
-
-      // Clear & reset timeout with new minimumUpdatePeriod
-      window.clearTimeout(this.minimumUpdatePeriodTimeout_);
 
       this.updateMinimumUpdatePeriodTimeout_();
     });


### PR DESCRIPTION
## Description
This is part of a set of upcoming changes to add support for live DASH playback. Specifically, this PR differentiates the handling of 2 cases which were formerly conflated:

1. The `MPD@minimumUpdatePeriod` attribute has a _value of 0_, indicating that the MPD has no validity after the moment it was retrieved.
2. The `MPD@minimumUpdatePeriod` attribute is _absent_, indicating the MPD has infinite validity and will never be updated

## Specific Changes proposed
- Update [`mpd-parser`](https://github.com/videojs/mpd-parser/pull/103) to allow us to identify case 2
- Make sure `updateMaster()` checks if a manifest's `minimumUpdatePeriod` value changes, and return the new manifest if so.
- Add handling for case 1: minimumUpdateperiod is 0 
  - Continue refreshing manifests every `targetDuration`, per existing [`TODO`](https://github.com/videojs/http-streaming/compare/update-minimumUpdatePeriod-handling?expand=1#diff-ca1029eb342915b65f2b261194fef835L660-L665)
- Add handling for case 2: minimumUpdatePeriod is absent
  - Do not trigger a `'minimumUpdatePeriod'` event as there is no need to refresh the manifest
- Add/update tests