### PR TITLE
fix: detect demuxed video underflow gaps

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -443,10 +443,15 @@ export default class PlaybackWatcher {
       return true;
     }
 
+    const sourceUpdater = this.tech_.vhs.masterPlaylistController_.sourceUpdater_;
     const buffered = this.tech_.buffered();
-    const nextRange = Ranges.findNextRange(buffered, currentTime);
+    const videoUnderflow = this.videoUnderflow_({
+      audioBuffered: sourceUpdater.audioBuffer && sourceUpdater.audioBuffered() || null,
+      videoBuffered: sourceUpdater.videoBuffer && sourceUpdater.videoBuffered() || null,
+      currentTime
+    });
 
-    if (this.videoUnderflow_(nextRange, buffered, currentTime)) {
+    if (videoUnderflow) {
       // Even though the video underflowed and was stuck in a gap, the audio overplayed
       // the gap, leading currentTime into a buffered range. Seeking to currentTime
       // allows the video to catch up to the audio position without losing any audio
@@ -459,6 +464,7 @@ export default class PlaybackWatcher {
       this.tech_.trigger({type: 'usage', name: 'hls-video-underflow'});
       return true;
     }
+    const nextRange = Ranges.findNextRange(buffered, currentTime);
 
     // check for gap
     if (nextRange.length > 0) {
@@ -512,18 +518,36 @@ export default class PlaybackWatcher {
     return false;
   }
 
-  videoUnderflow_(nextRange, buffered, currentTime) {
-    if (nextRange.length === 0) {
+  videoUnderflow_({videoBuffered, audioBuffered, currentTime}) {
+    if (!videoBuffered) {
+      return;
+    }
+    let gap;
+
+    if (videoBuffered.length && audioBuffered.length) {
+      const lastVideoRange = Ranges.findRange(videoBuffered, currentTime - 3);
+      const videoRange = Ranges.findRange(videoBuffered, currentTime);
+      const audioRange = Ranges.findRange(audioBuffered, currentTime);
+
+      if (audioRange.length && !videoRange.length && lastVideoRange.length) {
+        gap = {start: lastVideoRange.end(0), end: audioRange.end(0)};
+      }
+
+    } else {
+      const nextRange = Ranges.findNextRange(audioBuffered, currentTime);
+
       // Even if there is no available next range, there is still a possibility we are
       // stuck in a gap due to video underflow.
-      const gap = this.gapFromVideoUnderflow_(buffered, currentTime);
-
-      if (gap) {
-        this.logger_(`Encountered a gap in video from ${gap.start} to ${gap.end}. ` +
-                     `Seeking to current time ${currentTime}`);
-
-        return true;
+      if (!nextRange.length) {
+        gap = this.gapFromVideoUnderflow_(videoBuffered, currentTime);
       }
+    }
+
+    if (gap) {
+      this.logger_(`Encountered a gap in video from ${gap.start} to ${gap.end}. ` +
+        `Seeking to current time ${currentTime}`);
+
+      return true;
     }
 
     return false;

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -519,7 +519,7 @@ export default class PlaybackWatcher {
   }
 
   videoUnderflow_({videoBuffered, audioBuffered, currentTime}) {
-    // audio only content will not have video underflor :)
+    // audio only content will not have video underflow :)
     if (!videoBuffered) {
       return;
     }
@@ -527,7 +527,7 @@ export default class PlaybackWatcher {
 
     // find a gap in demuxed content.
     if (videoBuffered.length && audioBuffered.length) {
-      // in Chrome audio will continue to play for ~3 when we run out of video
+      // in Chrome audio will continue to play for ~3s when we run out of video
       // so we have to check that the video buffer did have some buffer in the
       // past.
       const lastVideoRange = Ranges.findRange(videoBuffered, currentTime - 3);

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -242,11 +242,11 @@ QUnit.test('skips over gap in Chrome due to demuxed video underflow', function(a
   const mpc = this.player.tech_.vhs.masterPlaylistController_;
 
   mpc.sourceUpdater_.videoBuffered = () => {
-    return videojs.createTimeRanges([[0, 10], [10, 15]]);
+    return videojs.createTimeRanges([[0, 15]]);
   };
 
   mpc.sourceUpdater_.audioBuffered = () => {
-    return videojs.createTimeRanges([[0, 10], [10, 20]]);
+    return videojs.createTimeRanges([[0, 20]]);
   };
 
   this.player.currentTime(18);

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -183,13 +183,24 @@ export const useFakeEnvironment = function(assert) {
         if (this.log && this.log[level] && this.log[level].restore) {
           if (assert) {
             const calls = (this.log[level].args || []).map((args) => {
-              return args.join(', ');
+              return args.reduce((acc, val) => {
+                if (acc) {
+                  acc += ', ';
+                }
+
+                acc += val;
+
+                if (val.stack) {
+                  acc += '\n' + val.stack;
+                }
+                return acc;
+              }, '');
             }).join('\n  ');
 
             assert.equal(
               this.log[level].callCount,
               0,
-              'no unexpected logs at level "' + level + '":\n  ' + calls
+              'no unexpected logs at level "' + level + '":\n' + calls
             );
           }
           this.log[level].restore();


### PR DESCRIPTION
## Description
We are seeing a video underflow for demuxed fmp4 content. I think the main issue is timing related, but I have yet to narrow down the cause. While going through our code I noticed that we already detect video underflows for **muxed** content. I added code to detect **demuxed** video underflows so that we can fix those as well.
