### PR TITLE
fix: dash manifest not refreshed if only some playlists are updated

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -61,7 +61,7 @@ export const parseMasterXml = ({ masterXml, srcUrl, clientOffset, sidxMapping })
  *         playlists merged in
  */
 export const updateMaster = (oldMaster, newMaster) => {
-  let noChanges;
+  let noChanges = true;
   let update = mergeOptions(oldMaster, {
     // These are top level properties that can be updated
     duration: newMaster.duration,
@@ -74,8 +74,7 @@ export const updateMaster = (oldMaster, newMaster) => {
 
     if (playlistUpdate) {
       update = playlistUpdate;
-    } else {
-      noChanges = true;
+      noChanges = false;
     }
   }
 

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -80,10 +80,15 @@ QUnit.test('updateMaster: returns falsy when there are no changes', function(ass
 
 QUnit.test('updateMaster: updates playlists', function(assert) {
   const master = {
-    playlists: {
-      length: 1,
-      0: { uri: '0', id: '0' }
+    playlists: [{
+      uri: '0',
+      id: '0'
     },
+    {
+      uri: '1',
+      id: '1',
+      segments: []
+    }],
     mediaGroups: {
       AUDIO: {},
       SUBTITLES: {}
@@ -92,15 +97,18 @@ QUnit.test('updateMaster: updates playlists', function(assert) {
     minimumUpdatePeriod: 0
   };
 
+  // Only the first playlist is changed
   const update = {
-    playlists: {
-      length: 1,
-      0: {
-        id: '0',
-        uri: '0',
-        segments: []
-      }
+    playlists: [{
+      id: '0',
+      uri: '0',
+      segments: []
     },
+    {
+      uri: '1',
+      id: '1',
+      segments: []
+    }],
     mediaGroups: {
       AUDIO: {},
       SUBTITLES: {}
@@ -112,14 +120,16 @@ QUnit.test('updateMaster: updates playlists', function(assert) {
   assert.deepEqual(
     updateMaster(master, update),
     {
-      playlists: {
-        length: 1,
-        0: {
-          id: '0',
-          uri: '0',
-          segments: []
-        }
+      playlists: [{
+        id: '0',
+        uri: '0',
+        segments: []
       },
+      {
+        uri: '1',
+        id: '1',
+        segments: []
+      }],
       mediaGroups: {
         AUDIO: {},
         SUBTITLES: {}


### PR DESCRIPTION
## Description
This fixes an issue where an MPD update can be missed if some media playlists are updated while the last playlist remains unchanged (see [here](https://github.com/videojs/http-streaming/blob/master/src/dash-playlist-loader.js#L71-L80))
## Specific Changes proposed
In `updateMaster()`, update `noChanges` to default to `true`, and set it to `false` if any playlist is changed.