### PR TITLE
fix: audio groups with the same uri as media do not count

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -297,5 +297,11 @@
       "com.widevine.alpha": "https://amssamples.keydelivery.mediaservices.windows.net/Widevine/?KID=1ab45440-532c-4399-94dc-5c5ad9584bac",
       "com.microsoft.playready": "https://amssamples.keydelivery.mediaservices.windows.net/PlayReady/"
     }
+  },
+  {
+    "name": "Big Buck Bunny Audio only, groups have same uri as renditons",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/audio-only-dupe-groups/prog_index.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
   }
 ]

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -402,11 +402,8 @@ export const initialize = {
         return playlist.attributes[type] === groupId;
       });
 
-      // List of playlists that have an AUDIO attribute value matching the current
-      // group ID
       for (const variantLabel in mediaGroups[type][groupId]) {
         let properties = mediaGroups[type][groupId][variantLabel];
-        let playlistLoader;
 
         // List of playlists for the current group ID that have a matching uri with
         // this alternate audio variant
@@ -422,6 +419,8 @@ export const initialize = {
           // from the same playlist.
           delete properties.resolvedUri;
         }
+
+        let playlistLoader;
 
         // if vhs-json was provided as the source, and the media playlist was resolved,
         // use the resolved media playlist object

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -375,7 +375,7 @@ export const initialize = {
       sourceType,
       segmentLoaders: { [type]: segmentLoader },
       requestOptions,
-      master: { mediaGroups },
+      master: { mediaGroups, playlists },
       mediaTypes: {
         [type]: {
           groups,
@@ -398,10 +398,30 @@ export const initialize = {
 
       // List of playlists that have an AUDIO attribute value matching the current
       // group ID
+      const groupPlaylists = playlists.filter(playlist => {
+        return playlist.attributes[type] === groupId;
+      });
 
+      // List of playlists that have an AUDIO attribute value matching the current
+      // group ID
       for (const variantLabel in mediaGroups[type][groupId]) {
         let properties = mediaGroups[type][groupId][variantLabel];
         let playlistLoader;
+
+        // List of playlists for the current group ID that have a matching uri with
+        // this alternate audio variant
+        const matchingPlaylists = groupPlaylists.filter(playlist => {
+          return playlist.resolvedUri === properties.resolvedUri;
+        });
+
+        if (matchingPlaylists.length) {
+          // If there is a playlist that has the same uri as this audio variant, assume
+          // that the playlist is audio only. We delete the resolvedUri property here
+          // to prevent a playlist loader from being created so that we don't have
+          // both the main and audio segment loaders loading the same audio segments
+          // from the same playlist.
+          delete properties.resolvedUri;
+        }
 
         // if vhs-json was provided as the source, and the media playlist was resolved,
         // use the resolved media playlist object

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -3620,14 +3620,14 @@ QUnit.test('creates source buffers after second trackinfo if demuxed', function(
     '#EXTM3U\n' +
     '#EXT-X-VERSION:4\n' +
     '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="en",DEFAULT=YES,AUTOSELECT=YES,' +
-      'LANGUAGE="en",URI="media.m3u8"\n' +
+      'LANGUAGE="en",URI="media-audio.m3u8"\n' +
     '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1,AUDIO="audio"\n' +
     'media.m3u8\n'
   );
   // video media
   this.standardXHRResponse(this.requests.shift());
   // audio media
-  this.standardXHRResponse(this.requests.shift());
+  this.standardXHRResponse(this.requests.shift(), manifests.media);
 
   assert.equal(createSourceBufferCalls.length, 0, 'have not created source buffers yet');
 
@@ -3903,7 +3903,7 @@ QUnit.test('uses codec info from manifest for source buffer creation even when d
     '#EXTM3U\n' +
       '#EXT-X-VERSION:4\n' +
       '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="en",DEFAULT=YES,AUTOSELECT=YES,' +
-        'LANGUAGE="en",URI="media.m3u8"\n' +
+        'LANGUAGE="en",URI="media-audio.m3u8"\n' +
       '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1,AUDIO="audio",' +
         'CODECS="mp4a.40.e, avc1.deadbeef"\n' +
       'media.m3u8\n'
@@ -3912,7 +3912,7 @@ QUnit.test('uses codec info from manifest for source buffer creation even when d
   // video media
   this.standardXHRResponse(this.requests.shift());
   // audio media
-  this.standardXHRResponse(this.requests.shift());
+  this.standardXHRResponse(this.requests.shift(), manifests.media);
 
   assert.equal(createSourceBufferCalls.length, 0, 'have not created source buffers yet');
 

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -218,6 +218,25 @@ QUnit[testFn]('Big Buck Bunny', function(assert) {
   });
 });
 
+QUnit[testFn]('Big Buck Bunny audio only, groups & renditions same uri', function(assert) {
+  const done = assert.async();
+
+  assert.expect(2);
+  const player = this.player;
+
+  playFor(player, 2, function() {
+    assert.ok(true, 'played for at least two seconds');
+    assert.equal(player.error(), null, 'has no player errors');
+
+    done();
+  });
+
+  player.src({
+    src: 'https://d2zihajmogu5jn.cloudfront.net/audio-only-dupe-groups/prog_index.m3u8',
+    type: 'application/x-mpegURL'
+  });
+});
+
 QUnit[testFn]('Live DASH', function(assert) {
   const done = assert.async();
 


### PR DESCRIPTION
## Description
When An audio group has the same uri as a main playlist, don't count it as an audio group. 

The code that I am using is from [this commit](https://github.com/videojs/http-streaming/commit/3cefde2c66ae7bfac8086b45d443502960bba844#diff-46e43d417013a9cfb72f6b3210979b63)

[I removed this code early on the the VHS 2 process](https://github.com/videojs/http-streaming/pull/469) as it was causing other issues, but after digging up some demuxed live streams I no longer see issues with live stream timeouts.

I created a source that replicates this issue and uploaded it next to some of our other test content. I also tested with a few of the demuxed live streams that we have and they all appear to work. It is likely that the live stream startup issues that I was seeing were fixed somewhere else.