### PR TITLE
Chore: rename mediaConfig_ and startingMedia_

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -808,8 +808,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
       // if the audio playlist loader exists, then alternate audio is active
-      if (!this.mainSegmentLoader_.startingMedia_ ||
-          this.mainSegmentLoader_.startingMedia_.hasVideo) {
+      if (!this.mainSegmentLoader_.currentMediaInfo_ ||
+          this.mainSegmentLoader_.currentMediaInfo_.hasVideo) {
         // if we do not know if the main segment loader contains video yet or if we
         // definitively know the main segment loader contains video, then we need to wait
         // for both main and audio segment loaders to call endOfStream
@@ -1346,7 +1346,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     const usingAudioLoader = !!this.mediaTypes_.AUDIO.activePlaylistLoader;
 
     // one or both loaders has not loaded sufficently to get codecs
-    if (!this.mainSegmentLoader_.startingMedia_ || (usingAudioLoader && !this.audioSegmentLoader_.startingMedia_)) {
+    if (!this.mainSegmentLoader_.currentMediaInfo_ || (usingAudioLoader && !this.audioSegmentLoader_.currentMediaInfo_)) {
       return false;
     }
 
@@ -1355,8 +1355,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
   getCodecsOrExclude_() {
     const media = {
-      main: this.mainSegmentLoader_.startingMedia_ || {},
-      audio: this.audioSegmentLoader_.startingMedia_ || {}
+      main: this.mainSegmentLoader_.currentMediaInfo_ || {},
+      audio: this.audioSegmentLoader_.currentMediaInfo_ || {}
     };
 
     // set "main" media equal to video

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -534,7 +534,7 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
     origRemove.call(segmentLoader, start, end);
   };
 
-  segmentLoader.startingMedia_ = { hasVideo: true };
+  segmentLoader.currentMediaInfo_ = { hasVideo: true };
   segmentLoader.audioDisabled_ = true;
 
   segmentLoader.sourceUpdater_.removeVideo = function(start, end) {
@@ -1044,8 +1044,8 @@ QUnit.test('waits for both main and audio loaders to finish before calling endOf
   MPC.mainSegmentLoader_.on('ended', () => videoEnded++);
   MPC.audioSegmentLoader_.on('ended', () => audioEnded++);
 
-  MPC.mainSegmentLoader_.startingMedia_ = { hasVideo: true };
-  MPC.audioSegmentLoader_.startingMedia_ = { hasAudio: true };
+  MPC.mainSegmentLoader_.currentMediaInfo_ = { hasVideo: true };
+  MPC.audioSegmentLoader_.currentMediaInfo_ = { hasAudio: true };
 
   // master
   this.standardXHRResponse(this.requests.shift(), manifests.demuxed);
@@ -2835,7 +2835,7 @@ QUnit.test('parses codec from audio only fmp4 init segment', function(assert) {
       },
       'parsed audio codec'
     );
-    assert.deepEqual(loader.startingMedia_, {
+    assert.deepEqual(loader.currentMediaInfo_, {
       audioCodec: 'mp4a.40.2',
       hasAudio: true,
       hasVideo: false,
@@ -2896,7 +2896,7 @@ QUnit.test('parses codec from video only fmp4 init segment', function(assert) {
       },
       'parsed video codec'
     );
-    assert.deepEqual(loader.startingMedia_, {
+    assert.deepEqual(loader.currentMediaInfo_, {
       hasAudio: false,
       hasVideo: true,
       isFmp4: true,
@@ -2957,7 +2957,7 @@ QUnit.test('parses codec from muxed fmp4 init segment', function(assert) {
       },
       'parsed video codec'
     );
-    assert.deepEqual(loader.startingMedia_, {
+    assert.deepEqual(loader.currentMediaInfo_, {
       hasAudio: true,
       hasVideo: true,
       videoCodec: 'avc1.42c00d',
@@ -4577,11 +4577,11 @@ QUnit.module('MasterPlaylistController codecs', {
       } = options;
 
       if (mainStartingMedia) {
-        this.mpc.mainSegmentLoader_.startingMedia_ = mainStartingMedia;
+        this.mpc.mainSegmentLoader_.currentMediaInfo_ = mainStartingMedia;
       }
 
       if (audioStartingMedia) {
-        this.mpc.audioSegmentLoader_.startingMedia_ = audioStartingMedia;
+        this.mpc.audioSegmentLoader_.currentMediaInfo_ = audioStartingMedia;
       }
 
       this.master = {mediaGroups: {AUDIO: {}}, playlists: []};
@@ -5165,7 +5165,7 @@ QUnit.test('main & audio loader only trackinfo works as expected', function(asse
   assert.equal(createBuffers, 0, 'createSourceBuffers not called');
   assert.equal(switchBuffers, 0, 'addOrChangeSourceBuffers not called');
 
-  this.mpc.audioSegmentLoader_.startingMedia_ = {
+  this.mpc.audioSegmentLoader_.currentMediaInfo_ = {
     hasVideo: false,
     hasAudio: true,
     audioCodec: 'mp4a.40.2'
@@ -5179,7 +5179,7 @@ QUnit.test('main & audio loader only trackinfo works as expected', function(asse
   this.mpc.sourceUpdater_.ready = () => true;
   this.mpc.sourceUpdater_.canChangeType = () => true;
 
-  this.mpc.mainSegmentLoader_.startingMedia_ = {
+  this.mpc.mainSegmentLoader_.currentMediaInfo_ = {
     videoCodec: 'avc1.4c400e',
     hasVideo: true,
     hasAudio: false
@@ -5195,7 +5195,7 @@ QUnit.test('main & audio loader only trackinfo works as expected', function(asse
   assert.equal(createBuffers, 1, 'createBuffers not called');
   assert.equal(switchBuffers, 1, 'addOrChangeSourceBuffers called');
 
-  this.mpc.audioSegmentLoader_.startingMedia_ = {
+  this.mpc.audioSegmentLoader_.currentMediaInfo_ = {
     hasVideo: false,
     hasAudio: true,
     audioCodec: 'mp4a.40.5'

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -3366,8 +3366,8 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
           endTime: 2,
           text: 'test'
         });
-        // set startingMedia_
-        loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+        // set currentMediaInfo_
+        loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
         loader.remove(0, 2);
         assert.equal(this.inbandTextTracks.CC1.cues.length, 0, 'all cues have been removed');
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1652,7 +1652,7 @@ QUnit.test('does not blacklist compatible H.264 codec strings', function(assert)
   const master = this.player.tech_.vhs.playlists.master;
   const loader = this.player.tech_.vhs.masterPlaylistController_.mainSegmentLoader_;
 
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
 
   assert.strictEqual(
@@ -1697,7 +1697,7 @@ QUnit.test('does not blacklist compatible AAC codec strings', function(assert) {
   const loader = this.player.tech_.vhs.masterPlaylistController_.mainSegmentLoader_;
   const master = this.player.tech_.vhs.playlists.master;
 
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
 
   assert.strictEqual(
@@ -1758,7 +1758,7 @@ QUnit.test('blacklists incompatible playlists by codec, without codec switching'
 
   mpc.sourceUpdater_.canChangeType = () => false;
 
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
   const playlists = master.playlists;
 
@@ -1818,7 +1818,7 @@ QUnit.test('does not blacklist incompatible codecs with codec switching', functi
 
   mpc.sourceUpdater_.canChangeType = () => true;
 
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
   const playlists = master.playlists;
 
@@ -1882,17 +1882,17 @@ QUnit.test('blacklists fmp4 playlists by browser support', function(assert) {
 
   playlistLoader.media = () => playlists[0];
   loader.mainStartingMedia_ = playlists[0];
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true, isFmp4: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true, isFmp4: true};
   loader.trigger('trackinfo');
 
   playlistLoader.media = () => playlists[1];
   loader.mainStartingMedia_ = playlists[1];
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true, isFmp4: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true, isFmp4: true};
   loader.trigger('trackinfo');
 
   playlistLoader.media = () => playlists[2];
   loader.mainStartingMedia_ = playlists[2];
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true, isFmp4: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true, isFmp4: true};
   loader.trigger('trackinfo');
 
   assert.strictEqual(playlists.length, 3, 'three playlists total');
@@ -1950,17 +1950,17 @@ QUnit.test('blacklists ts playlists by muxer support', function(assert) {
 
   playlistLoader.media = () => playlists[0];
   loader.mainStartingMedia_ = playlists[0];
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
 
   playlistLoader.media = () => playlists[1];
   loader.mainStartingMedia_ = playlists[1];
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
 
   playlistLoader.media = () => playlists[2];
   loader.mainStartingMedia_ = playlists[2];
-  loader.startingMedia_ = {hasVideo: true, hasAudio: true};
+  loader.currentMediaInfo_ = {hasVideo: true, hasAudio: true};
   loader.trigger('trackinfo');
 
   assert.strictEqual(playlists.length, 3, 'three playlists total');


### PR DESCRIPTION
mediaConfig_ and startingMedia_ are fairly poor names for variables, we should do better and rename them to something that can be easily understood. This pull request aims to do that. Originally this work would have been done as a part of #950 but this change might have a bigger impact than intended.