### PR TITLE
fix: use playlist NAME when available as its ID

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -43,7 +43,7 @@ export const parseMasterXml = ({ masterXml, srcUrl, clientOffset, sidxMapping })
     sidxMapping
   });
 
-  addPropertiesToMaster(master, srcUrl, 'dash');
+  addPropertiesToMaster(master, srcUrl);
 
   return master;
 };

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -43,7 +43,7 @@ export const parseMasterXml = ({ masterXml, srcUrl, clientOffset, sidxMapping })
     sidxMapping
   });
 
-  addPropertiesToMaster(master, srcUrl, 'dash');
+  addPropertiesToMaster(master, srcUrl, true);
 
   return master;
 };

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -43,7 +43,7 @@ export const parseMasterXml = ({ masterXml, srcUrl, clientOffset, sidxMapping })
     sidxMapping
   });
 
-  addPropertiesToMaster(master, srcUrl);
+  addPropertiesToMaster(master, srcUrl, 'dash');
 
   return master;
 };

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -100,27 +100,21 @@ export const setupMediaPlaylist = ({ playlist, uri, id }) => {
  * @param {Object} master
  *        The master playlist
  */
-export const setupMediaPlaylists = (master, type) => {
+export const setupMediaPlaylists = (master) => {
   let i = master.playlists.length;
 
   while (i--) {
     const playlist = master.playlists[i];
-    const createId = createPlaylistID(i, playlist.uri);
-    let id = createId;
-
-    // DASH Representations can change order across refreshes which can make referring to them by index not work
-    // Instead, use the provided id, available via the NAME attribute.
-    if (type === 'dash') {
-      id = playlist.attributes && playlist.attributes.NAME || id;
-    }
+    const id = createPlaylistID(i, playlist.uri);
 
     setupMediaPlaylist({
       playlist,
-      id
+      // DASH Representations can change order across refreshes which can make referring to them by index not work
+      // Instead, use the provided id, available via the NAME attribute.
+      id: playlist.attributes && playlist.attributes.NAME || id
     });
     playlist.resolvedUri = resolveUrl(master.uri, playlist.uri);
-    // make sure that if a DASH is used, the old "createId" id is also available
-    master.playlists[createId] = playlist;
+    master.playlists[id] = playlist;
     master.playlists[playlist.id] = playlist;
     // URI reference added for backwards compatibility
     master.playlists[playlist.uri] = playlist;
@@ -198,7 +192,7 @@ export const masterForMedia = (media, uri) => {
  * @param {string} uri
  *        The source URI
  */
-export const addPropertiesToMaster = (master, uri, type) => {
+export const addPropertiesToMaster = (master, uri) => {
   master.uri = uri;
 
   for (let i = 0; i < master.playlists.length; i++) {
@@ -231,6 +225,6 @@ export const addPropertiesToMaster = (master, uri, type) => {
     master.playlists[phonyUri] = properties.playlists[0];
   });
 
-  setupMediaPlaylists(master, type);
+  setupMediaPlaylists(master);
   resolveMediaGroupUris(master);
 };

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -108,7 +108,9 @@ export const setupMediaPlaylists = (master) => {
 
     setupMediaPlaylist({
       playlist,
-      id: createPlaylistID(i, playlist.uri)
+      // DASH Representations can change order across refreshes which can make referring to them by index not work
+      // Instead, use the provided id, available via the NAME attribute.
+      id: playlist.attributes && playlist.attributes.NAME || createPlaylistID(i, playlist.uri)
     });
     playlist.resolvedUri = resolveUrl(master.uri, playlist.uri);
     master.playlists[playlist.id] = playlist;

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -108,9 +108,7 @@ export const setupMediaPlaylists = (master) => {
 
     setupMediaPlaylist({
       playlist,
-      // DASH Representations can change order across refreshes which can make referring to them by index not work
-      // Instead, use the provided id, available via the NAME attribute.
-      id: playlist.attributes && playlist.attributes.NAME || createPlaylistID(i, playlist.uri)
+      id: createPlaylistID(i, playlist.uri)
     });
     playlist.resolvedUri = resolveUrl(master.uri, playlist.uri);
     master.playlists[playlist.id] = playlist;

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -105,14 +105,16 @@ export const setupMediaPlaylists = (master) => {
 
   while (i--) {
     const playlist = master.playlists[i];
+    const id = createPlaylistID(i, playlist.uri);
 
     setupMediaPlaylist({
       playlist,
       // DASH Representations can change order across refreshes which can make referring to them by index not work
       // Instead, use the provided id, available via the NAME attribute.
-      id: playlist.attributes && playlist.attributes.NAME || createPlaylistID(i, playlist.uri)
+      id: playlist.attributes && playlist.attributes.NAME || id
     });
     playlist.resolvedUri = resolveUrl(master.uri, playlist.uri);
+    master.playlists[id] = playlist;
     master.playlists[playlist.id] = playlist;
     // URI reference added for backwards compatibility
     master.playlists[playlist.uri] = playlist;

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -108,11 +108,12 @@ export const setupMediaPlaylists = (master, useNameForId) => {
 
   while (i--) {
     const playlist = master.playlists[i];
-    const createId = createPlaylistID(i, playlist.uri);
-    let id = createId;
+    const createdId = createPlaylistID(i, playlist.uri);
+    let id = createdId;
 
-    // DASH Representations can change order across refreshes which can make referring to them by index not work
-    // Instead, use the provided id, available via the NAME attribute.
+    // If useNameForId is set, use the NAME attribute for the ID.
+    // Generally, this will be used for DASH because
+    // DASH Representations can change order across refreshes which can make referring to them by index not work.
     if (useNameForId) {
       id = playlist.attributes && playlist.attributes.NAME || id;
     }
@@ -122,8 +123,8 @@ export const setupMediaPlaylists = (master, useNameForId) => {
       id
     });
     playlist.resolvedUri = resolveUrl(master.uri, playlist.uri);
-    // make sure that if a DASH is used, the old "createId" id is also available
-    master.playlists[createId] = playlist;
+    // make sure that if a useNameForId is true, the old "createdId" id is also available
+    master.playlists[createdId] = playlist;
     master.playlists[playlist.id] = playlist;
     // URI reference added for backwards compatibility
     master.playlists[playlist.uri] = playlist;

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -99,8 +99,11 @@ export const setupMediaPlaylist = ({ playlist, uri, id }) => {
  *
  * @param {Object} master
  *        The master playlist
+ * @param {boolean} [useNameForId=false]
+ *        Whether we should use the NAME property for ID.
+ *        Generally only used for DASH and defaults to false.
  */
-export const setupMediaPlaylists = (master, type) => {
+export const setupMediaPlaylists = (master, useNameForId) => {
   let i = master.playlists.length;
 
   while (i--) {
@@ -110,7 +113,7 @@ export const setupMediaPlaylists = (master, type) => {
 
     // DASH Representations can change order across refreshes which can make referring to them by index not work
     // Instead, use the provided id, available via the NAME attribute.
-    if (type === 'dash') {
+    if (useNameForId) {
       id = playlist.attributes && playlist.attributes.NAME || id;
     }
 
@@ -197,8 +200,11 @@ export const masterForMedia = (media, uri) => {
  *        Master manifest object
  * @param {string} uri
  *        The source URI
+ * @param {boolean} [useNameForId=false]
+ *        Whether we should use the NAME property for ID.
+ *        Generally only used for DASH and defaults to false.
  */
-export const addPropertiesToMaster = (master, uri, type) => {
+export const addPropertiesToMaster = (master, uri, useNameForId = false) => {
   master.uri = uri;
 
   for (let i = 0; i < master.playlists.length; i++) {
@@ -231,6 +237,6 @@ export const addPropertiesToMaster = (master, uri, type) => {
     master.playlists[phonyUri] = properties.playlists[0];
   });
 
-  setupMediaPlaylists(master, type);
+  setupMediaPlaylists(master, useNameForId);
   resolveMediaGroupUris(master);
 };

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -105,16 +105,14 @@ export const setupMediaPlaylists = (master) => {
 
   while (i--) {
     const playlist = master.playlists[i];
-    const id = createPlaylistID(i, playlist.uri);
 
     setupMediaPlaylist({
       playlist,
       // DASH Representations can change order across refreshes which can make referring to them by index not work
       // Instead, use the provided id, available via the NAME attribute.
-      id: playlist.attributes && playlist.attributes.NAME || id
+      id: playlist.attributes && playlist.attributes.NAME || createPlaylistID(i, playlist.uri)
     });
     playlist.resolvedUri = resolveUrl(master.uri, playlist.uri);
-    master.playlists[id] = playlist;
     master.playlists[playlist.id] = playlist;
     // URI reference added for backwards compatibility
     master.playlists[playlist.uri] = playlist;

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -586,7 +586,7 @@ export default class PlaylistLoader extends EventTarget {
 
     if (manifest.playlists) {
       this.master = manifest;
-      addPropertiesToMaster(this.master, this.srcUri(), 'hls');
+      addPropertiesToMaster(this.master, this.srcUri());
       // If the initial master playlist has playlists wtih segments already resolved,
       // then resolve URIs in advance, as they are usually done after a playlist request,
       // which may not happen if the playlist is resolved.

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -586,7 +586,7 @@ export default class PlaylistLoader extends EventTarget {
 
     if (manifest.playlists) {
       this.master = manifest;
-      addPropertiesToMaster(this.master, this.srcUri());
+      addPropertiesToMaster(this.master, this.srcUri(), 'hls');
       // If the initial master playlist has playlists wtih segments already resolved,
       // then resolve URIs in advance, as they are usually done after a playlist request,
       // which may not happen if the playlist is resolved.

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -1295,12 +1295,7 @@ QUnit.test('parseMasterXml: setup phony playlists and resolves uris', function(a
 
   assert.strictEqual(masterPlaylist.uri, loader.srcUrl, 'master playlist uri set correctly');
   assert.strictEqual(masterPlaylist.playlists[0].uri, 'placeholder-uri-0');
-  assert.strictEqual(masterPlaylist.playlists[0].id, '1080p');
-  assert.strictEqual(
-    masterPlaylist.playlists['1080p'],
-    masterPlaylist.playlists['0-placeholder-uri-0'],
-    'available via old and new ids'
-  );
+  assert.strictEqual(masterPlaylist.playlists[0].id, '0-placeholder-uri-0');
   assert.deepEqual(
     masterPlaylist.playlists['0-placeholder-uri-0'],
     masterPlaylist.playlists[0],
@@ -2300,13 +2295,8 @@ QUnit.test(
       'setup phony uri for media playlist'
     );
     assert.equal(
-      loader.master.playlists[0].id, '1080p',
+      loader.master.playlists[0].id, '0-placeholder-uri-0',
       'setup phony id for media playlist'
-    );
-    assert.strictEqual(
-      loader.master.playlists['1080p'],
-      loader.master.playlists['0-placeholder-uri-0'],
-      'reference by NAME and old id'
     );
     assert.strictEqual(
       loader.master.playlists['0-placeholder-uri-0'],
@@ -2317,13 +2307,8 @@ QUnit.test(
       'setup phony uri for media playlist'
     );
     assert.equal(
-      loader.master.playlists[1].id, '720p',
+      loader.master.playlists[1].id, '1-placeholder-uri-1',
       'setup phony id for media playlist'
-    );
-    assert.strictEqual(
-      loader.master.playlists['720p'],
-      loader.master.playlists['1-placeholder-uri-1'],
-      'reference by NAME and old id'
     );
     assert.strictEqual(
       loader.master.playlists['1-placeholder-uri-1'],

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -1295,7 +1295,12 @@ QUnit.test('parseMasterXml: setup phony playlists and resolves uris', function(a
 
   assert.strictEqual(masterPlaylist.uri, loader.srcUrl, 'master playlist uri set correctly');
   assert.strictEqual(masterPlaylist.playlists[0].uri, 'placeholder-uri-0');
-  assert.strictEqual(masterPlaylist.playlists[0].id, '0-placeholder-uri-0');
+  assert.strictEqual(masterPlaylist.playlists[0].id, '1080p');
+  assert.strictEqual(
+    masterPlaylist.playlists['1080p'],
+    masterPlaylist.playlists['0-placeholder-uri-0'],
+    'available via old and new ids'
+  );
   assert.deepEqual(
     masterPlaylist.playlists['0-placeholder-uri-0'],
     masterPlaylist.playlists[0],
@@ -2258,8 +2263,13 @@ QUnit.test(
       'setup phony uri for media playlist'
     );
     assert.equal(
-      loader.master.playlists[0].id, '0-placeholder-uri-0',
+      loader.master.playlists[0].id, '1080p',
       'setup phony id for media playlist'
+    );
+    assert.strictEqual(
+      loader.master.playlists['1080p'],
+      loader.master.playlists['0-placeholder-uri-0'],
+      'reference by NAME and old id'
     );
     assert.strictEqual(
       loader.master.playlists['0-placeholder-uri-0'],
@@ -2270,8 +2280,13 @@ QUnit.test(
       'setup phony uri for media playlist'
     );
     assert.equal(
-      loader.master.playlists[1].id, '1-placeholder-uri-1',
+      loader.master.playlists[1].id, '720p',
       'setup phony id for media playlist'
+    );
+    assert.strictEqual(
+      loader.master.playlists['720p'],
+      loader.master.playlists['1-placeholder-uri-1'],
+      'reference by NAME and old id'
     );
     assert.strictEqual(
       loader.master.playlists['1-placeholder-uri-1'],

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -1295,7 +1295,12 @@ QUnit.test('parseMasterXml: setup phony playlists and resolves uris', function(a
 
   assert.strictEqual(masterPlaylist.uri, loader.srcUrl, 'master playlist uri set correctly');
   assert.strictEqual(masterPlaylist.playlists[0].uri, 'placeholder-uri-0');
-  assert.strictEqual(masterPlaylist.playlists[0].id, '0-placeholder-uri-0');
+  assert.strictEqual(masterPlaylist.playlists[0].id, '1080p');
+  assert.strictEqual(
+    masterPlaylist.playlists['1080p'],
+    masterPlaylist.playlists['0-placeholder-uri-0'],
+    'available via old and new ids'
+  );
   assert.deepEqual(
     masterPlaylist.playlists['0-placeholder-uri-0'],
     masterPlaylist.playlists[0],
@@ -2295,8 +2300,13 @@ QUnit.test(
       'setup phony uri for media playlist'
     );
     assert.equal(
-      loader.master.playlists[0].id, '0-placeholder-uri-0',
+      loader.master.playlists[0].id, '1080p',
       'setup phony id for media playlist'
+    );
+    assert.strictEqual(
+      loader.master.playlists['1080p'],
+      loader.master.playlists['0-placeholder-uri-0'],
+      'reference by NAME and old id'
     );
     assert.strictEqual(
       loader.master.playlists['0-placeholder-uri-0'],
@@ -2307,8 +2317,13 @@ QUnit.test(
       'setup phony uri for media playlist'
     );
     assert.equal(
-      loader.master.playlists[1].id, '1-placeholder-uri-1',
+      loader.master.playlists[1].id, '720p',
       'setup phony id for media playlist'
+    );
+    assert.strictEqual(
+      loader.master.playlists['720p'],
+      loader.master.playlists['1-placeholder-uri-1'],
+      'reference by NAME and old id'
     );
     assert.strictEqual(
       loader.master.playlists['1-placeholder-uri-1'],

--- a/test/manifests/dash-swapped.mpd
+++ b/test/manifests/dash-swapped.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:full:2011" minBufferTime="1.5" mediaPresentationDuration="PT5S">
+  <Period>
+    <BaseURL>main/</BaseURL>
+    <AdaptationSet mimeType="video/mp4">
+      <BaseURL>video/</BaseURL>
+      <Representation id="720p" bandwidth="2400000" width="1280" height="720" codecs="avc1.420015">
+        <BaseURL>720/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$-segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="10" startNumber="0" />
+      </Representation>
+      <Representation id="1080p" bandwidth="6800000" width="1920" height="1080" codecs="avc1.420015">
+        <BaseURL>1080/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$-segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="10" startNumber="0" />
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4">
+      <BaseURL>audio/</BaseURL>
+      <Representation id="audio" bandwidth="128000" codecs="mp4a.40.2">
+        <BaseURL>720/</BaseURL>
+        <SegmentTemplate media="segment-$Number$.mp4" initialization="$RepresentationID$-init.mp4" duration="10" timescale="10" startNumber="0" />
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
This is #929 again. We had to revert one in #957 because it broke playback of the DASH Angel One stream.
Re-opening for now, but we'll need to rebase this and also fix the issue with the stream before it can be merged.