### PR TITLE
fix: noop vtt segment loader handle data

### DIFF
--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -375,6 +375,10 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.handleAppendsDone_();
   }
 
+  handleData_() {
+    // noop as we shouldn't be getting video/audio data captions
+    // that we do not support here.
+  }
   updateTimingInfoEnd_() {
     // noop
   }


### PR DESCRIPTION
We should noop handleData in vtt segment loader so that any captions which we don't support the type of, such as `stpp.ttml.im1t` from `tears of steal widevine unified streaming` do not attempt to append to sourceBuffers and cause a player append error.