### PR TITLE
fix: abort all loaders on earlyabort

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,7 @@ export default {
   BUFFER_LOW_WATER_LINE: 0,
   MAX_BUFFER_LOW_WATER_LINE: 30,
 
-  // TODO: Remove this when useBufferWaterLines is removed
+  // TODO: Remove this when experimentalBufferBasedABR is removed
   EXPERIMENTAL_MAX_BUFFER_LOW_WATER_LINE: 16,
 
   BUFFER_LOW_WATER_LINE_RATE: 1,

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -643,13 +643,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
         return;
       }
 
-      this.mainSegmentLoader_.abort();
-      if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
-        this.audioSegmentLoader_.abort();
-      }
-      if (this.mediaTypes_.SUBTITLES.activePlaylistLoader) {
-        this.subtitleSegmentLoader_.abort();
-      }
+      this.delegateLoaders_('all', ['abort']);
 
       this.blacklistCurrentPlaylist({
         message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -643,6 +643,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
         return;
       }
 
+      this.mainSegmentLoader_.abort();
+      if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
+        this.audioSegmentLoader_.abort();
+      }
+      if (this.mediaTypes_.SUBTITLES.activePlaylistLoader) {
+        this.subtitleSegmentLoader_.abort();
+      }
+
       this.blacklistCurrentPlaylist({
         message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +
           'request without rebuffering.'


### PR DESCRIPTION
## Description
> Note that this also effects the current non-experimental abr algorithm 

During low bandwidth situations continuing to download any segments over the video/audio segment is ill-advised as we need to get the buffer filled again ASAP. So when we get an early abort we have to abort all segment loaders to make way for the new playlist that is about to load, so that it can have priority.

Fixes #964 