### PR TITLE
fix: sustained bad network shouldn't pause

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -556,6 +556,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('progress', () => {
+      if (this.mainSegmentLoader_.earlyabortTimer) {
+        window.clearTimeout(this.mainSegmentLoader_.earlyabortTimer);
+        this.mainSegmentLoader_.earlyabortTimer = null;
+      }
       if (this.experimentalBufferBasedABR) {
         const nextPlaylist = this.selectPlaylist();
 
@@ -615,6 +619,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
         // if we shouldn't switch to the next playlist, do nothing
         if (!this.shouldSwitchToMedia_(nextPlaylist)) {
           this.logger_(`earlyabort triggered, but we will not be switching from ${currentPlaylist.id} -> ${nextPlaylist.id}.`);
+          this.mainSegmentLoader_.earlyabortTimer = window.setTimeout(() => {
+            this.mainSegmentLoader_.trigger('earlyabort');
+          }, 10 * 1000);
           return;
         }
       }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -619,9 +619,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
         // if we shouldn't switch to the next playlist, do nothing
         if (!this.shouldSwitchToMedia_(nextPlaylist)) {
           this.logger_(`earlyabort triggered, but we will not be switching from ${currentPlaylist.id} -> ${nextPlaylist.id}.`);
+          // try again in half the target duration to make sure that we
+          // have an opportunity to switch
           this.mainSegmentLoader_.earlyabortTimer_ = window.setTimeout(() => {
             this.mainSegmentLoader_.trigger('earlyabort');
-          }, 10 * 1000);
+          }, (this.media().targetDuration / 2) * 1000);
           return;
         }
       }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1372,6 +1372,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * that it controls
    */
   dispose() {
+    window.clearTimeout(this.mainSegmentLoader_.earlyabortTimer_);
+
     this.trigger('dispose');
     this.decrypter_.terminate();
     this.masterPlaylistLoader_.dispose();

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -556,9 +556,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('progress', () => {
-      if (this.mainSegmentLoader_.earlyabortTimer) {
-        window.clearTimeout(this.mainSegmentLoader_.earlyabortTimer);
-        this.mainSegmentLoader_.earlyabortTimer = null;
+      if (this.mainSegmentLoader_.earlyabortTimer_) {
+        window.clearTimeout(this.mainSegmentLoader_.earlyabortTimer_);
+        this.mainSegmentLoader_.earlyabortTimer_ = null;
       }
       if (this.experimentalBufferBasedABR) {
         const nextPlaylist = this.selectPlaylist();
@@ -619,7 +619,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
         // if we shouldn't switch to the next playlist, do nothing
         if (!this.shouldSwitchToMedia_(nextPlaylist)) {
           this.logger_(`earlyabort triggered, but we will not be switching from ${currentPlaylist.id} -> ${nextPlaylist.id}.`);
-          this.mainSegmentLoader_.earlyabortTimer = window.setTimeout(() => {
+          this.mainSegmentLoader_.earlyabortTimer_ = window.setTimeout(() => {
             this.mainSegmentLoader_.trigger('earlyabort');
           }, 10 * 1000);
           return;

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -556,10 +556,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('progress', () => {
-      if (this.mainSegmentLoader_.earlyabortTimer_) {
-        window.clearTimeout(this.mainSegmentLoader_.earlyabortTimer_);
-        this.mainSegmentLoader_.earlyabortTimer_ = null;
-      }
       if (this.experimentalBufferBasedABR) {
         const nextPlaylist = this.selectPlaylist();
 
@@ -627,6 +623,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
           return;
         }
       }
+
       this.blacklistCurrentPlaylist({
         message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +
           'request without rebuffering.'

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -359,6 +359,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // private instance variables
     this.checkBufferTimeout_ = null;
+    this.earlyabortTimer_ = null;
     this.error_ = void 0;
     this.currentTimeline_ = -1;
     this.pendingSegment_ = null;
@@ -520,6 +521,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (this.checkBufferTimeout_) {
       window.clearTimeout(this.checkBufferTimeout_);
     }
+    window.clearTimeout(this.earlyabortTimer_);
 
     if (this.syncController_ && this.triggerSyncInfoUpdate_) {
       this.syncController_.off('syncinfoupdate', this.triggerSyncInfoUpdate_);


### PR DESCRIPTION
When playing back bipbop with experimentalBufferBasedABR turned on and
we switch to Slow 3G in chrome, we may time out.
This is because
- earlyabort is turned off
- our last attempt at downswitching occurs when our forward buffer is
too full

To mitigate this, when we get an early abort set up a timer for 10
seconds to see if earlyabort conditions are met again. If a progress
event happens in the meantime, the earlyabort timer will be cancelled.

TODO:
- [ ] Make sure that the `setTimeout` is cancelled properly if the player is disposed (not sure if we have a `player.setTimeout()` like method
- [ ] figure out if there's a better way of doing this