### PR TITLE
fix: inline json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1009,6 +1009,47 @@
       "integrity": "sha512-Jq0JfThRZvmuDn0Sx3TTi0uf2ZhIDnx08l9af4741gCMghyT26zxR/DNPoPJCGDc1QFLohYdCWsMn21XFDt46Q==",
       "dev": true
     },
+    "@rollup/plugin-replace": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
+      "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "magic-string": "^0.25.5"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+          "dev": true
+        }
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@gkatsev/rollup-plugin-bundle-worker": "^1.0.2",
+    "@rollup/plugin-replace": "^2.3.3",
     "@videojs/generator-helpers": "~1.2.0",
     "d3": "^3.4.8",
     "es5-shim": "^4.5.13",

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -2,6 +2,12 @@ const generate = require('videojs-generate-rollup-config');
 const worker = require('@gkatsev/rollup-plugin-bundle-worker');
 const {terser} = require('rollup-plugin-terser');
 const createTestData = require('./create-test-data.js');
+const vhs = require('../package.json');
+const mux = require('mux.js/package.json');
+const mpd = require('mpd-parser/package.json');
+const m3u8 = require('m3u8-parser/package.json');
+const aes = require('aes-decrypter/package.json');
+const replace = require('@rollup/plugin-replace');
 
 // see https://github.com/videojs/videojs-generate-rollup-config
 // for options
@@ -28,6 +34,10 @@ const options = {
     defaults.module.splice(2, 0, 'worker');
     defaults.browser.splice(2, 0, 'worker');
     defaults.test.splice(3, 0, 'worker');
+
+    defaults.module.unshift('replace');
+    defaults.browser.unshift('replace');
+    defaults.test.unshift('replace');
     defaults.test.splice(0, 0, 'createTestData');
 
     // istanbul is only in the list for regular builds and not watch
@@ -44,6 +54,14 @@ const options = {
         output: {comments: 'some'},
         compress: {passes: 2},
         include: [/^.+\.min\.js$/]
+      }),
+      replace: replace({
+        "import {version as vhsVersion} from '../package.json';": `const vhsVersion = '${vhs.version}';`,
+        "import {version as muxVersion} from 'mux.js/package.json';": `const muxVersion = '${mux.version}';`,
+        "import {version as mpdVersion} from 'mpd-parser/package.json';": `const mpdVersion = '${mpd.version}';`,
+        "import {version as m3u8Version} from 'm3u8-parser/package.json';": `const m3u8Version = '${m3u8.version}';`,
+        "import {version as aesVersion} from 'aes-decrypter/package.json';": `const aesVersion = '${aes.version}';`,
+        'delimiters': ['', '']
       }),
       createTestData: createTestData()
     });

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -30,12 +30,17 @@ import {
   comparePlaylistBandwidth,
   comparePlaylistResolution
 } from './playlist-selectors.js';
+import {isAudioCodec, isVideoCodec, browserSupportsCodec} from '@videojs/vhs-utils/dist/codecs.js';
+
+// IMPORTANT:
+// keep these at the bottom they are replaced at build time
+// because webpack and rollup without plugins do not support json
+// and we do not want to break our users
 import {version as vhsVersion} from '../package.json';
 import {version as muxVersion} from 'mux.js/package.json';
 import {version as mpdVersion} from 'mpd-parser/package.json';
 import {version as m3u8Version} from 'm3u8-parser/package.json';
 import {version as aesVersion} from 'aes-decrypter/package.json';
-import {isAudioCodec, isVideoCodec, browserSupportsCodec} from '@videojs/vhs-utils/dist/codecs.js';
 
 const Vhs = {
   PlaylistLoader,


### PR DESCRIPTION
## Description
Ideally we would be able to specify regex externals in videojs-generate-rollup-config, but we cannot currently. For now we will use [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace) to fix issues with downstream webpack builds caused by importing json directly.
