### PR TITLE
Fix/check tech error

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -526,7 +526,7 @@ class VhsHandler extends Component {
     });
 
     this.on(this.tech_, 'error', function() {
-      if (this.masterPlaylistController_) {
+      if (this.tech_.error() && this.masterPlaylistController_) {
         this.masterPlaylistController_.pauseLoading();
       }
     });


### PR DESCRIPTION
A poster error is causing playback to stall as it triggers an error on tech. Errors on tech and the video element were thought to be fatal, guess that assumption was wrong. :doh: