### PR TITLE
fix: appendsdone abort and handle multiple id3 sections.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1181,9 +1181,9 @@
       }
     },
     "@videojs/vhs-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-2.2.0.tgz",
-      "integrity": "sha512-Mtq+doRlbNvis9TyI5kfOg+Vg8aHGXkSXiuNwnkcimqyaP3wO/s/iEVKPcmRUySKivjaWktjdEFVXYfaP+/HTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-2.2.1.tgz",
+      "integrity": "sha512-9Qbwx3LAdkG1jh2HKfninjXDxVZCeaoPcmct/bUcDRmLej68Z9XhLe5d2a9fy1qB+UuQwWg7YySASesWavYNjQ==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "global": "^4.3.2",
@@ -6858,9 +6858,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.6.tgz",
-      "integrity": "sha512-q5VIpqb28UVs5dKsOQkpHrPxqInMjiZ/f/4qW4gEBKlm2xeBasRjRJIokixFWj+r6PWfVSEygvPffXnG7aK99g=="
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.7.tgz",
+      "integrity": "sha512-YSr6B8MUgE4S18MptbY2XM+JKGbw9JDkgs7YkuE/T2fpDKjOhZfb/nD6vmsVxvLYOExWNaQn1UGBp6PGsnTtew=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@videojs/vhs-utils": "^2.2.0",
+    "@videojs/vhs-utils": "^2.2.1",
     "aes-decrypter": "3.0.2",
     "global": "^4.3.2",
     "m3u8-parser": "4.4.3",
     "mpd-parser": "0.12.0",
-    "mux.js": "5.6.6",
+    "mux.js": "5.6.7",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -2529,6 +2529,11 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
   handleAppendsDone_() {
+    // appendsdone can cause an abort
+    if (this.pendingSegment_) {
+      this.trigger('appendsdone');
+    }
+
     if (!this.pendingSegment_) {
       this.state = 'READY';
       // TODO should this move into this.checkForAbort to speed up requests post abort in
@@ -2538,8 +2543,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       }
       return;
     }
-
-    this.trigger('appendsdone');
 
     const segmentInfo = this.pendingSegment_;
 


### PR DESCRIPTION
`appendsdone` may cause an abort in segmentloaders which can then cause `pendingSegment` to be null **after** we just null checked it. Instead we should check if we have a `pendingSegment` then trigger appends done and see if an abort happens.