### PR TITLE
fix: correct retry-behavior for rendition-manifest retrieval on HLS Live streams that stop updating.

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -261,10 +261,10 @@ export default class PlaylistLoader extends EventTarget {
     const update = updateMaster(this.master, playlist);
 
     this.targetDuration = playlist.targetDuration;
+    this.media_ = this.master.playlists[id];
 
     if (update) {
       this.master = update;
-      this.media_ = this.master.playlists[id];
     } else {
       this.trigger('playlistunchanged');
     }


### PR DESCRIPTION
## Description
Fixes https://github.com/videojs/http-streaming/issues/975

This addresses a bug affecting live streams that support input-stream reconnect windows.

The player will iterate over all rendition manifests looking for new segments to download and play. When all rendition manifests have been evaluated and no updates are found, the player enters a tight infinite loop requesting a single rendition manifest until either a terminated rendition manifest is returned or the player is stopped/destroyed.

## Specific Changes proposed
This change updates the `this.media_` variable even when the rendition manifest contains no changes. This is necessary for the rendition manifest blacklisting to work in this scenario.

Demonstration of fix: https://youtu.be/hBsYg77_Ctw

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
