### PR TITLE
fix(experimentalBufferBasedABR): call selectPlaylist and change media on an interval

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -209,6 +209,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     const segmentLoaderSettings = {
       vhs: this.vhs_,
+      experimentalBufferBasedABR,
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
       seekable: () => this.seekable(),
@@ -599,25 +600,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('earlyabort', (event) => {
-      if (this.experimentalBufferBasedABR) {
-        const currentPlaylist = this.masterPlaylistLoader_.media();
-
-        // temporarily exclude the current playlist so that we can
-        // determine the next playlist that would be selected
-        // if this playlist were to be excluded.
-        currentPlaylist.excludeUntil = Infinity;
-
-        const nextPlaylist = this.selectPlaylist();
-
-        // un-exclude the current playlist for now
-        currentPlaylist.excludeUntil = null;
-
-        // if we shouldn't switch to the next playlist, do nothing
-        if (!this.shouldSwitchToMedia_(nextPlaylist)) {
-          this.logger_(`earlyabort triggered, but we will not be switching from ${currentPlaylist.id} -> ${nextPlaylist.id}.`);
-          return;
-        }
-      }
       this.blacklistCurrentPlaylist({
         message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +
           'request without rebuffering.'

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -209,7 +209,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     const segmentLoaderSettings = {
       vhs: this.vhs_,
-      experimentalBufferBasedABR,
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
       seekable: () => this.seekable(),
@@ -634,6 +633,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('earlyabort', (event) => {
+      // never try to early abort with the new ABR algorithm
+      if (this.experimentalBufferBasedABR) {
+        return;
+      }
+
       this.blacklistCurrentPlaylist({
         message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +
           'request without rebuffering.'

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -923,7 +923,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
 
-    this.abrTimer_();
+    this.stopABRTimer_();
     this.sourceUpdater_.endOfStream();
   }
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -598,14 +598,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
       });
 
       this.mainSegmentLoader_.on('progress', () => {
-        if (this.experimentalBufferBasedABR) {
-          const nextPlaylist = this.selectPlaylist();
-
-          if (this.shouldSwitchToMedia_(nextPlaylist)) {
-            this.masterPlaylistLoader_.media(nextPlaylist);
-          }
-        }
-
         this.trigger('progress');
       });
     }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -311,6 +311,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * @private
    */
   stopABRTimer_() {
+    // if we're scrubbing, we don't need to pause.
+    // This getter will be added to Video.js in version 7.11.
+    if (this.tech_.scrubbing && this.tech_.scrubbing()) {
+      return;
+    }
     window.clearInterval(this.abrTimer_);
     this.abrTimer_ = null;
   }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -337,6 +337,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.mediaIndex = null;
 
     // private settings
+    this.experimentalBufferBasedABR = settings.experimentalBufferBasedABR;
     this.hasPlayed_ = settings.hasPlayed;
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
@@ -1346,6 +1347,11 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
   earlyAbortWhenNeeded_(stats) {
+    // never try to early abort with the new ABR algorithm
+    if (this.experimentalBufferBasedABR) {
+      return;
+    }
+
     if (this.vhs_.tech_.paused() ||
         // Don't abort if the current playlist is on the lowestEnabledRendition
         // TODO: Replace using timeout with a boolean indicating whether this playlist is

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -337,7 +337,6 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.mediaIndex = null;
 
     // private settings
-    this.experimentalBufferBasedABR = settings.experimentalBufferBasedABR;
     this.hasPlayed_ = settings.hasPlayed;
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
@@ -1347,11 +1346,6 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
   earlyAbortWhenNeeded_(stats) {
-    // never try to early abort with the new ABR algorithm
-    if (this.experimentalBufferBasedABR) {
-      return;
-    }
-
     if (this.vhs_.tech_.paused() ||
         // Don't abort if the current playlist is on the lowestEnabledRendition
         // TODO: Replace using timeout with a boolean indicating whether this playlist is

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -5534,53 +5534,6 @@ QUnit.module('MasterPlaylistController experimentalBufferBasedABR', {
   }
 });
 
-QUnit.test('Determines if playlist should be aborted on earlyabort', function(assert) {
-  this.masterPlaylistController.mediaSource.trigger('sourceopen');
-  // master
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
-
-  const mediaChanges = [];
-  const playlistLoader = this.masterPlaylistController.masterPlaylistLoader_;
-  const currentMedia = playlistLoader.media();
-  const origMedia = playlistLoader.media.bind(playlistLoader);
-  const origWarn = videojs.log.warn;
-  const warnings = [];
-
-  this.masterPlaylistController.masterPlaylistLoader_.media = (media) => {
-    if (media) {
-      mediaChanges.push(media);
-    }
-    return origMedia(media);
-  };
-
-  videojs.log.warn = (text) => warnings.push(text);
-
-  assert.notOk(currentMedia.excludeUntil > 0, 'playlist not blacklisted');
-  assert.equal(mediaChanges.length, 0, 'no media change');
-
-  this.masterPlaylistController.shouldSwitchToMedia_ = () => false;
-  this.masterPlaylistController.mainSegmentLoader_.trigger('earlyabort');
-
-  assert.notOk(currentMedia.excludeUntil > 0, 'no exclusions if we should not switch');
-  assert.equal(mediaChanges.length, 0, 'no media change if we should not switch');
-
-  this.masterPlaylistController.shouldSwitchToMedia_ = () => true;
-  this.masterPlaylistController.mainSegmentLoader_.trigger('earlyabort');
-  assert.equal(mediaChanges.length, 1, 'one media change');
-  assert.equal(warnings.length, 1, 'one warning logged');
-  assert.equal(
-    warnings[0],
-    `Problem encountered with playlist ${currentMedia.id}. ` +
-                 'Aborted early because there isn\'t enough bandwidth to complete the ' +
-                 `request without rebuffering. Switching to playlist ${mediaChanges[0].id}.`,
-    'warning message is correct'
-  );
-
-  videojs.log.warn = origWarn;
-});
-
 QUnit.test('Determines if playlist should change on bandwidthupdate/progress from segment loader', function(assert) {
   let calls = 0;
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -5550,11 +5550,16 @@ QUnit.test('Determines if playlist should change on bandwidthupdate/progress fro
 
   // progress for a segment download
   this.masterPlaylistController.mainSegmentLoader_.trigger('progress');
-  assert.strictEqual(calls, 2, 'selects after segment progress');
+  assert.strictEqual(calls, 1, 'does not select after segment progress');
 
   // "downloaded" a segment
   this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
-  assert.strictEqual(calls, 3, 'selects after segment download');
+  assert.strictEqual(calls, 1, 'does not select after segment download');
+
+  this.clock.tick(250);
+  assert.strictEqual(calls, 2, 'selects after clock tick');
+  this.clock.tick(1000);
+  assert.strictEqual(calls, 6, 'selects after clock tick, 1000 is 4x250');
 
   // verify stats
   assert.equal(this.player.tech_.vhs.stats.bandwidth, 4194304, 'default bandwidth');


### PR DESCRIPTION
This is a followup to #886. There, I noticed that if we get sustained bad network we will time out because we will an opportunity for earlyabort. At first, I tried working around by delaying earlyabort in that case (#966) but as I was getting that ready I kept finding edge cases that we needed to account for. Specifically, the issue is that we only run our ABR algorithm on `progress` and `bandwidthchange` events from the segment loader. This means that if the download stalls, we stop run our algorithm and will eventually stall playback. Instead, we should remove earlyabort altogether (f897dde) and set up an interval (currently 250ms) to re-run our ABR algorithm. This means that if the network becomes bad for a sustained period, we will drop down once the buffer allows us but if the network recovers, we will switch up appropriately as well.

Also, the interval is stopped while we're paused.

Fixes #964.