### PR TITLE
fix: only prevent audio group creation if no other playlists are using it

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -303,5 +303,11 @@
     "uri": "https://d2zihajmogu5jn.cloudfront.net/audio-only-dupe-groups/prog_index.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
+  },
+  {
+    "name": "Big Buck Bunny Demuxed av, audio only rendition same as group",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/demuxed-ts-with-audio-only-rendition/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
   }
 ]

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -412,7 +412,7 @@ export const initialize = {
         });
 
         // If there are no playlists using this audio group other than ones
-        // that match it's uri. Then playlist is audio only. We delete the resolvedUri
+        // that match it's uri, then the playlist is audio only. We delete the resolvedUri
         // property here to prevent a playlist loader from being created so that we don't have
         // both the main and audio segment loaders loading the same audio segments
         // from the same playlist.

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -405,18 +405,18 @@ export const initialize = {
       for (const variantLabel in mediaGroups[type][groupId]) {
         let properties = mediaGroups[type][groupId][variantLabel];
 
-        // List of playlists for the current group ID that have a matching uri with
-        // this alternate audio variant
-        const matchingPlaylists = groupPlaylists.filter(playlist => {
-          return playlist.resolvedUri === properties.resolvedUri;
+        // List of playlists for the current group ID that do not have a matching uri
+        // with this alternate audio variant
+        const unmatchingPlaylists = groupPlaylists.filter(playlist => {
+          return playlist.resolvedUri !== properties.resolvedUri;
         });
 
-        if (matchingPlaylists.length) {
-          // If there is a playlist that has the same uri as this audio variant, assume
-          // that the playlist is audio only. We delete the resolvedUri property here
-          // to prevent a playlist loader from being created so that we don't have
-          // both the main and audio segment loaders loading the same audio segments
-          // from the same playlist.
+        // If there are no playlists using this audio group other than ones
+        // that match it's uri. Then playlist is audio only. We delete the resolvedUri
+        // property here to prevent a playlist loader from being created so that we don't have
+        // both the main and audio segment loaders loading the same audio segments
+        // from the same playlist.
+        if (!unmatchingPlaylists.length) {
           delete properties.resolvedUri;
         }
 

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -416,7 +416,7 @@ export const initialize = {
         // property here to prevent a playlist loader from being created so that we don't have
         // both the main and audio segment loaders loading the same audio segments
         // from the same playlist.
-        if (!unmatchingPlaylists.length) {
+        if (!unmatchingPlaylists.length && groupPlaylists.length) {
           delete properties.resolvedUri;
         }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -143,7 +143,7 @@ export const timestampOffsetForSegment = ({
   // the currently set timestampOffset, but this isn't desirable as it can produce bad
   // behavior, especially around long running live streams.
   if (!overrideCheck && segmentTimeline === currentTimeline) {
-    return null;
+    // return null;
   }
 
   // segmentInfo.startOfSegment used to be used as the timestamp offset, however, that
@@ -2472,9 +2472,7 @@ export default class SegmentLoader extends videojs.EventTarget {
         // priority, timing-wise, so we must wait
         typeof segmentInfo.timingInfo.start !== 'number' ||
         // already updated the timestamp offset for this segment
-        segmentInfo.changedTimestampOffset ||
-        // the alt audio loader should not be responsible for setting the timestamp offset
-        this.loaderType_ !== 'main') {
+        segmentInfo.changedTimestampOffset) {
       return;
     }
 
@@ -2490,12 +2488,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     // future (within the same segment), however, there may be a better way to handle it.
     segmentInfo.changedTimestampOffset = true;
 
-    if (segmentInfo.timestampOffset !== this.sourceUpdater_.videoTimestampOffset()) {
+    if (this.currentMediaInfo_.hasVideo && segmentInfo.timestampOffset !== this.sourceUpdater_.videoTimestampOffset()) {
       this.sourceUpdater_.videoTimestampOffset(segmentInfo.timestampOffset);
       didChange = true;
     }
 
-    if (segmentInfo.timestampOffset !== this.sourceUpdater_.audioTimestampOffset()) {
+    if (this.currentMediaInfo_.hasAudio && segmentInfo.timestampOffset !== this.sourceUpdater_.audioTimestampOffset()) {
       this.sourceUpdater_.audioTimestampOffset(segmentInfo.timestampOffset);
       didChange = true;
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -143,7 +143,7 @@ export const timestampOffsetForSegment = ({
   // the currently set timestampOffset, but this isn't desirable as it can produce bad
   // behavior, especially around long running live streams.
   if (!overrideCheck && segmentTimeline === currentTimeline) {
-    // return null;
+    return null;
   }
 
   // segmentInfo.startOfSegment used to be used as the timestamp offset, however, that
@@ -2472,7 +2472,9 @@ export default class SegmentLoader extends videojs.EventTarget {
         // priority, timing-wise, so we must wait
         typeof segmentInfo.timingInfo.start !== 'number' ||
         // already updated the timestamp offset for this segment
-        segmentInfo.changedTimestampOffset) {
+        segmentInfo.changedTimestampOffset ||
+        // the alt audio loader should not be responsible for setting the timestamp offset
+        this.loaderType_ !== 'main') {
       return;
     }
 
@@ -2488,12 +2490,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     // future (within the same segment), however, there may be a better way to handle it.
     segmentInfo.changedTimestampOffset = true;
 
-    if (this.currentMediaInfo_.hasVideo && segmentInfo.timestampOffset !== this.sourceUpdater_.videoTimestampOffset()) {
+    if (segmentInfo.timestampOffset !== this.sourceUpdater_.videoTimestampOffset()) {
       this.sourceUpdater_.videoTimestampOffset(segmentInfo.timestampOffset);
       didChange = true;
     }
 
-    if (this.currentMediaInfo_.hasAudio && segmentInfo.timestampOffset !== this.sourceUpdater_.audioTimestampOffset()) {
+    if (segmentInfo.timestampOffset !== this.sourceUpdater_.audioTimestampOffset()) {
       this.sourceUpdater_.audioTimestampOffset(segmentInfo.timestampOffset);
       didChange = true;
     }

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -1012,6 +1012,43 @@ QUnit.test('initialize audio correctly uses HLS source type', function(assert) {
   );
 });
 
+QUnit.test('no audio loader for audio only with duplicated audio groups', function(assert) {
+  this.master.mediaGroups.AUDIO.aud1 = {
+    en: { default: true, language: 'en', resolvedUri: 'en.m3u8' }
+  };
+
+  this.settings.sourceType = 'hls';
+
+  this.settings.master.playlists = [
+    {resolvedUri: 'en.m3u8', attributes: {AUDIO: 'aud1'}}
+  ];
+  MediaGroups.initialize.AUDIO('AUDIO', this.settings);
+
+  assert.notOk(
+    this.mediaTypes.AUDIO.groups.aud1[0].playlistLoader,
+    'no loader as audio group is the same as main renditions'
+  );
+});
+
+QUnit.test('audio loader created with audio group duplicated as audio only rendition', function(assert) {
+  this.master.mediaGroups.AUDIO.aud1 = {
+    en: { default: true, language: 'en', resolvedUri: 'en.m3u8' }
+  };
+
+  this.settings.sourceType = 'hls';
+
+  this.settings.master.playlists = [
+    {resolvedUri: 'video/en.m3u8', attributes: {AUDIO: 'aud1'}},
+    {resolvedUri: 'en.m3u8', attributes: {AUDIO: 'aud1'}}
+  ];
+  MediaGroups.initialize.AUDIO('AUDIO', this.settings);
+
+  assert.ok(
+    this.mediaTypes.AUDIO.groups.aud1[0].playlistLoader,
+    'audio loader created'
+  );
+});
+
 QUnit.test('initialize audio correctly uses DASH source type', function(assert) {
   // allow async methods to resolve before next test
   const done = assert.async();

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -237,6 +237,25 @@ QUnit[testFn]('Big Buck Bunny audio only, groups & renditions same uri', functio
   });
 });
 
+QUnit[testFn]('Big Buck Bunny Demuxed av, audio only rendition same as group', function(assert) {
+  const done = assert.async();
+
+  assert.expect(2);
+  const player = this.player;
+
+  playFor(player, 25, function() {
+    assert.ok(true, 'played for at least 25 seconds');
+    assert.equal(player.error(), null, 'has no player errors');
+
+    done();
+  });
+
+  player.src({
+    src: 'https://d2zihajmogu5jn.cloudfront.net/demuxed-ts-with-audio-only-rendition/master.m3u8',
+    type: 'application/x-mpegURL'
+  });
+});
+
 QUnit[testFn]('Live DASH', function(assert) {
   const done = assert.async();
 


### PR DESCRIPTION
Fixes an issue (not the only issue) with #977

caused by the fix in https://github.com/videojs/http-streaming/pull/952