### PR TITLE
fix: Revert #574 to fix caption removal issue

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1011,6 +1011,12 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     removeCuesFromTrack(start, end, this.segmentMetadataTrack_);
 
+    if (this.inbandTextTracks_) {
+      for (const id in this.inbandTextTracks_) {
+        removeCuesFromTrack(start, end, this.inbandTextTracks_[id]);
+      }
+    }
+
     // finished this function's removes
     removeFinished();
   }

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -241,7 +241,7 @@ export const removeCuesFromTrack = function(start, end, track) {
     cue = track.cues[i];
 
     // Remove any overlapping cue
-    if (cue.startTime >= start && cue.endTime <= end) {
+    if (cue.startTime <= end && cue.endTime >= start) {
       track.removeCue(cue);
     }
   }

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -364,9 +364,12 @@ export default class VTTSegmentLoader extends SegmentLoader {
 
     this.mediaSecondsLoaded += segment.duration;
 
-    segmentInfo.cues.forEach((cue) => {
+    if (segmentInfo.cues.length) {
       // remove any overlapping cues to prevent doubling
-      this.remove(cue.startTime, cue.endTime);
+      this.remove(segmentInfo.cues[0].endTime, segmentInfo.cues[segmentInfo.cues.length - 1].endTime);
+    }
+
+    segmentInfo.cues.forEach((cue) => {
       this.subtitlesTrack_.addCue(this.featuresNativeTextTracks_ ?
         new window.VTTCue(cue.startTime, cue.endTime, cue.text) :
         cue);

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -2182,7 +2182,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           }
         };
 
-        loader.remove(10, 20);
+        loader.remove(3, 10);
 
         assert.strictEqual(
           loader.inbandTextTracks_.CC1.cues.length,


### PR DESCRIPTION
## Description
Revert #574. That change is resulting in WebVTT cues with overlapping time-intervals (which the spec allows) being removed from the cue list. 
