### PR TITLE
Feat/config live seekable window

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Video.js Compatibility: 6.0, 7.0
       - [customTagMappers](#customtagmappers)
       - [cacheEncryptionKeys](#cacheencryptionkeys)
       - [handlePartialData](#handlepartialdata)
+      - [liveRangeSafeTimeDelta](#liverangesafetimedelta)
   - [Runtime Properties](#runtime-properties)
     - [vhs.playlists.master](#vhsplaylistsmaster)
     - [vhs.playlists.media](#vhsplaylistsmedia)
@@ -450,6 +451,11 @@ This option defaults to `false`.
 * Type: `boolean`,
 * Default: `false`
 * Use partial appends in the transmuxer and segment loader
+
+##### liveRangeSafeTimeDelta
+* Type: `boolean`,
+* Default: `false`
+* Allow to re-define length (in seconds) of time delta when you compare current time and the end of the buffered range.
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -63,7 +63,7 @@ not meant serve as an exhaustive list.
 * Video only (non DRM)
 * In-manifest [WebVTT] subtitles are automatically translated into standard HTML5 subtitle
   tracks
-* [AES-128] and SAMPLE-AES segment encryption
+* [AES-128] segment encryption
 
 ## Notable Missing Features
 
@@ -126,6 +126,7 @@ not yet been implemented. VHS currently supports everything in the
 * Use of AVERAGE-BANDWIDTH in [EXT-X-STREAM-INF] (value parsed but not used)
 * Use of FRAME-RATE in [EXT-X-STREAM-INF] (value parsed but not used)
 * Use of HDCP-LEVEL in [EXT-X-STREAM-INF]
+* SAMPLE-AES segment encryption
 
 In the event of encoding changes within a playlist (see
 https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-6.3.3), the

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -76,6 +76,7 @@ export default class PlaybackWatcher {
     this.tech_ = options.tech;
     this.seekable = options.seekable;
     this.allowSeeksWithinUnsafeLiveWindow = options.allowSeeksWithinUnsafeLiveWindow;
+    this.liveRangeSafeTimeDelta = options.liveRangeSafeTimeDelta;
     this.media = options.media;
 
     this.consecutiveUpdates = 0;
@@ -503,7 +504,7 @@ export default class PlaybackWatcher {
     if (seekable.length &&
         // can't fall before 0 and 0 seekable start identifies VOD stream
         seekable.start(0) > 0 &&
-        currentTime < seekable.start(0) - Ranges.SAFE_TIME_DELTA) {
+        currentTime < seekable.start(0) - (this.liveRangeSafeTimeDelta || Ranges.SAFE_TIME_DELTA)) {
       return true;
     }
 

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -1170,6 +1170,23 @@ QUnit.test('detects live window falloff', function(assert) {
   );
 });
 
+QUnit.test('respects liveRangeSafeTimeDelta flag', function(assert) {
+  this.playbackWatcher.liveRangeSafeTimeDelta = 1;
+
+  const beforeSeekableWindow_ =
+    this.playbackWatcher.beforeSeekableWindow_.bind(this.playbackWatcher);
+
+  assert.ok(
+    beforeSeekableWindow_(videojs.createTimeRanges([[12, 20]]), 10),
+    'true if playlist live and current time before seekable'
+  );
+
+  assert.ok(
+    !beforeSeekableWindow_(videojs.createTimeRanges([]), 10),
+    'false if no seekable range'
+  );
+});
+
 QUnit.test('detects beyond seekable window for VOD', function(assert) {
   const playlist = {
     endList: true,


### PR DESCRIPTION
## Description
During live streaming in low bandwidth situations `playback-watcher` try different times to seek to live edge without waiting for buffered contents. This behaviour causing waiting status "loop" because buffer will never reach minimum contents in order to perform playback.

## Specific Changes proposed
Configure method `beforeSeekableWindow_` in order to accept new configuration parameter `liveRangeSafeTimeDelta` to adjust safe time delta.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [X] Docs/guides updated
  - [X] Example created ([JSBin](https://jsbin.com/vuguqik/edit?html,output))
- [ ] Reviewed by Two Core Contributors
