### PR TITLE
Wait for EME initialization before appending content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10691,9 +10691,9 @@
       }
     },
     "videojs-contrib-eme": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-3.7.1.tgz",
-      "integrity": "sha512-zWUT2TFZ1zJ0gILZIx9KQELwHQmtaQzmlPJ36pWHh3IogMcWOeWIGBmrIc6leSGN7ZCeV8xieig7CNsAEXlQMg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-3.8.0.tgz",
+      "integrity": "sha512-ZSNqMviFdzZfAWJyyt8xSak7SR+ZFdwb0Fs30LCmp0qKgqM5EgNF/blhPjkiz7NzXD+VO6TmhsRlZJ7qaQ811g==",
       "dev": true,
       "requires": {
         "global": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "shelljs": "^0.8.2",
     "sinon": "^8.1.1",
     "url-toolkit": "^2.1.3",
-    "videojs-contrib-eme": "^3.2.0",
+    "videojs-contrib-eme": "^3.8.0",
     "videojs-contrib-quality-levels": "^2.0.4",
     "videojs-generate-karma-config": "~7.0.0",
     "videojs-generate-rollup-config": "~5.0.1",

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -650,7 +650,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     const updateCodecs = () => {
-      if (!this.sourceUpdater_.ready()) {
+      if (!this.sourceUpdater_.hasCreatedSourceBuffers()) {
         return this.tryToCreateSourceBuffers_();
       }
 
@@ -1547,7 +1547,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
     // check if codec switching is happening
-    if (this.sourceUpdater_.ready() && !this.sourceUpdater_.canChangeType()) {
+    if (
+      this.sourceUpdater_.hasCreatedSourceBuffers() &&
+      !this.sourceUpdater_.canChangeType()
+    ) {
       const switchMessages = [];
 
       ['video', 'audio'].forEach((type) => {
@@ -1583,7 +1586,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
   tryToCreateSourceBuffers_() {
     // media source is not ready yet or sourceBuffers are already
     // created.
-    if (this.mediaSource.readyState !== 'open' || this.sourceUpdater_.ready()) {
+    if (
+      this.mediaSource.readyState !== 'open' ||
+      this.sourceUpdater_.hasCreatedSourceBuffers()
+    ) {
       return;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1713,7 +1713,6 @@ export default class SegmentLoader extends videojs.EventTarget {
 
   hasEnoughInfoToAppend_() {
     if (!this.sourceUpdater_.ready()) {
-      // waiting on one of the segment loaders to get enough data to create source buffers
       return false;
     }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -295,9 +295,7 @@ export const waitForKeySessionCreation = ({
   // initializeMediaKeys also won't use the webkit-prefixed APIs.
   keySystemsOptionsArr.forEach((keySystemsOptions) => {
     keySessionCreatedPromises.push(new Promise((resolve, reject) => {
-      player.tech_.one('keysessioncreated', () => {
-        resolve();
-      });
+      player.tech_.one('keysessioncreated', resolve);
     }));
 
     initializationFinishedPromises.push(new Promise((resolve, reject) => {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -5021,7 +5021,8 @@ QUnit.test('excludes on codec switch if codec switching not supported', function
   });
 
   // sourceUpdater_ already setup
-  this.mpc.sourceUpdater_.ready = () => true;
+  this.mpc.sourceUpdater_.initializedEme();
+  this.mpc.sourceUpdater_.createdSourceBuffers_ = () => true;
   this.mpc.sourceUpdater_.canChangeType = () => false;
   this.mpc.sourceUpdater_.codecs = {
     audio: 'mp4a.40.2',
@@ -5061,7 +5062,8 @@ QUnit.test('does not exclude on codec switch between the same base codec', funct
   });
 
   // sourceUpdater_ already setup
-  this.mpc.sourceUpdater_.ready = () => true;
+  this.mpc.sourceUpdater_.initializedEme();
+  this.mpc.sourceUpdater_.createdSourceBuffers_ = () => true;
   this.mpc.sourceUpdater_.canChangeType = () => false;
   this.mpc.sourceUpdater_.codecs = {
     audio: 'mp4a.40.2',
@@ -5111,7 +5113,8 @@ QUnit.test('main loader only trackinfo works as expected', function(assert) {
   assert.equal(createBuffers, 1, 'createSourceBuffers called');
   assert.equal(switchBuffers, 0, 'addOrChangeSourceBuffers not called');
 
-  this.mpc.sourceUpdater_.ready = () => true;
+  this.mpc.sourceUpdater_.initializedEme();
+  this.mpc.sourceUpdater_.createdSourceBuffers_ = () => true;
   this.mpc.sourceUpdater_.canChangeType = () => true;
 
   this.contentSetup({
@@ -5181,7 +5184,8 @@ QUnit.test('main & audio loader only trackinfo works as expected', function(asse
   assert.equal(createBuffers, 1, 'createSourceBuffers called');
   assert.equal(switchBuffers, 0, 'addOrChangeSourceBuffers not called');
 
-  this.mpc.sourceUpdater_.ready = () => true;
+  this.mpc.sourceUpdater_.initializedEme();
+  this.mpc.sourceUpdater_.createdSourceBuffers_ = () => true;
   this.mpc.sourceUpdater_.canChangeType = () => true;
 
   this.mpc.mainSegmentLoader_.currentMediaInfo_ = {

--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -53,6 +53,10 @@ QUnit.module('Source Updater', {
     video.src = URL.createObjectURL(this.mediaSource);
     this.sourceUpdater = new SourceUpdater(this.mediaSource);
 
+    // This is normally done at the top level of the plugin, but will not happen in
+    // an isolated module.
+    this.sourceUpdater.initializedEme();
+
     // wait for the source to open (or error) before running through tests
     return new Promise((accept, reject) => {
       this.mediaSource.addEventListener('sourceopen', accept);
@@ -162,6 +166,7 @@ QUnit.test('verifies that sourcebuffer is in source buffers list before attempti
   };
 
   this.sourceUpdater = new SourceUpdater(createMediaSource());
+  this.sourceUpdater.initializedEme();
   this.sourceUpdater.createSourceBuffers({
     audio: 'mp4a.40.2',
     video: 'avc1.4d400d'
@@ -179,6 +184,7 @@ QUnit.test('verifies that sourcebuffer is in source buffers list before attempti
 
   this.sourceUpdater.dispose();
   this.sourceUpdater = new SourceUpdater(createMediaSource());
+  this.sourceUpdater.initializedEme();
   this.sourceUpdater.createSourceBuffers({
     audio: 'mp4a.40.2',
     video: 'avc1.4d400d'
@@ -335,13 +341,15 @@ QUnit.test('setting audio timestamp offset without buffer is a noop', function(a
 });
 
 QUnit.test('ready with a video buffer', function(assert) {
+  this.sourceUpdater.initializedEme();
   this.sourceUpdater.createSourceBuffers({
     video: 'avc1.4d400d'
   });
-  assert.ok(this.sourceUpdater.ready(), 'source updater is ready');
+  assert.ok(this.sourceUpdater.ready(), 'source updater has started');
 });
 
 QUnit.test('ready with an audio buffer', function(assert) {
+  this.sourceUpdater.initializedEme();
   this.sourceUpdater.createSourceBuffers({
     audio: 'mp4a.40.2'
   });
@@ -349,10 +357,24 @@ QUnit.test('ready with an audio buffer', function(assert) {
 });
 
 QUnit.test('ready with both an audio and video buffer', function(assert) {
+  this.sourceUpdater.initializedEme();
   this.sourceUpdater.createSourceBuffers({
     video: 'avc1.4d400d',
     audio: 'mp4a.40.2'
   });
+  assert.ok(this.sourceUpdater.ready(), 'source updater is ready');
+});
+
+QUnit.test('ready once source buffers created and eme initialized', function(assert) {
+  // the module initializes by default
+  this.sourceUpdater.initializedEme_ = false;
+  assert.notOk(this.sourceUpdater.ready(), 'source updater is not ready');
+  this.sourceUpdater.createSourceBuffers({
+    video: 'avc1.4d400d',
+    audio: 'mp4a.40.2'
+  });
+  assert.notOk(this.sourceUpdater.ready(), 'source updater is not ready');
+  this.sourceUpdater.initializedEme();
   assert.ok(this.sourceUpdater.ready(), 'source updater is ready');
 });
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -596,6 +596,12 @@ export const setupMediaSource = (mediaSource, sourceUpdater, options) => {
 
   videoEl.src = window.URL.createObjectURL(mediaSource);
 
+  // With the addition of the initialized EME requirement for source-updater start, a lot
+  // of tests which use the media source, but don't start at the top level of the plugin
+  // (where the EME initialization is done) faileddue to the source updatel never
+  // reporting as ready. This direct initialization works around the issue.
+  sourceUpdater.initializedEme();
+
   return new Promise((resolve, reject) => {
     mediaSource.addEventListener('sourceopen', () => {
       const codecs = {};

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4376,7 +4376,7 @@ QUnit.test('populates quality levels list when available', function(assert) {
   );
 });
 
-QUnit.test('configures eme for DASH if present on sourceUpdater ready', function(assert) {
+QUnit.test('configures eme for DASH on source buffer creation', function(assert) {
   this.player.eme = {
     options: {
       previousSetting: 1
@@ -4425,7 +4425,7 @@ QUnit.test('configures eme for DASH if present on sourceUpdater ready', function
     }
   };
 
-  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.trigger('ready');
+  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.trigger('createdsourcebuffers');
 
   assert.deepEqual(this.player.eme.options, {
     previousSetting: 1
@@ -4445,7 +4445,7 @@ QUnit.test('configures eme for DASH if present on sourceUpdater ready', function
   }, 'set source eme options');
 });
 
-QUnit.test('configures eme for HLS if present on sourceUpdater ready', function(assert) {
+QUnit.test('configures eme for HLS on source buffer creation', function(assert) {
   this.player.eme = {
     options: {
       previousSetting: 1
@@ -4479,7 +4479,7 @@ QUnit.test('configures eme for HLS if present on sourceUpdater ready', function(
     media: () => media
   };
 
-  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.trigger('ready');
+  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.trigger('createdsourcebuffers');
 
   assert.deepEqual(this.player.eme.options, {
     previousSetting: 1
@@ -4499,7 +4499,7 @@ QUnit.test('configures eme for HLS if present on sourceUpdater ready', function(
   }, 'set source eme options');
 });
 
-QUnit.test('integration: configures eme for DASH if present on sourceUpdater ready', function(assert) {
+QUnit.test('integration: configures eme for DASH on source buffer creation', function(assert) {
   assert.timeout(3000);
   const done = assert.async();
 
@@ -4519,25 +4519,28 @@ QUnit.test('integration: configures eme for DASH if present on sourceUpdater rea
   });
   openMediaSource(this.player, this.clock);
 
-  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.on('ready', () => {
-    assert.deepEqual(this.player.eme.options, {
-      previousSetting: 1
-    }, 'did not modify plugin options');
+  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.on(
+    'createdsourcebuffers',
+    () => {
+      assert.deepEqual(this.player.eme.options, {
+        previousSetting: 1
+      }, 'did not modify plugin options');
 
-    assert.deepEqual(this.player.currentSource(), {
-      src: 'dash.mpd',
-      type: 'application/dash+xml',
-      keySystems: {
-        keySystem1: {
-          url: 'url1',
-          audioContentType: 'audio/mp4;codecs="mp4a.40.2"',
-          videoContentType: 'video/mp4;codecs="avc1.420015"'
+      assert.deepEqual(this.player.currentSource(), {
+        src: 'dash.mpd',
+        type: 'application/dash+xml',
+        keySystems: {
+          keySystem1: {
+            url: 'url1',
+            audioContentType: 'audio/mp4;codecs="mp4a.40.2"',
+            videoContentType: 'video/mp4;codecs="avc1.420015"'
+          }
         }
-      }
-    }, 'set source eme options');
+      }, 'set source eme options');
 
-    done();
-  });
+      done();
+    }
+  );
 
   this.standardXHRResponse(this.requests[0]);
   // this allows the audio playlist loader to load
@@ -4550,7 +4553,7 @@ QUnit.test('integration: configures eme for DASH if present on sourceUpdater rea
   this.standardXHRResponse(this.requests[4], mp4AudioSegment());
 });
 
-QUnit.test('integration: configures eme for HLS if present on sourceUpdater ready', function(assert) {
+QUnit.test('integration: configures eme for HLS on source buffer creation', function(assert) {
   assert.timeout(3000);
   const done = assert.async();
 
@@ -4570,25 +4573,28 @@ QUnit.test('integration: configures eme for HLS if present on sourceUpdater read
   });
   openMediaSource(this.player, this.clock);
 
-  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.on('ready', () => {
-    assert.deepEqual(this.player.eme.options, {
-      previousSetting: 1
-    }, 'did not modify plugin options');
+  this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.on(
+    'createdsourcebuffers',
+    () => {
+      assert.deepEqual(this.player.eme.options, {
+        previousSetting: 1
+      }, 'did not modify plugin options');
 
-    assert.deepEqual(this.player.currentSource(), {
-      src: 'demuxed-two.m3u8',
-      type: 'application/x-mpegURL',
-      keySystems: {
-        keySystem1: {
-          url: 'url1',
-          audioContentType: 'audio/mp4;codecs="mp4a.40.2"',
-          videoContentType: 'video/mp4;codecs="avc1.420015"'
+      assert.deepEqual(this.player.currentSource(), {
+        src: 'demuxed-two.m3u8',
+        type: 'application/x-mpegURL',
+        keySystems: {
+          keySystem1: {
+            url: 'url1',
+            audioContentType: 'audio/mp4;codecs="mp4a.40.2"',
+            videoContentType: 'video/mp4;codecs="avc1.420015"'
+          }
         }
-      }
-    }, 'set source eme options');
+      }, 'set source eme options');
 
-    done();
-  });
+      done();
+    }
+  );
 
   // master manifest
   this.standardXHRResponse(this.requests.shift());


### PR DESCRIPTION
Requires https://github.com/videojs/videojs-contrib-eme/pull/124

## Description
Wait for EME initialization before appending content. This is particularly important for Chrome, where, if unencrypted content is appended before encrypted content and the key session has not been created, a MEDIA_ERR_DECODE will be thrown once the encrypted content is reached during playback.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
