### PR TITLE
fix: VTTCues with identical time intervals being incorrectly removed

### DIFF
--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -240,9 +240,47 @@ export const removeCuesFromTrack = function(start, end, track) {
   while (i--) {
     cue = track.cues[i];
 
-    // Remove any overlapping cue
+    // Remove any cue within the provided start and end time
     if (cue.startTime >= start && cue.endTime <= end) {
       track.removeCue(cue);
+    }
+  }
+};
+
+/**
+ * Remove duplicate cues from a track on video.js (a cue is considered a
+ * duplicate if it has the same time interval and text as another)
+ *
+ * @param {Object} track the text track to remove the duplicate cues from
+ * @private
+ */
+export const removeDuplicateCuesFromTrack = function(track) {
+  const cues = track.cues;
+
+  if (!cues) {
+    return;
+  }
+
+  for (let i = 0; i < cues.length; i++) {
+    const duplicates = [];
+    let occurrences = 0;
+
+    for (let j = 0; j < cues.length; j++) {
+      if (
+        cues[i].startTime === cues[j].startTime &&
+        cues[i].endTime === cues[j].endTime &&
+        cues[i].text === cues[j].text
+      ) {
+        occurrences++;
+
+        if (occurrences > 1) {
+          duplicates.push(cues[j]);
+        }
+      }
+    }
+
+    if (duplicates.length) {
+      duplicates.forEach(dupe => track.removeCue(dupe));
     }
   }
 };


### PR DESCRIPTION
## Description
This is a replacement for #995, which was an attempt to revert a PR that resulted in WebVTT cues with identical time-intervals (which the spec allows) being removed from the cue list. However, simply reverting the change broke 608 captions, so another solution was required.

The main goals of this PR are to:
1. Make sure WebVTT cues are not removed from the TextTrackList just because they have the same time-intervals
2. Satisfy the original purpose of this [logic](https://github.com/videojs/http-streaming/blob/main/src/vtt-segment-loader.js#L368-L369) (originally [this](https://github.com/videojs/videojs-contrib-hls/pull/1219)) that I removed, which is to make sure any cues that "overlap" VTT segments (cues that are both the last cue of one segment and the first cue of the next segment) are removed.

## Solution
We can meet those criteria by only removing cues that have identical time intervals *and* identical text. This will ensure we remove any cues that overlap VTT segments, while keeping any cues that are actually intended to be displayed at the same time (which we can *reasonably* assume will have different text)

## Specific Additions
1. Create `removeDuplicateCuesFromTrack()` function in text-track utils
2. Modify the vtt-segment-loader so that we run the de-duping after adding VTTcues from a new segment
3. Unit tests