### PR TITLE
chore: add multiple soon-to-work sources

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -318,19 +318,19 @@
   },
   {
     "name": "(Not Working) fmp4 x264/flac no manifest codecs",
-    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-flac-no-manifect-codecs/master.m3u8",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-flac-no-manifest-codecs/master.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
   },
   {
     "name": "(Not Working) fmp4 x264/opus no manifest codecs",
-    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-opus-no-manifect-codecs/master.m3u8",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-opus-no-manifest-codecs/master.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
   },
   {
     "name": "fmp4 h264/aac no manifest codecs",
-    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-muxed-no-playlist-codecs/master.m3u8",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-muxed-no-playlist-codecs/index.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
   },

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -309,5 +309,35 @@
     "uri": "https://d2zihajmogu5jn.cloudfront.net/demuxed-ts-with-audio-only-rendition/master.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
+  },
+  {
+    "name": "(Not Working) sidx v1 dash",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/sidx-v1-dash/Dog.mpd",
+    "mimetype": "application/dash+xml",
+    "features": []
+  },
+  {
+    "name": "(Not Working) fmp4 x264/flac no manifest codecs",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-flac-no-manifect-codecs/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "(Not Working) fmp4 x264/opus no manifest codecs",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-opus-no-manifect-codecs/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "fmp4 h264/aac no manifest codecs",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/fmp4-muxed-no-playlist-codecs/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "(Not Working) ts one valid codec among many invalid",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/ts-one-valid-many-invalid/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
   }
 ]


### PR DESCRIPTION
## Description
This pull request adds multiple sources that will be fixed by the following pull request/releases
1. fmp4/opus and fmp4/flac ~ currently in mux.js master, needs a release https://github.com/videojs/mux.js/pull/355
2. fmp4/aac currently works
3. ts with one valid audio/video codec but a bunch of invalid codecs too
4. sidx version 1 box dash. needs https://github.com/videojs/mux.js/pull/310