### PR TITLE
feat: update to mux.js 5.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1296,6 +1296,11 @@
             "global": "^4.3.2",
             "xmldom": "^0.1.27"
           }
+        },
+        "mux.js": {
+          "version": "5.6.7",
+          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.7.tgz",
+          "integrity": "sha512-YSr6B8MUgE4S18MptbY2XM+JKGbw9JDkgs7YkuE/T2fpDKjOhZfb/nD6vmsVxvLYOExWNaQn1UGBp6PGsnTtew=="
         }
       }
     },
@@ -7167,9 +7172,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.7.tgz",
-      "integrity": "sha512-YSr6B8MUgE4S18MptbY2XM+JKGbw9JDkgs7YkuE/T2fpDKjOhZfb/nD6vmsVxvLYOExWNaQn1UGBp6PGsnTtew=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.7.0.tgz",
+      "integrity": "sha512-SINb/qE0iN7YdpbGHtcj8JoHAJWXITUcN9ZCmakThZ8pVGvWukBMCDfJbEVmY2+GqmmrUkLkwUN9Ec2YLUSbuA=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "global": "^4.3.2",
     "m3u8-parser": "4.5.0",
     "mpd-parser": "0.15.0",
-    "mux.js": "5.6.7",
+    "mux.js": "5.7.0",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fixes issue with baseTime 0
- Initial support for CEA 708 captions
- Support for SIDX v1 boxes
- opus/flac support in fmp4 playlists


Closes #1001, fixes #909