### PR TITLE
fix: keep running the minimumUpdatePeriod unless cancelled or changed

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -649,6 +649,7 @@ export default class DashPlaylistLoader extends EventTarget {
     const createMUPTimeout = (mup) => {
       this.minimumUpdatePeriodTimeout_ = window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
+        createMUPTimeout(mup);
       }, mup);
     };
 


### PR DESCRIPTION
## Description
After the dash playlist loader refactors the timeout for minimumUpdatePeriod is not set every time a refresh happens for master, as master isn't always changing. We should just set another timeout for minimumUpdatePeriod after triggering so that we can keep it going without worrying about updating it if its unchanged.