### PR TITLE
fix: track id 0 is valid

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -194,7 +194,7 @@ const handleInitSegmentResponse =
 
     segment.map.tracks[track.type] = track;
 
-    if (track.id && track.timescale) {
+    if (typeof track.id === 'number' && track.timescale) {
       segment.map.timescales = segment.map.timescales || {};
       segment.map.timescales[track.id] = track.timescale;
     }


### PR DESCRIPTION
## Description
fmp4 Tracks with id 0 are broken as we don't add their timescale to the init segment map.