### PR TITLE
fix: when changing renditions over a discontinuity, don't use buffere…

### DIFF
--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -217,6 +217,20 @@ QUnit.test('returns value when overrideCheck is true', function(assert) {
   );
 });
 
+QUnit.test('uses startOfSegment when timeline is before current', function(assert) {
+  assert.equal(
+    timestampOffsetForSegment({
+      segmentTimeline: 0,
+      currentTimeline: 1,
+      startOfSegment: 3,
+      buffered: videojs.createTimeRanges([[1, 5], [7, 8]]),
+      overrideCheck: true
+    }),
+    3,
+    'returned startOfSegment'
+  );
+});
+
 QUnit.module('shouldWaitForTimelineChange');
 
 QUnit.test('should not wait if timelines are the same', function(assert) {


### PR DESCRIPTION
…d end as segment start

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
