### PR TITLE
fix(experimentalBufferBasedABR): start ABR timer on main playlist load

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -259,7 +259,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.setupSegmentLoaderListeners_();
 
     if (this.experimentalBufferBasedABR) {
-      this.startABRTimer_();
+      this.masterPlaylistLoader_.one('loadedplaylist', () => this.startABRTimer_());
       this.tech_.on('pause', () => this.stopABRTimer_());
       this.tech_.on('play', () => this.startABRTimer_());
     }

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -155,6 +155,11 @@ export const simpleSelector = function(
   limitRenditionByPlayerDimensions
 ) {
 
+  // If we end up getting called before `master` is available, exit early
+  if (!master) {
+    return;
+  }
+
   const options = {
     bandwidth: playerBandwidth,
     width: playerWidth,


### PR DESCRIPTION
Start the timer later, so we don't try to call `simpleSelector` without a playlist. However, we should add a null-check there just in case.

Fixes #1025