### PR TITLE
chore(demo): clear type on manual source change

### DIFF
--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -413,6 +413,11 @@
         urlButton.click();
       }
     });
+    stateEls.url.addEventListener('input', function(event) {
+      if (stateEls.type.value.length) {
+        stateEls.type.value = '';
+      }
+    });
     stateEls.type.addEventListener('keyup', function(event) {
       if (event.key === 'Enter') {
         urlButton.click();


### PR DESCRIPTION
If a user manually changes the url, the type may not be correct anymore.
We should clear it. Given that we auto-detect .m3u8 and .mpd types, it
shouldn't be a big deal and would cause less problems than the incorrect
type being present for the given source.