### PR TITLE
fix: continue retrying playlist if even if it fails when live

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -226,6 +226,14 @@ export default class PlaylistLoader extends EventTarget {
     };
 
     this.trigger('error');
+
+    // refresh live playlists after a target duration passes
+    if (!this.media().endList) {
+      window.clearTimeout(this.mediaUpdateTimeout);
+      this.mediaUpdateTimeout = window.setTimeout(() => {
+        this.trigger('mediaupdatetimeout');
+      }, refreshDelay(this.media(), false));
+    }
   }
 
   /**


### PR DESCRIPTION
For Live HLS, even if a playlist errors out during playback, we want to continue retrying it because it's possible it'll recover.