### PR TITLE
test: clear segment transmuxer in media segment request tests

### DIFF
--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -1213,7 +1213,6 @@ QUnit.test('callbacks fire for TS segment with partial data', function(assert) {
   this.standardXHRResponse(request, muxedSegment());
 });
 
-// TODO: tests after this one appear to fail
 QUnit.test('data callback does not fire if too little partial data', function(assert) {
   const progressSpy = sinon.spy();
   const dataSpy = sinon.spy();
@@ -1251,7 +1250,6 @@ QUnit.test('data callback does not fire if too little partial data', function(as
 
   assert.ok(progressSpy.callCount, 'got a progress event');
   assert.notOk(dataSpy.callCount, 'did not get data event');
-  this.standardXHRResponse(request, muxedSegment());
 });
 
 // TODO test only worked with the completion of a segment request. It should be rewritten

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -10,6 +10,7 @@ import {
 } from './test-helpers';
 import TransmuxWorker from 'worker!../src/transmuxer-worker.worker.js';
 import Decrypter from 'worker!../src/decrypter-worker.worker.js';
+import {dispose as segmentTransmuxerDispose} from '../src/segment-transmuxer.js';
 import {
   aacWithoutId3 as aacWithoutId3Segment,
   aacWithId3 as aacWithId3Segment,
@@ -91,6 +92,9 @@ const sharedHooks = {
     if (this.transmuxer) {
       this.transmuxer.terminate();
     }
+
+    // clear current transmux on segment transmuxer
+    segmentTransmuxerDispose();
   }
 
 };
@@ -1247,6 +1251,7 @@ QUnit.test('data callback does not fire if too little partial data', function(as
 
   assert.ok(progressSpy.callCount, 'got a progress event');
   assert.notOk(dataSpy.callCount, 'did not get data event');
+  this.standardXHRResponse(request, muxedSegment());
 });
 
 // TODO test only worked with the completion of a segment request. It should be rewritten


### PR DESCRIPTION
Basically tests after test in media segment requester can fail. It just so happens that those are our playback tests. They fail because we have a `currentTransmux` in the `SegmentTransmuxer` after that gets disposed everything works!