### PR TITLE
fix: store queue and current transmux on transmuxer instead of global

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -528,14 +528,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       time: 0
     };
 
-    this.transmuxer_ = segmentTransmuxer.createTransmuxer({
-      remux: false,
-      alignGopsAtEnd: this.safeAppend_,
-      keepOriginalTimestamps: true,
-      handlePartialData: this.handlePartialData_,
-      parse708captions: this.parse708captions_
-    });
-
+    this.transmuxer_ = this.createTransmuxer_();
     this.triggerSyncInfoUpdate_ = () => this.trigger('syncinfoupdate');
     this.syncController_.on('syncinfoupdate', this.triggerSyncInfoUpdate_);
 
@@ -593,6 +586,16 @@ export default class SegmentLoader extends videojs.EventTarget {
         }
       });
     }
+  }
+
+  createTransmuxer_() {
+    return segmentTransmuxer.createTransmuxer({
+      remux: false,
+      alignGopsAtEnd: this.safeAppend_,
+      keepOriginalTimestamps: true,
+      handlePartialData: this.handlePartialData_,
+      parse708captions: this.parse708captions_
+    });
   }
 
   /**

--- a/src/segment-transmuxer.js
+++ b/src/segment-transmuxer.js
@@ -1,4 +1,4 @@
-import TransmuxWorker from 'worker!./transmuxer-worker.worker.js';
+import TransmuxWorker from 'worker!./transmuxer-worker.js';
 
 export const handleData_ = (event, transmuxedData, callback) => {
   const {

--- a/src/segment-transmuxer.js
+++ b/src/segment-transmuxer.js
@@ -189,7 +189,7 @@ export const processTransmux = (options) => {
 
 export const dequeue = (transmuxer) => {
   transmuxer.currentTransmux = null;
-  if (transmuxer.transmuxQueue && transmuxer.transmuxQueue.length) {
+  if (transmuxer.transmuxQueue.length) {
     transmuxer.currentTransmux = transmuxer.transmuxQueue.shift();
     if (typeof transmuxer.currentTransmux === 'function') {
       transmuxer.currentTransmux();

--- a/src/segment-transmuxer.js
+++ b/src/segment-transmuxer.js
@@ -1,5 +1,4 @@
-const transmuxQueue = [];
-let currentTransmux;
+import TransmuxWorker from 'worker!./transmuxer-worker.worker.js';
 
 export const handleData_ = (event, transmuxedData, callback) => {
   const {
@@ -66,30 +65,31 @@ export const handleGopInfo_ = (event, transmuxedData) => {
   transmuxedData.gopInfo = event.data.gopInfo;
 };
 
-export const processTransmux = ({
-  transmuxer,
-  bytes,
-  audioAppendStart,
-  gopsToAlignWith,
-  isPartial,
-  remux,
-  onData,
-  onTrackInfo,
-  onAudioTimingInfo,
-  onVideoTimingInfo,
-  onVideoSegmentTimingInfo,
-  onAudioSegmentTimingInfo,
-  onId3,
-  onCaptions,
-  onDone
-}) => {
+export const processTransmux = (options) => {
+  const {
+    transmuxer,
+    bytes,
+    audioAppendStart,
+    gopsToAlignWith,
+    isPartial,
+    remux,
+    onData,
+    onTrackInfo,
+    onAudioTimingInfo,
+    onVideoTimingInfo,
+    onVideoSegmentTimingInfo,
+    onAudioSegmentTimingInfo,
+    onId3,
+    onCaptions,
+    onDone
+  } = options;
   const transmuxedData = {
     isPartial,
     buffer: []
   };
 
   const handleMessage = (event) => {
-    if (!currentTransmux) {
+    if (transmuxer.currentTransmux !== options) {
       // disposed
       return;
     }
@@ -134,7 +134,7 @@ export const processTransmux = ({
     });
 
     /* eslint-disable no-use-before-define */
-    dequeue();
+    dequeue(transmuxer);
     /* eslint-enable */
   };
 
@@ -187,30 +187,30 @@ export const processTransmux = ({
   transmuxer.postMessage({ action: isPartial ? 'partialFlush' : 'flush' });
 };
 
-export const dequeue = () => {
-  currentTransmux = null;
-  if (transmuxQueue.length) {
-    currentTransmux = transmuxQueue.shift();
-    if (typeof currentTransmux === 'function') {
-      currentTransmux();
+export const dequeue = (transmuxer) => {
+  transmuxer.currentTransmux = null;
+  if (transmuxer.transmuxQueue && transmuxer.transmuxQueue.length) {
+    transmuxer.currentTransmux = transmuxer.transmuxQueue.shift();
+    if (typeof transmuxer.currentTransmux === 'function') {
+      transmuxer.currentTransmux();
     } else {
-      processTransmux(currentTransmux);
+      processTransmux(transmuxer.currentTransmux);
     }
   }
 };
 
 export const processAction = (transmuxer, action) => {
   transmuxer.postMessage({ action });
-  dequeue();
+  dequeue(transmuxer);
 };
 
 export const enqueueAction = (action, transmuxer) => {
-  if (!currentTransmux) {
-    currentTransmux = action;
+  if (!transmuxer.currentTransmux) {
+    transmuxer.currentTransmux = action;
     processAction(transmuxer, action);
     return;
   }
-  transmuxQueue.push(processAction.bind(null, transmuxer, action));
+  transmuxer.transmuxQueue.push(processAction.bind(null, transmuxer, action));
 };
 
 export const reset = (transmuxer) => {
@@ -222,23 +222,35 @@ export const endTimeline = (transmuxer) => {
 };
 
 export const transmux = (options) => {
-  if (!currentTransmux) {
-    currentTransmux = options;
+  if (!options.transmuxer.currentTransmux) {
+    options.transmuxer.currentTransmux = options;
     processTransmux(options);
     return;
   }
-  transmuxQueue.push(options);
+  options.transmuxer.transmuxQueue.push(options);
 };
 
-export const dispose = () => {
-  // clear out module-level references
-  currentTransmux = null;
-  transmuxQueue.length = 0;
+export const createTransmuxer = (options) => {
+  const transmuxer = new TransmuxWorker();
+
+  transmuxer.currentTransmux = null;
+  transmuxer.transmuxQueue = [];
+  const term = transmuxer.terminate;
+
+  transmuxer.terminate = () => {
+    transmuxer.currentTransmux = null;
+    transmuxer.transmuxQueue.length = 0;
+    return term.call(transmuxer);
+  };
+
+  transmuxer.postMessage({action: 'init', options});
+
+  return transmuxer;
 };
 
 export default {
   reset,
-  dispose,
   endTimeline,
-  transmux
+  transmux,
+  createTransmuxer
 };

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -8,9 +8,8 @@ import {
   standardXHRResponse,
   downloadProgress
 } from './test-helpers';
-import TransmuxWorker from 'worker!../src/transmuxer-worker.js';
+import {createTransmuxer as createTransmuxer_} from '../src/segment-transmuxer.js';
 import Decrypter from 'worker!../src/decrypter-worker.js';
-import {dispose as segmentTransmuxerDispose} from '../src/segment-transmuxer.js';
 import {
   aacWithoutId3 as aacWithoutId3Segment,
   aacWithId3 as aacWithId3Segment,
@@ -71,18 +70,11 @@ const sharedHooks = {
     };
 
     this.createTransmuxer = (isPartial) => {
-      const transmuxer = new TransmuxWorker();
-
-      transmuxer.postMessage({
-        action: 'init',
-        options: {
-          remux: false,
-          keepOriginalTimestamps: true,
-          handlePartialData: isPartial
-        }
+      return createTransmuxer_({
+        remux: false,
+        keepOriginalTimestamps: true,
+        handlePartialData: isPartial
       });
-
-      return transmuxer;
     };
   },
   afterEach(assert) {
@@ -92,9 +84,6 @@ const sharedHooks = {
     if (this.transmuxer) {
       this.transmuxer.terminate();
     }
-
-    // clear current transmux on segment transmuxer
-    segmentTransmuxerDispose();
   }
 
 };

--- a/test/transmuxer-worker.test.js
+++ b/test/transmuxer-worker.test.js
@@ -1,5 +1,5 @@
 import QUnit from 'qunit';
-import TransmuxWorker from 'worker!../src/transmuxer-worker.js';
+import {createTransmuxer as createTransmuxer_} from '../src/segment-transmuxer.js';
 import {
   mp4Captions as mp4CaptionsSegment,
   muxed as muxedSegment,
@@ -10,18 +10,11 @@ import {
 import '../src/videojs-http-streaming';
 
 const createTransmuxer = (isPartial) => {
-  const transmuxer = new TransmuxWorker();
-
-  transmuxer.postMessage({
-    action: 'init',
-    options: {
-      remux: false,
-      keepOriginalTimestamps: true,
-      handlePartialData: isPartial
-    }
+  return createTransmuxer_({
+    remux: false,
+    keepOriginalTimestamps: true,
+    handlePartialData: isPartial
   });
-
-  return transmuxer;
 };
 
 // The final done message from the Transmux worker


### PR DESCRIPTION
## Problem
So this is somewhat of a bigger issue then I originally realized when I found an issue in tests for #1043 . The segmentTransmuxer stores a global cache of the currentTransmux and transmux queues. This causes a few issues:

1. Separate audio/video transmuxes will bottleneck on another
2. When running two or more videos on a page each video has a chance to bottleneck all the others with it's transmuxQueue and currentTransmux
3. Tests/dispose is flakey because mediaSegmentRequest sets currentTransmux/transmuxQueue but only segmentLoader disposes it.

## Changes
Store the transmuxQueue and currentTransmux on the transmuxer that is being used rather than keeping a global list.