### PR TITLE
chore: add ll-hls source and legacy avc source

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -339,5 +339,17 @@
     "uri": "https://d2zihajmogu5jn.cloudfront.net/ts-one-valid-many-invalid-codecs/master.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
+  },
+  {
+    "name": "Legacy AVC Codec",
+    "uri": "https://d2zihajmogu5jn.cloudfront.net/legacy-avc-codec/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
+  },
+  {
+    "name": "Apple LL-HLS test stream",
+    "uri": "https://ll-hls-test.apple.com/cmaf/master.m3u8",
+    "mimetype": "application/x-mpegurl",
+    "features": []
   }
 ]

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -345,11 +345,5 @@
     "uri": "https://d2zihajmogu5jn.cloudfront.net/legacy-avc-codec/master.m3u8",
     "mimetype": "application/x-mpegurl",
     "features": []
-  },
-  {
-    "name": "Apple LL-HLS test stream",
-    "uri": "https://ll-hls-test.apple.com/cmaf/master.m3u8",
-    "mimetype": "application/x-mpegurl",
-    "features": []
   }
 ]


### PR DESCRIPTION
Noticed we were missing a legacy avc source so I created one and added it. We also need to add the ll-hls stream for upcoming work so I added that as well.