### PR TITLE
feat: use EXT-X-PART for LL-HLS

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,10 @@
       Handle Partial (reloads player)
     </label>
     <label>
+      <input id=llhls type="checkbox">
+      [EXPERIMENTAL] Enables support for ll-hls (reloads player)
+    </label>
+    <label>
       <input id=buffer-water type="checkbox">
       [EXPERIMENTAL] Use Buffer Level for ABR (reloads player)
     </label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6162,9 +6162,9 @@
       }
     },
     "m3u8-parser": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.5.2.tgz",
-      "integrity": "sha512-sN/lu3TiRxmG2RFjZxo5c0/7Dr4RrEztl43jXrWwj5gFZ7vfa2iIxGfiPx485dm5QCazaIcKk+vNkUso8Aq0Ag==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.6.0.tgz",
+      "integrity": "sha512-dKhhpMcPqDM/KzULVrNyDZ/z766peQjwUghDTcl6TE7DQKAt/vm74/IMUAxpO34f6LDpM+OH/dYGQwW1eM4yWw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@videojs/vhs-utils": "^3.0.0",
     "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
-    "m3u8-parser": "4.5.2",
+    "m3u8-parser": "4.6.0",
     "mpd-parser": "0.15.4",
     "mux.js": "5.10.0",
     "video.js": "^6 || ^7"

--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -386,7 +386,7 @@
               overrideNative: getInputValue(stateEls['override-native']),
               handlePartialData: getInputValue(stateEls.partial),
               experimentalBufferBasedABR: getInputValue(stateEls['buffer-water']),
-              llhls: getInputValue(stateEls.llhls)
+              experimentalLLHLS: getInputValue(stateEls.llhls)
             }
           }
         });

--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -241,6 +241,7 @@
     'sync-workers',
     'liveui',
     'partial',
+    'llhls',
     'url',
     'type',
     'keysystems',
@@ -298,6 +299,13 @@
     stateEls.debug.addEventListener('change', function(event) {
       saveState();
       window.videojs.log.level(event.target.checked ? 'debug' : 'info');
+    });
+
+    stateEls.llhls.addEventListener('change', function(event) {
+      saveState();
+
+      // reload the player and scripts
+      stateEls.minified.dispatchEvent(newEvent('change'));
     });
 
     stateEls.partial.addEventListener('change', function(event) {
@@ -377,7 +385,8 @@
             vhs: {
               overrideNative: getInputValue(stateEls['override-native']),
               handlePartialData: getInputValue(stateEls.partial),
-              experimentalBufferBasedABR: getInputValue(stateEls['buffer-water'])
+              experimentalBufferBasedABR: getInputValue(stateEls['buffer-water']),
+              llhls: getInputValue(stateEls.llhls)
             }
           }
         });

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -26,7 +26,8 @@ export const parseManifest = ({
   oninfo,
   manifestString,
   customTagParsers = [],
-  customTagMappers = []
+  customTagMappers = [],
+  llhls
 }) => {
   const parser = new M3u8Parser();
 
@@ -43,7 +44,35 @@ export const parseManifest = ({
   parser.push(manifestString);
   parser.end();
 
-  return parser.manifest;
+  const manifest = parser.manifest;
+
+  // remove llhls features from the parsed manifest
+  if (!llhls) {
+    [
+      'preloadSegment',
+      'skip',
+      'serverControl',
+      'renditionReports',
+      'partInf',
+      'partTargetDuration'
+    ].forEach(function(k) {
+      if (manifest.hasOwnProperty(k)) {
+        delete manifest[k];
+      }
+    });
+
+    if (manifest.segments) {
+      manifest.segments.forEach(function(segment) {
+        ['parts', 'preloadHints'].forEach(function(k) {
+          if (segment.hasOwnProperty(k)) {
+            delete segment[k];
+          }
+        });
+      });
+    }
+  }
+
+  return manifest;
 };
 
 /**

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -12,12 +12,18 @@ export const createPlaylistID = (index, uri) => {
 /**
  * Parses a given m3u8 playlist
  *
+ * @param {Function} [onwarn]
+ *        a function to call when the parser triggers a warning event.
+ * @param {Function} [oninfo]
+ *        a function to call when the parser triggers an info event.
  * @param {string} manifestString
  *        The downloaded manifest string
  * @param {Object[]} [customTagParsers]
  *        An array of custom tag parsers for the m3u8-parser instance
  * @param {Object[]} [customTagMappers]
- *         An array of custom tag mappers for the m3u8-parser instance
+ *        An array of custom tag mappers for the m3u8-parser instance
+ * @param {boolean} [llhls=false]
+ *        Wether to keep ll-hls features in the manifest after parsing.
  * @return {Object}
  *         The manifest object
  */

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -22,7 +22,7 @@ export const createPlaylistID = (index, uri) => {
  *        An array of custom tag parsers for the m3u8-parser instance
  * @param {Object[]} [customTagMappers]
  *        An array of custom tag mappers for the m3u8-parser instance
- * @param {boolean} [llhls=false]
+ * @param {boolean} [experimentalLLHLS=false]
  *        Wether to keep ll-hls features in the manifest after parsing.
  * @return {Object}
  *         The manifest object
@@ -33,7 +33,7 @@ export const parseManifest = ({
   manifestString,
   customTagParsers = [],
   customTagMappers = [],
-  llhls
+  experimentalLLHLS
 }) => {
   const parser = new M3u8Parser();
 
@@ -53,7 +53,8 @@ export const parseManifest = ({
   const manifest = parser.manifest;
 
   // remove llhls features from the parsed manifest
-  if (!llhls) {
+  // if we don't want llhls support.
+  if (!experimentalLLHLS) {
     [
       'preloadSegment',
       'skip',

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -23,7 +23,7 @@ export const createPlaylistID = (index, uri) => {
  * @param {Object[]} [customTagMappers]
  *        An array of custom tag mappers for the m3u8-parser instance
  * @param {boolean} [experimentalLLHLS=false]
- *        Wether to keep ll-hls features in the manifest after parsing.
+ *        Whether to keep ll-hls features in the manifest after parsing.
  * @return {Object}
  *         The manifest object
  */

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -971,7 +971,7 @@ export const mediaSegmentRequest = ({
   }
 
   const segmentRequestOptions = videojs.mergeOptions(xhrOptions, {
-    uri: segment.resolvedUri,
+    uri: segment.part && segment.part.resolvedUri || segment.resolvedUri,
     responseType: 'arraybuffer',
     headers: segmentXhrHeaders(segment)
   });

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -77,7 +77,7 @@ export const resolveSegmentUris = (segment, baseUri) => {
       if (p.resolvedUri) {
         return;
       }
-      p.resolvedUri = resolveUrl(baseUri, p.URI);
+      p.resolvedUri = resolveUrl(baseUri, p.uri);
     });
   }
 
@@ -86,7 +86,7 @@ export const resolveSegmentUris = (segment, baseUri) => {
       if (p.resolvedUri) {
         return;
       }
-      p.resolvedUri = resolveUrl(baseUri, p.URI);
+      p.resolvedUri = resolveUrl(baseUri, p.uri);
     });
   }
 };

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -51,11 +51,11 @@ export const updateSegments = (original, update, offset) => {
     }
 
     // part merging happens above. If the new playlist has no parts for
-    // a segment, they are no longer valid for requsting
+    // a segment, they are no longer valid for requesting
     if (oldSegments[i] && oldSegments[i].parts) {
       delete oldSegments[i].parts;
     }
-    result[newIndex] = mergeOptions(original[i], result[i - offset]);
+    result[newIndex] = mergeOptions(original[i], result[newIndex]);
   }
   return result;
 };

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -207,7 +207,7 @@ export default class PlaylistLoader extends EventTarget {
 
     this.customTagParsers = (vhsOptions && vhsOptions.customTagParsers) || [];
     this.customTagMappers = (vhsOptions && vhsOptions.customTagMappers) || [];
-    this.llhls = (vhsOptions && vhsOptions.llhls) || false;
+    this.experimentalLLHLS = (vhsOptions && vhsOptions.experimentalLLHLS) || false;
 
     // initialize the loader state
     this.state = 'HAVE_NOTHING';
@@ -290,7 +290,7 @@ export default class PlaylistLoader extends EventTarget {
       manifestString: playlistString,
       customTagParsers: this.customTagParsers,
       customTagMappers: this.customTagMappers,
-      llhls: this.llhls
+      experimentalLLHLS: this.experimentalLLHLS
     });
 
     playlist.lastRequest = Date.now();

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -28,6 +28,10 @@ const { mergeOptions, EventTarget } = videojs;
  * @return {Object} the merged segment
  */
 export const updateSegment = (a, b) => {
+  if (!a) {
+    return b;
+  }
+
   const result = mergeOptions(a, b);
 
   // only the old segment has parts

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -34,7 +34,7 @@ export const updateSegment = (a, b) => {
 
   const result = mergeOptions(a, b);
 
-  // only the old segment has parts
+  // if only the old segment has parts
   // then the parts are no longer valid
   if (a.parts && !b.parts) {
     delete result.parts;
@@ -55,7 +55,7 @@ export const updateSegment = (a, b) => {
 /**
  * Returns a new array of segments that is the result of merging
  * properties from an older list of segments onto an updated
- * list. No properties on the updated playlist will be overridden.
+ * list. No properties on the updated playlist will be ovewritten.
  *
  * @param {Array} original the outdated list of segments
  * @param {Array} update the updated list of segments

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -977,7 +977,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (this.mediaIndex !== null) {
       this.mediaIndex -= mediaSequenceDiff;
 
-      // mediaIndex is invalid, set it to null
+      // this can happen if we are going to load the first segment, but get a playlist
+      // update during that. mediaIndex would go from 0 to -1 if mediaSequence in the
+      // new playlist was incremented by 1.
       if (this.mediaIndex < 0) {
         this.mediaIndex = null;
         this.partIndex = null;
@@ -1342,13 +1344,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Under normal playback conditions fetching is a simple walk forward
       const segment = playlist.segments[currentMediaIndex];
 
-      if (segment && segment.end) {
-        startOfSegment = segment.end;
-      } else {
-        startOfSegment = lastBufferedEnd;
-      }
+      startOfSegment = segment.end ? segment.end : lastBufferedEnd;
 
-      if (!segment || !segment.parts || !segment.parts.length || !segment.parts[nextPartIndex]) {
+      if (!segment.parts || !segment.parts.length || !segment.parts[nextPartIndex]) {
         nextMediaIndex = currentMediaIndex + 1;
         nextPartIndex = 0;
       } else {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -990,8 +990,12 @@ export default class SegmentLoader extends videojs.EventTarget {
         // unless parts fell off of the playlist for this segment.
         // In that case we need to reset partIndex and resync
         if (this.partIndex && (!segment.parts || !segment.parts.length || !segment.parts[this.partIndex])) {
+          const mediaIndex = this.mediaIndex;
+
           this.logger_(`currently processing part (index ${this.partIndex}) no longer exists.`);
           this.resetLoader();
+
+          this.mediaIndex = mediaIndex;
         }
       }
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1002,15 +1002,20 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (segmentInfo) {
       segmentInfo.mediaIndex -= mediaSequenceDiff;
 
-      // we need to update the referenced segment so that timing information is
-      // saved for the new playlist's segment, however, if the segment fell off the
-      // playlist, we can leave the old reference and just lose the timing info
-      if (segmentInfo.mediaIndex >= 0) {
-        segmentInfo.segment = newPlaylist.segments[segmentInfo.mediaIndex];
-      }
+      if (segmentInfo.mediaIndex < 0) {
+        segmentInfo.mediaIndex = null;
+        segmentInfo.partIndex = null;
+      } else {
+        // we need to update the referenced segment so that timing information is
+        // saved for the new playlist's segment, however, if the segment fell off the
+        // playlist, we can leave the old reference and just lose the timing info
+        if (segmentInfo.mediaIndex >= 0) {
+          segmentInfo.segment = newPlaylist.segments[segmentInfo.mediaIndex];
+        }
 
-      if (segmentInfo.partIndex >= 0 && segmentInfo.segment.parts) {
-        segmentInfo.part = segmentInfo.segment.parts[segmentInfo.partIndex];
+        if (segmentInfo.partIndex >= 0 && segmentInfo.segment.parts) {
+          segmentInfo.part = segmentInfo.segment.parts[segmentInfo.partIndex];
+        }
       }
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -988,7 +988,7 @@ export default class SegmentLoader extends videojs.EventTarget {
         // unless parts fell off of the playlist for this segment.
         // In that case we need to reset partIndex and resync
         if (this.partIndex && (!segment.parts || !segment.parts.length || !segment.parts[this.partIndex])) {
-          this.logger_(`part fell off on part ${this.partIndex}`);
+          this.logger_(`currently processing part (index ${this.partIndex}) no longer exists.`);
           this.resetLoader();
         }
       }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -995,6 +995,9 @@ export default class SegmentLoader extends videojs.EventTarget {
           this.logger_(`currently processing part (index ${this.partIndex}) no longer exists.`);
           this.resetLoader();
 
+          // We want to throw away the partIndex and the data associated with it,
+          // as the part was dropped from our current playlists segment.
+          // The mediaIndex will still be valid so keep that around.
           this.mediaIndex = mediaIndex;
         }
       }

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -665,7 +665,8 @@ class VhsHandler extends Component {
       'playlistSelector',
       'initialPlaylistSelector',
       'experimentalBufferBasedABR',
-      'liveRangeSafeTimeDelta'
+      'liveRangeSafeTimeDelta',
+      'llhls'
     ].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -666,7 +666,7 @@ class VhsHandler extends Component {
       'initialPlaylistSelector',
       'experimentalBufferBasedABR',
       'liveRangeSafeTimeDelta',
-      'llhls'
+      'experimentalLLHLS'
     ].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -873,6 +873,7 @@ export const LoaderCommonFactory = ({
       });
 
       QUnit.test('drops partIndex if playlist update drops parts', function(assert) {
+        assert.timeout(100000000000000000000);
         return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           loader.playlist(playlistWithDuration(50, {
             mediaSequence: 0,

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -802,6 +802,151 @@ export const LoaderCommonFactory = ({
       });
     });
 
+    // only main/fmp4 segment loaders use parts/partIndex
+    if (usesAsyncAppends) {
+      QUnit.test('mediaIndex and partIndex are used', function(assert) {
+        const appendPart = (segmentIndex, partIndex) => {
+          this.clock.tick(1);
+
+          assert.equal(
+            this.requests[0].url,
+            `segment${segmentIndex}.part${partIndex}.ts`,
+            `requested mediaIndex #${segmentIndex} partIndex #${partIndex}`
+          );
+          standardXHRResponse(this.requests.shift(), testData());
+
+          if (usesAsyncAppends) {
+            return new Promise((resolve, reject) => {
+              loader.one('appended', resolve);
+              loader.one('error', reject);
+            });
+          }
+
+          return Promise.resolve();
+        };
+
+        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+          loader.playlist(playlistWithDuration(50, {
+            mediaSequence: 0,
+            endList: false,
+            llhls: true
+          }));
+
+          loader.load();
+          loader.mediaIndex = 2;
+          return Promise.resolve();
+        }).then(() => appendPart(2, 0))
+          .then(() => appendPart(2, 1))
+          .then(() => appendPart(2, 2))
+          .then(() => appendPart(2, 3))
+          .then(() => appendPart(2, 4))
+          .then(() => appendPart(3, 0));
+      });
+
+      QUnit.test('mediaIndex and partIndex survive playlist change', function(assert) {
+        const appendPart = (segmentIndex, partIndex) => {
+          this.clock.tick(1);
+
+          assert.equal(
+            this.requests[0].url,
+            `segment${segmentIndex}.part${partIndex}.ts`,
+            `requested mediaIndex #${segmentIndex} partIndex #${partIndex}`
+          );
+          standardXHRResponse(this.requests.shift(), testData());
+
+          if (usesAsyncAppends) {
+            return new Promise((resolve, reject) => {
+              loader.one('appended', resolve);
+              loader.one('error', reject);
+            });
+          }
+
+          return Promise.resolve();
+        };
+
+        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+          loader.playlist(playlistWithDuration(50, {
+            mediaSequence: 0,
+            endList: false,
+            llhls: true
+          }));
+
+          loader.load();
+          loader.mediaIndex = 4;
+          return Promise.resolve();
+        }).then(() => appendPart(4, 0))
+          .then(() => appendPart(4, 1))
+          .then(() => appendPart(4, 2))
+          .then(() => {
+
+            // Update the playlist shifting the mediaSequence by 2 which will result
+            // in a decrement of the mediaIndex by 2 to 1
+            loader.playlist(playlistWithDuration(50, {
+              mediaSequence: 2,
+              endList: false,
+              llhls: true
+            }));
+            // verify that we still try to append the next part for that segment.
+            return appendPart(2, 3);
+          }).then(() => appendPart(2, 4));
+      });
+
+      QUnit.test('drops partIndex if playlist update drops parts', function(assert) {
+        const appendPart = (segmentIndex, partIndex) => {
+          this.clock.tick(1);
+
+          assert.equal(
+            this.requests[0].url,
+            `segment${segmentIndex}.part${partIndex}.ts`,
+            `requested mediaIndex #${segmentIndex} partIndex #${partIndex}`
+          );
+          standardXHRResponse(this.requests.shift(), testData());
+
+          if (usesAsyncAppends) {
+            return new Promise((resolve, reject) => {
+              loader.one('appended', resolve);
+              loader.one('error', reject);
+            });
+          }
+
+          return Promise.resolve();
+        };
+
+        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+          loader.playlist(playlistWithDuration(50, {
+            mediaSequence: 0,
+            endList: false,
+            llhls: true
+          }));
+
+          loader.load();
+          loader.mediaIndex = 4;
+          return Promise.resolve();
+        }).then(() => appendPart(4, 0))
+          .then(() => appendPart(4, 1))
+          .then(() => appendPart(4, 2))
+          .then(() => {
+
+            // Update the playlist shifting the mediaSequence by 2 which will result
+            // in a decrement of the mediaIndex by 2 to 1
+            loader.playlist(playlistWithDuration(50, {
+              mediaSequence: 4,
+              endList: false,
+              llhls: true
+            }));
+
+            assert.equal(loader.partIndex, null, 'partIndex was dropped');
+            this.clock.tick(1);
+
+            assert.equal(
+              this.requests[0].url,
+              '1.ts',
+              'requested mediaIndex 1 only'
+            );
+          });
+      });
+    }
+
     QUnit.test('segment 404s should trigger an error', function(assert) {
       const errors = [];
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1003,6 +1003,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         this.clock.tick(1);
 
         assert.equal(loader.mediaIndex, null, 'mediaIndex reset by seek to seekable');
+        assert.equal(loader.partIndex, null, 'partIndex reset by seek to seekable');
         assert.equal(syncInfoUpdates, 1, 'syncinfoupdate was triggered');
       });
     });

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -478,7 +478,7 @@ export const playlistWithDuration = function(time, conf) {
     if (conf && conf.llhls && (count - i) <= 3) {
       segment.parts = [];
       const partRemainder = segment.duration % result.partTargetDuration;
-      const partCount = Math.floor(segment.duration / result.targetDuration) + (partRemainder ? 1 : 0);
+      const partCount = Math.floor(segment.duration / result.partTargetDuration) + (partRemainder ? 1 : 0);
 
       for (let z = 0; z < partCount; z++) {
         const uri = `segment${i}.part${z}${extension}`;


### PR DESCRIPTION
## Description
Implements support for EXT-X-PART and EXT-X-PRELOAD-HINT
Requires https://github.com/videojs/m3u8-parser/pull/137

## Future pull requests
* ~~Use `#EXT-X-PART-INF`, query parameters for delta updates, `#EXT-X-SERVER-CONTROL`, and `#EXT-X-SKIP`~~ #1079 
* ~~Use `#EXT-X-PRELOAD-HINT` aka `preloadSegment` on the manifest~~ #1078 

## Investigation
* How would we use `#EXT-X-RENDITION-REPORT` when switching renditions? Is it only relevant in the context of delta updates?