### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ consistent experience.
 // via the constructor
 var player = videojs('playerId', {
   html5: {
-    vhs: {
+    hls: {
       overrideNative: true
     },
     nativeAudioTracks: false,


### PR DESCRIPTION
## Description

Fix code snippet
`vhs` did nothing. I tested with `hls` and its overriding on android correctly now.

Correct snippet taken from https://github.com/videojs/video.js/issues/6087#issuecomment-508797919