### PR TITLE
feat: Allow xhr override globally

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -74,7 +74,9 @@ const xhrFactory = function() {
       }
     }
 
-    const request = videojsXHR(options, function(error, response) {
+    const xhrMethod = videojs.Vhs.xhr.name !== 'XhrFunction' ? videojs.Vhs.xhr : videojsXHR;
+
+    const request = xhrMethod(options, function(error, response) {
       return callbackWrapper(request, error, response, callback);
     });
     const originalAbort = request.abort;

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -75,6 +75,7 @@ const xhrFactory = function() {
     }
 
     // Use the standard videojs.xhr() method unless `videojs.Vhs.xhr` has been overriden
+    // TODO: switch back to videojs.Vhs.xhr.name === 'XhrFunction' when we drop IE11
     const xhrMethod = videojs.Vhs.xhr.original === true ? videojsXHR : videojs.Vhs.xhr;
 
     const request = xhrMethod(options, function(error, response) {

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -74,7 +74,8 @@ const xhrFactory = function() {
       }
     }
 
-    const xhrMethod = videojs.Vhs.xhr.name !== 'XhrFunction' ? videojs.Vhs.xhr : videojsXHR;
+    // Use the standard videojs.xhr() method unless `videojs.Vhs.xhr` has been overriden
+    const xhrMethod = videojs.Vhs.xhr.original === true ? videojsXHR : videojs.Vhs.xhr;
 
     const request = xhrMethod(options, function(error, response) {
       return callbackWrapper(request, error, response, callback);
@@ -89,6 +90,8 @@ const xhrFactory = function() {
     request.requestTime = Date.now();
     return request;
   };
+
+  xhr.original = true;
 
   return xhr;
 };

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4267,6 +4267,36 @@ QUnit.test('Allows specifying the beforeRequest function globally', function(ass
   assert.equal(this.player.tech_.vhs.stats.bandwidth, 4194304, 'default');
 });
 
+QUnit.test('Allows specifying custom xhr() function globally', function(assert) {
+  const originalXhr = videojs.Vhs.xhr;
+  let customXhr = false;
+
+  videojs.Vhs.xhr = function(opts, callback) {
+    customXhr = true;
+    return videojs.xhr(opts, function(err, response, body) {
+      callback(err, response);
+    });
+  };
+
+  this.player.src({
+    src: 'master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  // master
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.ok(customXhr, 'customXhr was called');
+
+  videojs.Vhs.xhr = originalXhr;
+
+  // verify stats
+  assert.equal(this.player.tech_.vhs.stats.bandwidth, 4194304, 'default');
+});
+
 QUnit.test('Allows overriding the global beforeRequest function', function(assert) {
   let beforeGlobalRequestCalled = 0;
   let beforeLocalRequestCalled = 0;


### PR DESCRIPTION
## Description
It is not currently possible to override or add any custom XHR logic at initialization, since the `xhr()` method is not exposed on the tech until the source is set ([see](https://github.com/videojs/http-streaming/blob/main/src/videojs-http-streaming.js#L1153)) and uses a reference to the [original `videojs.xhr()`](https://github.com/videojs/http-streaming/blob/main/src/xhr.js#L77).

Although it is unadvisable in most cases (as mentioned in the docs), it is still useful to have the ability to do it, and the existing `beforeRequest()` hook is insufficient in many cases.

## Specific Changes proposed
- Substitute a custom `videojs.Vhs.xhr` function for `videojsXHR`, if it is provided
- This PR does not add any documentation, as I wasn't sure if it is something we want to document
