### PR TITLE
fix: allow buffer removes when there's no current media info in loader

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -750,6 +750,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
    */
   fastQualityChange_(media = this.selectPlaylist()) {
     if (media === this.masterPlaylistLoader_.media()) {
+      this.logger_('skipping fastQualityChange because new media is same as old');
       return;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1096,7 +1096,8 @@ export default class SegmentLoader extends videojs.EventTarget {
       end = this.duration_();
     }
 
-    if (!this.sourceUpdater_ || !this.currentMediaInfo_) {
+    if (!this.sourceUpdater_ || !this.startingMediaInfo_) {
+      this.logger_('skipping remove because no source updater or starting media info');
       // nothing to remove if we haven't processed any media
       return;
     }
@@ -1115,7 +1116,15 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.sourceUpdater_.removeAudio(start, end, removeFinished);
     }
 
-    if (this.loaderType_ === 'main' && this.currentMediaInfo_ && this.currentMediaInfo_.hasVideo) {
+    // While it would be better to only remove video if the main loader has video, this
+    // should be safe with audio only as removeVideo will call back even if there's no
+    // video buffer.
+    //
+    // In theory we can check to see if there's video before calling the remove, but in
+    // the event that we're switching between renditions and from video to audio only
+    // (when we add support for that), we may need to clear the video contents despite
+    // what the new media will contain.
+    if (this.loaderType_ === 'main') {
       this.gopBuffer_ = removeGopBuffer(this.gopBuffer_, start, end, this.timeMapping_);
       removesRemaining++;
       this.sourceUpdater_.removeVideo(start, end, removeFinished);

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -534,7 +534,7 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
     origRemove.call(segmentLoader, start, end);
   };
 
-  segmentLoader.currentMediaInfo_ = { hasVideo: true };
+  segmentLoader.startingMediaInfo_ = { hasVideo: true };
   segmentLoader.audioDisabled_ = true;
 
   segmentLoader.sourceUpdater_.removeVideo = function(start, end) {


### PR DESCRIPTION
Previously, if there wasn't any current media info in the loader, then a
remove of buffered contents would not be processed. This would
intuitively make sense, as if there wasn't current media info, then in
theory there shouldn't be any buffered contents. However, it is possible
for there to be buffered contents without current media info in the event
of a non destructive rendition switch. This was noticed when switching
renditions, expecting a fast quality change to clear the contents and
continue playback at a new rendition. Sometimes the remove wouldn't
happen, so the content would continue to play back the old buffered
content from a different rendition. This fix instead allows the removes
so long as there is starting media info (which is available after first
segment download).

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
