### PR TITLE
chore: mirror player.src on the demo page demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
     </label>
     <label>
       <input id=mirror-source type="checkbox" checked>
-      Mirror sources from player.src (reloads player)
+      Mirror sources from player.src (reloads player, uses EXPERIMENTAL sourceset option)
     </label>
     <label>
       Preload (reloads player)

--- a/index.html
+++ b/index.html
@@ -89,6 +89,10 @@
       Override Native (reloads player)
     </label>
     <label>
+      <input id=mirror-source type="checkbox" checked>
+      Mirror sources from player.src (reloads player)
+    </label>
+    <label>
       Preload (reloads player)
       <select id=preload>
         <option selected>auto</option>


### PR DESCRIPTION
## Description
Uses sourceset to mirror the source that was set via `player.src` in the ui so that it will be saved on page reload!
