### PR TITLE
fix: sometimes subtitlesTrack_.cues is null

### DIFF
--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -54,7 +54,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
    *         TimeRange object representing the current buffered ranges
    */
   buffered_() {
-    if (!this.subtitlesTrack_ || !this.subtitlesTrack_.cues.length) {
+    if (!this.subtitlesTrack_ || !this.subtitlesTrack_.cues || !this.subtitlesTrack_.cues.length) {
       return videojs.createTimeRanges();
     }
 


### PR DESCRIPTION
fix: sometimes subtitlesTrack_.cues is null

## Description
![image](https://user-images.githubusercontent.com/18487241/108166517-a593d100-7137-11eb-82f3-7aeb0d45f80f.png)
![image](https://user-images.githubusercontent.com/18487241/108166668-d96ef680-7137-11eb-9361-1001aa54a15a.png)

sometimes subtitlesTrack_.cues is null

## Specific Changes proposed

I added null check code.

## Requirements Checklist
- [v] Feature implemented / Bug fixed

- [ ] Reviewed by Two Core Contributors
