### PR TITLE
Skip over playback gaps that occur in the beginning of streams

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -133,6 +133,7 @@ export default class PlaybackWatcher {
       this.tech_.off('waiting', waitingHandler);
       this.tech_.off(timerCancelEvents, cancelTimerHandler);
       this.tech_.off('canplay', canPlayHandler);
+      this.tech_.off('play', playHandler);
 
       loaderTypes.forEach((type) => {
         mpc[`${type}SegmentLoader_`].off('appendsdone', loaderChecks[type].updateend);

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -81,11 +81,12 @@ QUnit.test('skips over gap at beginning of stream if played before content is bu
   // check that player jumped the gap
   assert.equal(
     Math.round(this.player.currentTime()),
-    2, 'Player seeked over gap after timer'
+    2,
+    'Player seeked over gap after timer'
   );
 });
 
-QUnit.test('Multiple play events do not cause the gap-skipping logic to be called sooner than expected', function(assert) {
+QUnit.test('multiple play events do not cause the gap-skipping logic to be called sooner than expected', function(assert) {
   let vhsGapSkipEvents = 0;
   let hlsGapSkipEvents = 0;
 
@@ -129,7 +130,8 @@ QUnit.test('Multiple play events do not cause the gap-skipping logic to be calle
   // check that player did not skip the gap
   assert.equal(
     Math.round(this.player.currentTime()),
-    0, 'Player seeked over gap after timer'
+    0,
+    'Player did not seek over gap'
   );
 });
 
@@ -1203,7 +1205,7 @@ QUnit.module('PlaybackWatcher isolated functions', {
         on: () => {},
         off: () => {},
         one: () => {},
-        paused: () => true,
+        paused: () => false,
         // needed to construct a playback watcher
         options_: {
           playerId: 'mock-player-id'

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -1202,6 +1202,8 @@ QUnit.module('PlaybackWatcher isolated functions', {
       tech: {
         on: () => {},
         off: () => {},
+        one: () => {},
+        paused: () => true,
         // needed to construct a playback watcher
         options_: {
           playerId: 'mock-player-id'


### PR DESCRIPTION
## Description
Fixes #1084 . There is an edge case that is exposed when a gap exists at the beginning of the stream and no content is buffered by the time the first `waiting` event has emitted. This leaves the player in a state where it's no longer checking for playback stalls (or gaps).

## Specific Changes proposed
As mentioned in the linked issue, we have decided to proceed by checking for stalls when the first `play` event is emitted.

## Requirements Checklist
- [ x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
