### PR TITLE
Monitor playback for stalls due to gaps in the beginning of stream when a new source is loaded

### DIFF
--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -72,7 +72,7 @@ QUnit.test('skips over gap at beginning of stream if played before content is bu
   this.player.tech_.trigger('waiting');
   // create a buffer with a gap of 2 seconds at beginning of stream
   this.player.tech_.buffered = () => videojs.createTimeRanges([[2, 10]]);
-  // Playback watcher loop runs on a 250ms clock and needs run 6 consecutive stall checks before skipping the gap
+  // Playback watcher loop runs on a 250ms clock and needs 6 consecutive stall checks before skipping the gap
   this.clock.tick(250 * 6);
   // Need to wait for the duration of the gap
   this.clock.tick(2000);
@@ -113,7 +113,7 @@ QUnit.test('multiple play events do not cause the gap-skipping logic to be calle
   openMediaSource(this.player, this.clock);
   // create a buffer with a gap of 2 seconds at beginning of stream
   this.player.tech_.buffered = () => videojs.createTimeRanges([[2, 10]]);
-  // Playback watcher loop runs on a 250ms clock and needs run 6 consecutive stall checks before skipping the gap
+  // Playback watcher loop runs on a 250ms clock and needs 6 consecutive stall checks before skipping the gap
   // Start with 5 consecutive playback checks
   this.clock.tick(250 * 5);
   // and then simulate the playback monitor being called 'manually' by a new play event
@@ -185,7 +185,7 @@ QUnit.test('changing sources does not break ability to skip gap at beginning of 
   this.player.tech_.trigger('waiting');
   // create a buffer with a gap of 2 seconds at beginning of stream
   this.player.tech_.buffered = () => videojs.createTimeRanges([[2, 10]]);
-  // Playback watcher loop runs on a 250ms clock and needs run 6 consecutive stall checks before skipping the gap
+  // Playback watcher loop runs on a 250ms clock and needs 6 consecutive stall checks before skipping the gap
   this.clock.tick(250 * 6);
   // Need to wait for the duration of the gap
   this.clock.tick(2000);
@@ -212,7 +212,7 @@ QUnit.test('changing sources does not break ability to skip gap at beginning of 
   openMediaSource(this.player, this.clock);
   this.clock.tick(1);
 
-  // Playback watcher loop runs on a 250ms clock and needs run 6 consecutive stall checks before skipping the gap
+  // Playback watcher loop runs on a 250ms clock and needs 6 consecutive stall checks before skipping the gap
   this.clock.tick(250 * 6);
   // Need to wait for the duration of the gap
   this.clock.tick(2000);


### PR DESCRIPTION
## Description
This is a follow-up fix for #[1084](https://github.com/videojs/http-streaming/issues/1084). @gesinger noticed an additional edge that's exposed when a new source is loaded via `player.src()` while the player was playing. This led to our `play` event handler not being called since it was wrapped by a check to ensure the player was in a paused state.

Additionally, I cleaned up a couple of tests by relying on Player API instead of firing HTML5Media events. This ensures the test more closely follows playback behavior in a production environment.

## Specific Changes proposed
Removed the condition around the play event listener in PlaybackWatcher. Since we're using `one` and not `on`, I expect this change to be safe and not cause gaps to be skipped at irregular intervals (a test was also added in my last change to ensure this is true).

Feel free to demo [here](http://localhost:9999/?debug=false&autoplay=true&muted=false&minified=false&sync-workers=false&liveui=false&partial=false&url=https%3A%2F%2Flivectorprodmedia12-usea.licdn.com%2F0c13be2a-1820-4837-8318-29b9e6187219%2FL4D5ded7c97c980f000-livemanifest.ism%2Fmanifest(format%3Dm3u8-aapl)&type=application%2Fx-mpegurl&keysystems=&buffer-water=false&override-native=true&preload=auto&mirror-source=true). Make sure the "AutoPlay" setting is checked. Allow the source to play and then enter the same source in the demo’s “load a URL” input and click “load”. Notice the source does not skip the gap and does not start.

## Requirements Checklist
- [x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
