### PR TITLE
fix: support automatic configuration of audio and video only DRM sources

### DIFF
--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -59,8 +59,8 @@ not meant serve as an exhaustive list.
 * Any browser supported resolution (e.g., 4k)
 * Any browser supported framerate (e.g., 60fps)
 * [DRM] via [videojs-contrib-eme]
-* Audio only (non DRM)
-* Video only (non DRM)
+* Audio only (non DASH)
+* Video only (non DASH)
 * In-manifest [WebVTT] subtitles are automatically translated into standard HTML5 subtitle
   tracks
 * [AES-128] segment encryption
@@ -94,10 +94,6 @@ supported when packaged within [TS].
 * [Dolby Vision] (DVHE)
 * [Dolby Digital] Audio (AC-3)
 * [Dolby Digital Plus] (E-AC-3)
-
-### General Missing Features
-
-* Audio/video only DRM streams
 
 ### HLS Missing Features
 
@@ -141,6 +137,7 @@ features in the DASH specification that are not yet implemented in VHS:
 Note that many of the following are parsed by [mpd-parser] but are either not yet used, or
 simply take on their default values (in the case where they have valid defaults).
 
+* Audio and video only streams
 * Audio rendition switching
   * Each video rendition is paired with an audio rendition for the duration of playback.
 * MPD

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -5853,6 +5853,61 @@ QUnit.test('emeKeySystems adds content types for all keySystems', function(asser
   );
 });
 
+QUnit.test('emeKeySystems supports audio only', function(assert) {
+  assert.deepEqual(
+    emeKeySystems(
+      { keySystem1: {}, keySystem2: {} },
+      { attributes: { CODECS: 'mp4a.40.2c' } },
+    ),
+    {
+      keySystem1: {
+        audioContentType: 'audio/mp4;codecs="mp4a.40.2c"'
+      },
+      keySystem2: {
+        audioContentType: 'audio/mp4;codecs="mp4a.40.2c"'
+      }
+    },
+    'added content type'
+  );
+});
+
+QUnit.test('emeKeySystems supports external audio only', function(assert) {
+  assert.deepEqual(
+    emeKeySystems(
+      { keySystem1: {}, keySystem2: {} },
+      { attributes: {} },
+      { attributes: { CODECS: 'mp4a.40.2c' } },
+    ),
+    {
+      keySystem1: {
+        audioContentType: 'audio/mp4;codecs="mp4a.40.2c"'
+      },
+      keySystem2: {
+        audioContentType: 'audio/mp4;codecs="mp4a.40.2c"'
+      }
+    },
+    'added content type'
+  );
+});
+
+QUnit.test('emeKeySystems supports video only', function(assert) {
+  assert.deepEqual(
+    emeKeySystems(
+      { keySystem1: {}, keySystem2: {} },
+      { attributes: { CODECS: 'avc1.420015' } },
+    ),
+    {
+      keySystem1: {
+        videoContentType: 'video/mp4;codecs="avc1.420015"'
+      },
+      keySystem2: {
+        videoContentType: 'video/mp4;codecs="avc1.420015"'
+      }
+    },
+    'added content type'
+  );
+});
+
 QUnit.test('emeKeySystems retains non content type properties', function(assert) {
   assert.deepEqual(
     emeKeySystems(


### PR DESCRIPTION
## Description
To test, [encrypted video creator](https://github.com/gesinger/encrypted-video-creator) can be used to create three streams with the following options:

```bash
$ npm run start -- --source [some video].mp4 --destination [some video]-audio-and-video-widevine --key-system widevine
$ npm run start -- --source [some video].mp4 --audio-only --destination [some video]-audio-only-widevine --key-system widevine
$ npm run start -- --source [some video].mp4 --video-only --destination [some video]-video-only-widevine --key-system widevine
```

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
