### PR TITLE
fix: Only add sidxMapping on successful sidx request and parse.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6445,20 +6445,20 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.15.4.tgz",
-      "integrity": "sha512-YcOclxKc5gnT87UQYwRoPJpWOFvQORwN+bXYmTWCJ4U2pCSS7jjtPrIhoOLHFAyekj48CHTX4hjGBV/VSNsUsg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.16.0.tgz",
+      "integrity": "sha512-/pOFsDbOxXFAla47rYMdIypBZVtsQ9q3OHNuKtW2CJMaCGtNDtUcLS+B2TToYmB20rgi3XIgkyc2EsIvIAS4NA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.0",
         "global": "^4.4.0",
-        "xmldom": "^0.4.0"
+        "xmldom": "^0.5.0"
       },
       "dependencies": {
         "xmldom": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-          "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+          "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
     "m3u8-parser": "4.5.2",
-    "mpd-parser": "0.15.4",
+    "mpd-parser": "0.16.0",
     "mux.js": "5.10.0",
     "video.js": "^6 || ^7"
   },

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -354,7 +354,6 @@ export default class DashPlaylistLoader extends EventTarget {
         // sidx parsing failed.
         this.requestErrored_(e, request, startingState);
         return;
-
       }
 
       sidxMapping[sidxKey] = {

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -2,6 +2,7 @@ import videojs from 'video.js';
 import {
   parse as parseMpd,
   addSidxSegmentsToPlaylist,
+  generateSidxKey,
   parseUTCTiming
 } from 'mpd-parser';
 import {
@@ -110,18 +111,6 @@ export const parseMasterXml = ({ masterXml, srcUrl, clientOffset, sidxMapping })
   addPropertiesToMaster(master, srcUrl);
 
   return master;
-};
-
-export const generateSidxKey = (sidxInfo) => {
-  // should be non-inclusive
-  const sidxByteRangeEnd =
-    sidxInfo.byterange.offset +
-    sidxInfo.byterange.length -
-    1;
-
-  return sidxInfo.uri + '-' +
-    sidxInfo.byterange.offset + '-' +
-    sidxByteRangeEnd;
 };
 
 /**
@@ -358,6 +347,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
     const fin = (err, request) => {
       if (this.requestErrored_(err, request, startingState)) {
+        delete sidxMapping[sidxKey];
         return;
       }
 

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -3,12 +3,12 @@ import sinon from 'sinon';
 import {
   default as DashPlaylistLoader,
   updateMaster,
-  generateSidxKey,
   compareSidxEntry,
   filterChangedSidxMappings,
   parseMasterXml
 } from '../src/dash-playlist-loader';
 import xhrFactory from '../src/xhr';
+import {generateSidxKey} from 'mpd-parser';
 import {
   useFakeEnvironment,
   standardXHRResponse,
@@ -382,22 +382,6 @@ QUnit.test('updateMaster: updates minimumUpdatePeriod', function(assert) {
       duration: 0,
       minimumUpdatePeriod: 2
     }
-  );
-});
-
-QUnit.test('generateSidxKey: generates correct key', function(assert) {
-  const sidxInfo = {
-    byterange: {
-      offset: 1,
-      length: 5
-    },
-    uri: 'uri'
-  };
-
-  assert.strictEqual(
-    generateSidxKey(sidxInfo),
-    'uri-1-5',
-    'the key byterange should have a inclusive end'
   );
 });
 

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -452,15 +452,24 @@ QUnit.test('filterChangedSidxMappings: removes change sidx info from mapping', f
   const loader = new DashPlaylistLoader('dash-sidx.mpd', this.fakeVhs);
 
   loader.load();
+  // master
   this.standardXHRResponse(this.requests.shift());
-  this.standardXHRResponse(this.requests.shift());
+
+  // container request
+  this.standardXHRResponse(this.requests.shift(), mp4VideoInitSegment().subarray(0, 10));
+  // sidx byterange request
+  this.standardXHRResponse(this.requests.shift(), sidxResponse());
   const childPlaylist = loader.master.mediaGroups.AUDIO.audio.en.playlists[0];
 
   const childLoader = new DashPlaylistLoader(childPlaylist, this.fakeVhs, false, loader);
 
   childLoader.load();
   this.clock.tick(1);
-  this.standardXHRResponse(this.requests.shift());
+
+  // audio playlist container request
+  this.standardXHRResponse(this.requests.shift(), mp4VideoInitSegment().subarray(0, 10));
+  // audio sidx byterange request
+  this.standardXHRResponse(this.requests.shift(), sidxResponse());
 
   const oldSidxMapping = loader.sidxMapping_;
   let newSidxMapping = filterChangedSidxMappings(


### PR DESCRIPTION
## Description
Requires https://github.com/videojs/mpd-parser/pull/123

Fixes our `Angel One - Widevine, fmp4, webm, subs, alternate audio tracks` and i'm sure it fixes others.
