### PR TITLE
feat: add vhs-ready event

### DIFF
--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -435,16 +435,15 @@
         } else {
           sources.dispatchEvent(newEvent('change'));
         }
+        player.on('vhs-ready', function() {
+          window.vhs = player.tech_.vhs;
+          window.mpc = player.tech_.vhs.masterPlaylistController_;
+        });
+
         player.on('loadedmetadata', function() {
-          if (player.tech_.vhs) {
-            window.vhs = player.tech_.vhs;
-            window.mpc = player.tech_.vhs.masterPlaylistController_;
+          if (window.vhs && window.mpc) {
             window.mpc.masterPlaylistLoader_.on('mediachange', regenerateRepresentations);
             regenerateRepresentations();
-
-          } else {
-            window.vhs = null;
-            window.mpc = null;
           }
         });
         cb(player);

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -940,7 +940,7 @@ class VhsHandler extends Component {
 
     this.tech_.src(this.mediaSourceUrl_);
 
-    this.player_.trigger('vhs-ready');
+    this.tech_.trigger('vhs-ready');
   }
 
   /**

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -939,6 +939,8 @@ class VhsHandler extends Component {
     this.mediaSourceUrl_ = window.URL.createObjectURL(this.masterPlaylistController_.mediaSource);
 
     this.tech_.src(this.mediaSourceUrl_);
+
+    this.player_.trigger('vhs-ready');
   }
 
   /**


### PR DESCRIPTION
Add a `vhs-ready` event that is trigger directly after vhs is setup so that things like the master playlist, playlist selection, or segment loader setup can be intercepted. It also helps us determine when vhs is in use.
