### PR TITLE
chore: update to mux.js@5.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6475,9 +6475,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.10.0.tgz",
-      "integrity": "sha512-kLzvYsHYBwNa+ckkmpxWV3eImwntJbrwd1KbN4WR0hLe+dK/KB82aCuC0fQzAI2hkjYszdlSGsAWFgYdiFBUuA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.11.0.tgz",
+      "integrity": "sha512-Q/iLfohHh5Pp6lW7EFtcxNuaCNJ3Ruywfy46pWLsY+yIxR1kXXImYY1wOhg8jLdBMs1kRaZqsiB4Zncsiw0a2Q==",
       "requires": {
         "@babel/runtime": "^7.11.2"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "global": "^4.4.0",
     "m3u8-parser": "4.6.0",
     "mpd-parser": "0.15.4",
-    "mux.js": "5.10.0",
+    "mux.js": "5.11.0",
     "video.js": "^6 || ^7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Update to mux.js 5.11.0, supports parsing more mp4 boxes.