### PR TITLE
feat: mark Video.js as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "mux.js": "5.11.0",
     "video.js": "^6 || ^7"
   },
+  "peerDependencies": {
+    "video.js": "^6 || ^7"
+  },
   "devDependencies": {
     "@rollup/plugin-replace": "^2.3.4",
     "@videojs/generator-helpers": "~2.0.1",


### PR DESCRIPTION
Trying out marking vjs as a peer dep.
I'll probably do a pre-release from this branch and then a pre-release of Video.js as well to see how things work.