### PR TITLE
fix: experimentalLLHLS option should always be passed

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -636,7 +636,7 @@ export default class PlaylistLoader extends EventTarget {
         manifestString: req.responseText,
         customTagParsers: this.customTagParsers,
         customTagMappers: this.customTagMappers,
-        llhls: this.llhls
+        experimentalLLHLS: this.experimentalLLHLS
       });
 
       this.setupInitialPlaylist(manifest);


### PR DESCRIPTION
## Description
I guess I missed one of the `llhls` -> `exerimentalLLHLS` changes in `playlist-loader.js`
