### PR TITLE
chore: dont run tests on chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       run: sudo apt-get install ffmpeg pulseaudio
       if: ${{startsWith(matrix.os, 'ubuntu')}}
 
+    - name: remove chromium
+      run: sudo apt-get remove chromium-browser
+      if: ${{startsWith(matrix.os, 'ubuntu')}}
+
     - name: start pulseaudio for firefox on linux w/o browserstack
       run: pulseaudio -D
       if: ${{startsWith(matrix.os, 'ubuntu')}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   should-skip:
     continue-on-error: true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
       should-skip-job: ${{steps.skip-check.outputs.should_skip}}
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         test-type: [unit, playback, playback-min, coverage]
     env:
       BROWSER_STACK_USERNAME: ${{secrets.BROWSER_STACK_USERNAME}}
@@ -57,7 +57,7 @@ jobs:
       if: ${{startsWith(matrix.os, 'ubuntu')}}
 
     - name: remove chromium
-      run: sudo apt-get remove chromium-browser
+      run: sudo apt-get remove chromium*
       if: ${{startsWith(matrix.os, 'ubuntu')}}
 
     - name: start pulseaudio for firefox on linux w/o browserstack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,6 @@ jobs:
       run: sudo apt-get install ffmpeg pulseaudio
       if: ${{startsWith(matrix.os, 'ubuntu')}}
 
-    - name: remove chromium
-      run: sudo apt-get remove chromium*
-      if: ${{startsWith(matrix.os, 'ubuntu')}}
-
     - name: start pulseaudio for firefox on linux w/o browserstack
       run: pulseaudio -D
       if: ${{startsWith(matrix.os, 'ubuntu')}}

--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
     preferHeadless: false,
     browsers(aboutToRun) {
       return aboutToRun.filter(function(launcherName) {
-        return !(/^Safari/).test(launcherName);
+        return !(/^(Safari|Chromium)/).test(launcherName);
       });
     },
     files(defaults) {


### PR DESCRIPTION
## Description
We can really run our tests in chromium as we require basic media types to be supported, which chromium does not support.