### PR TITLE
fix: set audio status on loaders when setting up media groups

### DIFF
--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -810,7 +810,11 @@ export const setupMediaGroups = (settings) => {
     mediaTypes,
     masterPlaylistLoader,
     tech,
-    vhs
+    vhs,
+    segmentLoaders: {
+      ['AUDIO']: audioSegmentLoader,
+      main: mainSegmentLoader
+    }
   } = settings;
 
   // setup active group and track getters and change event handlers
@@ -833,6 +837,20 @@ export const setupMediaGroups = (settings) => {
     mediaTypes.AUDIO.tracks[groupId].enabled = true;
     mediaTypes.AUDIO.onGroupChanged();
     mediaTypes.AUDIO.onTrackChanged();
+
+    const activeAudioGroup = mediaTypes.AUDIO.getActiveGroup();
+
+    // a similar check for handling setAudio on each loader is run again each time the
+    // track is changed, but needs to be handled here since the track may not be considered
+    // changed on the first call to onTrackChanged
+    if (!activeAudioGroup.playlistLoader) {
+      // either audio is muxed with video or the stream is audio only
+      mainSegmentLoader.setAudio(true);
+    } else {
+      // audio is demuxed
+      mainSegmentLoader.setAudio(false);
+      audioSegmentLoader.setAudio(true);
+    }
   }
 
   masterPlaylistLoader.on('mediachange', () => {

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -1542,7 +1542,6 @@ QUnit.module('MediaGroups', function() {
     this.master.mediaGroups.AUDIO.aud1 = {
       en: { default: true, language: 'en', resolvedUri: 'aud1/en.m3u8' }
     };
-    this.settings.sourceType = 'hls';
 
     MediaGroups.setupMediaGroups(this.settings);
 
@@ -1556,13 +1555,12 @@ QUnit.module('MediaGroups', function() {
     );
   });
 
-  QUnit.test('sets audio true for main loader if alternate tracks with main stream as URI attribute', function(assert) {
+  QUnit.test('audio true for main loader if alternate tracks with main stream as URI attribute', function(assert) {
     this.media = {resolvedUri: 'en.m3u8', attributes: {AUDIO: 'aud1'}};
     this.master.playlists = [this.media];
     this.master.mediaGroups.AUDIO.aud1 = {
       en: { default: true, language: 'en', resolvedUri: 'en.m3u8' }
     };
-    this.settings.sourceType = 'hls';
 
     MediaGroups.setupMediaGroups(this.settings);
 


### PR DESCRIPTION
Although the audio status is set in onTrackChanged for media groups, and
the function is called when the media groups are first set up, the track
is not always considered changed. This means that for demuxed audio, the
main loader may still think it should be using its own audio itself,
leading to issues when crossing discontinuities (i.e., the main loader
will cross the discontinuity before waiting for the audio loader to be
ready, leading to audio timestamps that aren't correct).

This change ensures that the audio status is set on setup, regardless of
whether the track is considered changed. Subsequent changes are handled
in onTrackChanged.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
