### PR TITLE
feat: Caption services (608/708) metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ This option defaults to `false`.
 ##### captionServices
 * Type: `object`
 * Default: undefined
-* Allow to override instream captions like 608 and 708 to provide labels or languaages.
+* Provide extra information, like a label or a language, for instream (608 and 708) captions.
 
 The captionServices options object has properties that map to the caption services. Each property is an object itself that includes several properties, like a label or language.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Video.js Compatibility: 6.0, 7.0
       - [handlePartialData](#handlepartialdata)
       - [liveRangeSafeTimeDelta](#liverangesafetimedelta)
       - [captionServices](#captionservices)
+        - [Format](#format)
+        - [Example](#example)
   - [Runtime Properties](#runtime-properties)
     - [vhs.playlists.master](#vhsplaylistsmaster)
     - [vhs.playlists.media](#vhsplaylistsmedia)
@@ -475,8 +477,8 @@ This option defaults to `false`.
 The captionServices options object has properties that map to the caption services. Each property is an object itself that includes several properties, like a label or language.
 
 For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 captions, the service names are `SERVICEn` where `n` is a digit between `1` and `63`.
-Format:
-```json
+###### Format
+```js
 {
   vhs: {
     captionServices: {
@@ -488,8 +490,8 @@ Format:
   }
 }
 ```
-Example:
-```json
+###### Example
+```js
 {
   vhs: {
     captionServices: {

--- a/README.md
+++ b/README.md
@@ -483,8 +483,9 @@ For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 
   vhs: {
     captionServices: {
       [serviceName]: {
-        language: String,
-        label: String
+        language: String, // optional
+        label: String, // optional
+        default: boolean // optional
       }
     }
   }
@@ -501,7 +502,8 @@ For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 
       },
       SERVICE1: {
         langauge: 'kr',
-        label: 'Korean'
+        label: 'Korean',
+        default: true
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Video.js Compatibility: 6.0, 7.0
       - [cacheEncryptionKeys](#cacheencryptionkeys)
       - [handlePartialData](#handlepartialdata)
       - [liveRangeSafeTimeDelta](#liverangesafetimedelta)
+      - [captionServices](#captionservices)
   - [Runtime Properties](#runtime-properties)
     - [vhs.playlists.master](#vhsplaylistsmaster)
     - [vhs.playlists.media](#vhsplaylistsmedia)
@@ -465,6 +466,45 @@ This option defaults to `false`.
 * Type: `number`,
 * Default: [`SAFE_TIME_DELTA`](https://github.com/videojs/http-streaming/blob/e7cb63af010779108336eddb5c8fd138d6390e95/src/ranges.js#L17)
 * Allow to  re-define length (in seconds) of time delta when you compare current time and the end of the buffered range.
+
+##### captionServices
+* Type: `object`
+* Default: undefined
+* Allow to override instream captions like 608 and 708 to provide labels or languaages.
+
+The captionServices options object has properties that map to the caption services. Each property is an object itself that includes several properties, like a label or language.
+
+For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 captions, the service names are `SERVICEn` where `n` is a digit between `1` and `63`.
+Format:
+```json
+{
+  vhs: {
+    captionServices: {
+      [serviceName]: {
+        language: String,
+        label: String
+      }
+    }
+  }
+}
+```
+Example:
+```json
+{
+  vhs: {
+    captionServices: {
+      CC1: {
+        language: 'en',
+        label: 'English'
+      },
+      SERVICE1: {
+        langauge: 'kr',
+        label: 'Korean'
+      }
+    }
+  }
+}
+```
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1340,6 +1340,17 @@
             "@videojs/vhs-utils": "^3.0.0",
             "global": "^4.4.0"
           }
+        },
+        "mpd-parser": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.16.0.tgz",
+          "integrity": "sha512-/pOFsDbOxXFAla47rYMdIypBZVtsQ9q3OHNuKtW2CJMaCGtNDtUcLS+B2TToYmB20rgi3XIgkyc2EsIvIAS4NA==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "^3.0.0",
+            "global": "^4.4.0",
+            "xmldom": "^0.5.0"
+          }
         }
       }
     },
@@ -6502,12 +6513,12 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.16.0.tgz",
-      "integrity": "sha512-/pOFsDbOxXFAla47rYMdIypBZVtsQ9q3OHNuKtW2CJMaCGtNDtUcLS+B2TToYmB20rgi3XIgkyc2EsIvIAS4NA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.17.0.tgz",
+      "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
+        "@videojs/vhs-utils": "^3.0.2",
         "global": "^4.4.0",
         "xmldom": "^0.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",
-    "mpd-parser": "0.16.0",
+    "mpd-parser": "0.17.0",
     "mux.js": "5.11.0",
     "video.js": "^6 || ^7"
   },

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -652,11 +652,6 @@ export const initialize = {
           default: properties.default && properties.autoselect
         };
 
-        // we need to translate SERVICEn for 708 to how mux.js currently labels them
-        if (/^cc708_/.test(newProps.instreamId)) {
-          newProps.instreamId = 'SERVICE' + properties.instreamId.split('_')[1];
-        }
-
         if (captionServices[newProps.instreamId]) {
           newProps = videojs.mergeOptions(newProps, captionServices[newProps.instreamId]);
         }

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -638,9 +638,8 @@ export const initialize = {
       for (const variantLabel in mediaGroups[type][groupId]) {
         const properties = mediaGroups[type][groupId][variantLabel];
 
-        // We only support CEA608 captions for now, so ignore anything that
-        // doesn't use a CCx INSTREAM-ID
-        if (!properties.instreamId.match(/CC\d/)) {
+        // Look for either 608 (CCn) or 708 (SERVICEn) caption services
+        if (!/^(?:CC|SERVICE)/.test(properties.instreamId)) {
           continue;
         }
 

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -643,17 +643,35 @@ export const initialize = {
           continue;
         }
 
+        const captionServices = tech.options_.vhs && tech.options_.vhs.captionServices || {};
+
+        let label = variantLabel;
+        let language = properties.language;
+        let instreamId = properties.instreamId;
+        let def = properties.default && properties.autoselect;
+
+        // we need to translate SERVICEn for 708 to how mux.js currently labels them
+        if (/^cc708_/.test(instreamId)) {
+          instreamId = 'SERVICE' + properties.instreamId.split('_')[1];
+        }
+
+        if (captionServices[instreamId]) {
+          label = captionServices[instreamId].label;
+          language = captionServices[instreamId].language;
+          def = captionServices[instreamId].default;
+        }
+
         // No PlaylistLoader is required for Closed-Captions because the captions are
         // embedded within the video stream
         groups[groupId].push(videojs.mergeOptions({ id: variantLabel }, properties));
 
         if (typeof tracks[variantLabel] === 'undefined') {
           const track = tech.addRemoteTextTrack({
-            id: properties.instreamId,
+            id: instreamId,
             kind: 'captions',
-            default: properties.default && properties.autoselect,
-            language: properties.language,
-            label: variantLabel
+            default: def,
+            language,
+            label
           }, false).track;
 
           tracks[variantLabel] = track;

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -645,20 +645,24 @@ export const initialize = {
 
         const captionServices = tech.options_.vhs && tech.options_.vhs.captionServices || {};
 
-        let label = variantLabel;
-        let language = properties.language;
-        let instreamId = properties.instreamId;
-        let def = properties.default && properties.autoselect;
+        let newProps = {
+          label: variantLabel,
+          language: properties.language,
+          instreamId: properties.instreamId,
+          default: properties.default && properties.autoselect
+        };
 
         // we need to translate SERVICEn for 708 to how mux.js currently labels them
-        if (/^cc708_/.test(instreamId)) {
-          instreamId = 'SERVICE' + properties.instreamId.split('_')[1];
+        if (/^cc708_/.test(newProps.instreamId)) {
+          newProps.instreamId = 'SERVICE' + properties.instreamId.split('_')[1];
         }
 
-        if (captionServices[instreamId]) {
-          label = captionServices[instreamId].label;
-          language = captionServices[instreamId].language;
-          def = captionServices[instreamId].default;
+        if (captionServices[newProps.instreamId]) {
+          newProps = videojs.mergeOptions(newProps, captionServices[newProps.instreamId]);
+        }
+
+        if (newProps.default === undefined) {
+          delete newProps.default;
         }
 
         // No PlaylistLoader is required for Closed-Captions because the captions are
@@ -667,11 +671,11 @@ export const initialize = {
 
         if (typeof tracks[variantLabel] === 'undefined') {
           const track = tech.addRemoteTextTrack({
-            id: instreamId,
+            id: newProps.instreamId,
             kind: 'captions',
-            default: def,
-            language,
-            label
+            default: newProps.default,
+            language: newProps.language,
+            label: newProps.label
           }, false).track;
 
           tracks[variantLabel] = track;

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -24,12 +24,28 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       // in the m3u8 for us to use
       inbandTextTracks[captionStream] = track;
     } else {
+      const captionServices = tech.options_.vhs && tech.options_.vhs.captionServices || {};
+      let label = captionStream;
+      let language = captionStream;
+      let instreamId = captionStream;
+
+      // we need to translate SERVICEn for 708 to how mux.js currently labels them
+      if (/^cc708_/.test(captionStream)) {
+        instreamId = 'SERVICE' + captionStream.split('_')[1];
+      }
+
+      if (captionServices[instreamId]) {
+        label = captionServices[instreamId].label;
+        language = captionServices[instreamId].language;
+      }
+
       // Otherwise, create a track with the default `CC#` label and
       // without a language
       inbandTextTracks[captionStream] = tech.addRemoteTextTrack({
         kind: 'captions',
-        id: captionStream,
-        label: captionStream
+        id: instreamId,
+        label,
+        language
       }, false).track;
     }
   }

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -35,10 +35,12 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       const captionServices = tech.options_.vhs && tech.options_.vhs.captionServices || {};
       let label = captionStream;
       let language = captionStream;
+      let def = false;
 
       if (captionServices[instreamId]) {
         label = captionServices[instreamId].label;
         language = captionServices[instreamId].language;
+        def = captionServices[instreamId].default;
       }
 
       // Otherwise, create a track with the default `CC#` label and
@@ -46,6 +48,7 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       inbandTextTracks[captionStream] = tech.addRemoteTextTrack({
         kind: 'captions',
         id: instreamId,
+        default: def,
         label,
         language
       }, false).track;

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -32,6 +32,8 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       // in the m3u8 for us to use
       inbandTextTracks[captionStream] = track;
     } else {
+      // This section gets called when we have caption services that aren't specified in the manifest.
+      // Manifest level caption services are handled in media-groups.js under CLOSED-CAPTIONS.
       const captionServices = tech.options_.vhs && tech.options_.vhs.captionServices || {};
       let label = captionStream;
       let language = captionStream;
@@ -49,6 +51,7 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       inbandTextTracks[captionStream] = tech.addRemoteTextTrack({
         kind: 'captions',
         id: instreamId,
+        // TODO: investigate why this doesn't seem to turn the caption on by default
         default: def,
         label,
         language

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -36,11 +36,12 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       let label = captionStream;
       let language = captionStream;
       let def = false;
+      const captionService = captionServices[instreamId];
 
-      if (captionServices[instreamId]) {
-        label = captionServices[instreamId].label;
-        language = captionServices[instreamId].language;
-        def = captionServices[instreamId].default;
+      if (captionService) {
+        label = captionService.label;
+        language = captionService.language;
+        def = captionService.default;
       }
 
       // Otherwise, create a track with the default `CC#` label and

--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -16,7 +16,15 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
   if (!inbandTextTracks[captionStream]) {
     tech.trigger({type: 'usage', name: 'vhs-608'});
     tech.trigger({type: 'usage', name: 'hls-608'});
-    const track = tech.textTracks().getTrackById(captionStream);
+
+    let instreamId = captionStream;
+
+    // we need to translate SERVICEn for 708 to how mux.js currently labels them
+    if (/^cc708_/.test(captionStream)) {
+      instreamId = 'SERVICE' + captionStream.split('_')[1];
+    }
+
+    const track = tech.textTracks().getTrackById(instreamId);
 
     if (track) {
       // Resuse an existing track with a CC# id because this was
@@ -27,12 +35,6 @@ export const createCaptionsTrackIfNotExists = function(inbandTextTracks, tech, c
       const captionServices = tech.options_.vhs && tech.options_.vhs.captionServices || {};
       let label = captionStream;
       let language = captionStream;
-      let instreamId = captionStream;
-
-      // we need to translate SERVICEn for 708 to how mux.js currently labels them
-      if (/^cc708_/.test(captionStream)) {
-        instreamId = 'SERVICE' + captionStream.split('_')[1];
-      }
 
       if (captionServices[instreamId]) {
         label = captionServices[instreamId].label;

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -45,6 +45,7 @@ export const LoaderCommonHooks = {
     this.fakeVhs = {
       xhr: xhrFactory(),
       tech_: {
+        options_: {},
         paused: () => this.paused,
         playbackRate: () => this.playbackRate,
         currentTime: () => this.currentTime,

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -3260,7 +3260,7 @@ QUnit.test(
       .map(cap => Object.assign({name: cap.id}, cap));
 
     assert.equal(capsArr.length, 4, '4 closed-caption tracks defined in playlist');
-    assert.equal(addedCaps.length, 4, '4 tracks added internally');
+    assert.equal(addedCaps.length, 4, '4 tracks, 2 608 and 2 708 tracks, added internally');
     assert.equal(addedCaps[0].instreamId, 'CC1', 'first 608 track is CC1');
     assert.equal(addedCaps[2].instreamId, 'CC3', 'second 608 track is CC3');
 
@@ -3325,7 +3325,7 @@ QUnit.test(
       .map(cap => Object.assign({name: cap.id}, cap));
 
     assert.equal(capsArr.length, 4, '4 closed-caption tracks defined in playlist');
-    assert.equal(addedCaps.length, 4, '4 tracks added internally');
+    assert.equal(addedCaps.length, 4, '4 tracks, 2 608 and 2 708 tracks, added internally');
     assert.equal(addedCaps[1].instreamId, 'SERVICE1', 'first 708 track is SERVICE1');
     assert.equal(addedCaps[3].instreamId, 'SERVICE3', 'second 708 track is SERVICE3');
 

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -1259,7 +1259,18 @@ QUnit.module('MediaGroups', function() {
         en608: { language: 'en', default: true, autoselect: true, instreamId: 'CC1' },
         en708: { language: 'en', instreamId: 'SERVICE1' },
         fr608: { language: 'fr', instreamId: 'CC3' },
-        fr708: { language: 'fr', instreamId: 'SERVICE3' }
+        fr708: { language: 'fr', instreamId: 'SERVICE3' },
+        kr708: { language: 'kor', instreamId: 'SERVICE4' }
+      };
+
+      // verify that captionServices option can modify properties
+      this.settings.tech.options_.vhs = {
+        captionServices: {
+          SERVICE4: {
+            label: 'Korean',
+            default: true
+          }
+        }
       };
 
       MediaGroups.initialize[type](type, this.settings);
@@ -1271,13 +1282,21 @@ QUnit.module('MediaGroups', function() {
             { id: 'en608', default: true, autoselect: true, language: 'en', instreamId: 'CC1' },
             { id: 'en708', language: 'en', instreamId: 'SERVICE1' },
             { id: 'fr608', language: 'fr', instreamId: 'CC3' },
-            { id: 'fr708', language: 'fr', instreamId: 'SERVICE3' }
+            { id: 'fr708', language: 'fr', instreamId: 'SERVICE3' },
+            { id: 'kr708', language: 'kor', instreamId: 'SERVICE4' }
           ]
         }, 'creates group properties'
       );
       assert.ok(this.mediaTypes[type].tracks.en608, 'created text track');
       assert.ok(this.mediaTypes[type].tracks.fr608, 'created text track');
       assert.equal(this.mediaTypes[type].tracks.en608.default, true, 'en608 track auto selected');
+      assert.deepEqual(this.mediaTypes[type].tracks.kr708, {
+        id: 'SERVICE4',
+        kind: 'captions',
+        language: 'kor',
+        label: 'Korean',
+        default: true
+      }, 'kr708 fields are overriden by the options');
     }
   );
 

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -1078,6 +1078,7 @@ QUnit.module('MediaGroups', function() {
         masterPlaylistLoader: {master: this.master},
         vhs: {},
         tech: {
+          options_: {},
           addRemoteTextTrack(track) {
             return { track };
           }
@@ -1268,7 +1269,9 @@ QUnit.module('MediaGroups', function() {
         {
           CCs: [
             { id: 'en608', default: true, autoselect: true, language: 'en', instreamId: 'CC1' },
-            { id: 'fr608', language: 'fr', instreamId: 'CC3' }
+            { id: 'en708', language: 'en', instreamId: 'SERVICE1' },
+            { id: 'fr608', language: 'fr', instreamId: 'CC3' },
+            { id: 'fr708', language: 'fr', instreamId: 'SERVICE3' }
           ]
         }, 'creates group properties'
       );

--- a/test/text-tracks.test.js
+++ b/test/text-tracks.test.js
@@ -11,7 +11,8 @@ import {
 const { module, test } = Qunit;
 
 class MockTextTrack {
-  constructor() {
+  constructor(opts = {}) {
+    Object.keys(opts).forEach((opt) => (this[opt] = opts[opt]));
     this.cues = [];
   }
   addCue(cue) {
@@ -33,9 +34,9 @@ class MockTech {
       }
     };
   }
-  addRemoteTextTrack({kind, id, label}) {
-    this.tracks[id] = new MockTextTrack();
-    return { track: this.tracks[id] };
+  addRemoteTextTrack(opts) {
+    this.tracks[opts.id] = new MockTextTrack(opts);
+    return { track: this.tracks[opts.id] };
   }
   trigger() {}
   textTracks() {
@@ -62,6 +63,27 @@ test('creates a track if it does not exist yet', function(assert) {
 
   createCaptionsTrackIfNotExists(inbandTracks, tech, 'CC1');
   assert.ok(inbandTracks.CC1, 'CC1 track was added');
+});
+
+test('creates a 708 track if it does not exist yet', function(assert) {
+  const inbandTracks = {};
+  const tech = new MockTech();
+
+  createCaptionsTrackIfNotExists(inbandTracks, tech, 'cc708_1');
+  assert.ok(inbandTracks.cc708_1, 'cc708_1 track was added');
+});
+
+test('maps mux.js 708 track name to HLS and DASH service name', function(assert) {
+  const inbandTracks = {};
+  const tech = new MockTech();
+
+  createCaptionsTrackIfNotExists(inbandTracks, tech, 'cc708_1');
+  assert.ok(inbandTracks.cc708_1, 'cc708_1 track was added');
+  assert.equal(inbandTracks.cc708_1.id, 'SERVICE1', 'SERVICE1 created from cc708_1');
+  createCaptionsTrackIfNotExists(inbandTracks, tech, 'cc708_3');
+  assert.ok(inbandTracks.cc708_3, 'cc708_3 track was added');
+  assert.equal(inbandTracks.cc708_3.id, 'SERVICE3', 'SERVICE3 created from cc708_3');
+
 });
 
 test('fills inbandTextTracks if a track already exists', function(assert) {

--- a/test/text-tracks.test.js
+++ b/test/text-tracks.test.js
@@ -26,6 +26,7 @@ class MockTextTrack {
 
 class MockTech {
   constructor() {
+    this.options_ = {};
     this.tracks = {
       getTrackById(id) {
         return this[id];

--- a/test/text-tracks.test.js
+++ b/test/text-tracks.test.js
@@ -83,7 +83,29 @@ test('maps mux.js 708 track name to HLS and DASH service name', function(assert)
   createCaptionsTrackIfNotExists(inbandTracks, tech, 'cc708_3');
   assert.ok(inbandTracks.cc708_3, 'cc708_3 track was added');
   assert.equal(inbandTracks.cc708_3.id, 'SERVICE3', 'SERVICE3 created from cc708_3');
+});
 
+test('can override caption services settings', function(assert) {
+  const inbandTracks = {};
+  const tech = new MockTech();
+
+  tech.options_ = {
+    vhs: {
+      captionServices: {
+        SERVICE1: {
+          label: 'hello'
+        },
+        CC1: {
+          label: 'goodbye'
+        }
+      }
+    }
+  };
+
+  createCaptionsTrackIfNotExists(inbandTracks, tech, 'cc708_1');
+  assert.equal(inbandTracks.cc708_1.label, 'hello', 'we set a custom label for SERVICE1');
+  createCaptionsTrackIfNotExists(inbandTracks, tech, 'CC1');
+  assert.equal(inbandTracks.CC1.label, 'goodbye', 'we set a custom label for CC1');
 });
 
 test('fills inbandTextTracks if a track already exists', function(assert) {


### PR DESCRIPTION
Add an option for caption services metadata in case the user wants to specify labels for 608/708 captions, override the ones provided in the manifest, or needs to add more information like character encoding (this isn't currently available but will be added some time in the future).
For HLS, an `EXT-X-MEDIA` tag can be specified with an `INSTREAM-ID` attribute. We already support this. https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-08#section-4.4.6.1
This PR updated mpd-parser which uses the ANSI 214 supplamental spec section 7.2 to parse out the same information from MPD files. https://github.com/videojs/mpd-parser/pull/131.

Adds a property called `captionServices` which has properties of the caption service IDs like `CC1` or `SERVICE1` and allows a user to specify a `language` and `label`.