### PR TITLE
chore: do not strip debugger statements

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -77,7 +77,8 @@ const options = {
       }),
       strip: strip({
         functions: ['TEST_ONLY_*'],
-        debugger: false
+        debugger: false,
+        sourceMap: false
       }),
       createTestData: createTestData()
     });

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -76,7 +76,8 @@ const options = {
         compress: {passes: 2}
       }),
       strip: strip({
-        functions: ['TEST_ONLY_*']
+        functions: ['TEST_ONLY_*'],
+        debugger: false
       }),
       createTestData: createTestData()
     });


### PR DESCRIPTION
## Description
`debugger;` statements are currently being stripped. 
