### PR TITLE
fix: Prevent skipping frames in adts data via mux.js 5.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6563,9 +6563,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.11.2.tgz",
-      "integrity": "sha512-/qvYK2lU8ETFY9DyGp4IX2Lhlm3ajqk8pUfX1I7is7OmPYrTM0csS2zXyW9wCpHq0yMZLLR9yEz0mwYKanfHdQ==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.11.3.tgz",
+      "integrity": "sha512-wL7zb7CMthrTVhVFOKiU/HrWeNA9vbPNIIebhkFRz5g2nTDgBsQPsDoHYW8pk4sgHgY9wvuzrqlDvLkhdPPgrw==",
       "requires": {
         "@babel/runtime": "^7.11.2"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",
     "mpd-parser": "0.17.0",
-    "mux.js": "5.11.2",
+    "mux.js": "5.11.3",
     "video.js": "^6 || ^7"
   },
   "peerDependencies": {


### PR DESCRIPTION
see https://github.com/videojs/mux.js/pull/390
