### PR TITLE
fix: Use segmentInfo.trackInfo to get segment information.

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1045,9 +1045,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     let isEndOfStream = this.mainSegmentLoader_.ended_;
 
     if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
+      const mainMediaInfo = this.mainSegmentLoader_.getCurrentMediaInfo_();
+
       // if the audio playlist loader exists, then alternate audio is active
-      if (!this.mainSegmentLoader_.currentMediaInfo_ ||
-          this.mainSegmentLoader_.currentMediaInfo_.hasVideo) {
+      if (!mainMediaInfo || mainMediaInfo.hasVideo) {
         // if we do not know if the main segment loader contains video yet or if we
         // definitively know the main segment loader contains video, then we need to wait
         // for both main and audio segment loaders to call endOfStream
@@ -1619,9 +1620,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
   areMediaTypesKnown_() {
     const usingAudioLoader = !!this.mediaTypes_.AUDIO.activePlaylistLoader;
+    const hasMainMediaInfo = !!this.mainSegmentLoader_.getCurrentMediaInfo_();
+    // if we are not using an audio loader, then we have audio media info
+    // otherwise check on the segment loader.
+    const hasAudioMediaInfo = !usingAudioLoader ? true : !!this.audioSegmentLoader_.getCurrentMediaInfo_();
 
     // one or both loaders has not loaded sufficently to get codecs
-    if (!this.mainSegmentLoader_.currentMediaInfo_ || (usingAudioLoader && !this.audioSegmentLoader_.currentMediaInfo_)) {
+    if (!hasMainMediaInfo || !hasAudioMediaInfo) {
       return false;
     }
 
@@ -1630,8 +1635,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
   getCodecsOrExclude_() {
     const media = {
-      main: this.mainSegmentLoader_.currentMediaInfo_ || {},
-      audio: this.audioSegmentLoader_.currentMediaInfo_ || {}
+      main: this.mainSegmentLoader_.getCurrentMediaInfo_() || {},
+      audio: this.audioSegmentLoader_.getCurrentMediaInfo_() || {}
     };
 
     // set "main" media equal to video

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -811,12 +811,14 @@ export default class SegmentLoader extends videojs.EventTarget {
    *         TimeRange object representing the current buffered ranges
    */
   buffered_() {
-    if (!this.sourceUpdater_ || !this.startingMediaInfo_) {
+    const trackInfo = this.getMediaInfo_();
+
+    if (!this.sourceUpdater_ || !trackInfo) {
       return videojs.createTimeRanges();
     }
 
     if (this.loaderType_ === 'main') {
-      const { hasAudio, hasVideo, isMuxed } = this.startingMediaInfo_;
+      const { hasAudio, hasVideo, isMuxed } = trackInfo;
 
       if (hasVideo && hasAudio && !this.audioDisabled_ && !isMuxed) {
         return this.sourceUpdater_.buffered();
@@ -1206,7 +1208,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    if (!this.sourceUpdater_ || !this.startingMediaInfo_) {
+    if (!this.sourceUpdater_ || !this.getMediaInfo_()) {
       this.logger_('skipping remove because no source updater or starting media info');
       // nothing to remove if we haven't processed any media
       return;
@@ -1871,7 +1873,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // created together (before appending). Source buffer creation uses the presence of
     // audio and video data to determine whether to create audio/video source buffers, and
     // uses processed (transmuxed or parsed) media to determine the types required.
-    if (!this.currentMediaInfo_) {
+    if (!this.getCurrentMediaInfo_()) {
       return true;
     }
 
@@ -1905,6 +1907,14 @@ export default class SegmentLoader extends videojs.EventTarget {
     return true;
   }
 
+  getCurrentMediaInfo_(segmentInfo = this.pendingSegment_) {
+    return segmentInfo && segmentInfo.trackInfo || this.currentMediaInfo_;
+  }
+
+  getMediaInfo_(segmentInfo = this.pendingSegment_) {
+    return this.getCurrentMediaInfo_(segmentInfo) || this.startingMediaInfo_;
+  }
+
   hasEnoughInfoToAppend_() {
     if (!this.sourceUpdater_.ready()) {
       return false;
@@ -1917,15 +1927,13 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     const segmentInfo = this.pendingSegment_;
+    const trackInfo = this.getCurrentMediaInfo_();
 
-    // no segment to append any data for or
-    // we do not have information on this specific
-    // segment yet
-    if (!segmentInfo || !segmentInfo.trackInfo) {
+    if (!segmentInfo || !trackInfo) {
       return false;
     }
 
-    const {hasAudio, hasVideo, isMuxed} = this.currentMediaInfo_;
+    const {hasAudio, hasVideo, isMuxed} = trackInfo;
 
     if (hasVideo && !segmentInfo.videoTimingInfo) {
       return false;
@@ -2005,8 +2013,9 @@ export default class SegmentLoader extends videojs.EventTarget {
       segmentInfo.timingInfo.start =
         segmentInfo[timingInfoPropertyForMedia(result.type)].start;
     } else {
+      const trackInfo = this.getCurrentMediaInfo_();
       const useVideoTimingInfo =
-        this.loaderType_ === 'main' && this.currentMediaInfo_.hasVideo;
+        this.loaderType_ === 'main' && trackInfo && trackInfo.hasVideo;
       let firstVideoFrameTimeForData;
 
       if (useVideoTimingInfo) {
@@ -2711,7 +2720,9 @@ export default class SegmentLoader extends videojs.EventTarget {
   }
 
   waitForAppendsToComplete_(segmentInfo) {
-    if (!this.currentMediaInfo_) {
+    const trackInfo = this.getCurrentMediaInfo_(segmentInfo);
+
+    if (!trackInfo) {
       this.error({
         message: 'No starting media returned, likely due to an unsupported media format.',
         blacklistDuration: Infinity
@@ -2722,7 +2733,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Although transmuxing is done, appends may not yet be finished. Throw a marker
     // on each queue this loader is responsible for to ensure that the appends are
     // complete.
-    const {hasAudio, hasVideo, isMuxed} = this.currentMediaInfo_;
+    const {hasAudio, hasVideo, isMuxed} = trackInfo;
     const waitForVideo = this.loaderType_ === 'main' && hasVideo;
     const waitForAudio = !this.audioDisabled_ && hasAudio && !isMuxed;
 
@@ -2790,7 +2801,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
   checkForIllegalMediaSwitch(trackInfo) {
     const illegalMediaSwitchError =
-      illegalMediaSwitch(this.loaderType_, this.currentMediaInfo_, trackInfo);
+      illegalMediaSwitch(this.loaderType_, this.getCurrentMediaInfo_(), trackInfo);
 
     if (illegalMediaSwitchError) {
       this.error({
@@ -2845,8 +2856,9 @@ export default class SegmentLoader extends videojs.EventTarget {
 
   updateTimingInfoEnd_(segmentInfo) {
     segmentInfo.timingInfo = segmentInfo.timingInfo || {};
+    const trackInfo = this.getMediaInfo_();
     const useVideoTimingInfo =
-      this.loaderType_ === 'main' && this.currentMediaInfo_.hasVideo;
+      this.loaderType_ === 'main' && trackInfo && trackInfo.hasVideo;
     const prioritizedTimingInfo = useVideoTimingInfo && segmentInfo.videoTimingInfo ?
       segmentInfo.videoTimingInfo : segmentInfo.audioTimingInfo;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1929,6 +1929,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     const segmentInfo = this.pendingSegment_;
     const trackInfo = this.getCurrentMediaInfo_();
 
+    // no segment to append any data for or
+    // we do not have information on this specific
+    // segment yet
     if (!segmentInfo || !trackInfo) {
       return false;
     }


### PR DESCRIPTION
## Description
This prevents an issue shown via the test that I added. Mainly that a playlist change that happens before we append data from a `pendingSegment_` will cause reset `this.currentMediaInfo_` to be null. Thus causing `handleData_`'s call to `hasEnoughInfoToAppend_`  to throw on `this.currentMediaInfo_.hasAudio`