### PR TITLE
feat: Add experimentalExactManifestTimings which forgoes TIME_FUDGE_FACTOR during segment choice

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,10 @@
       [EXPERIMENTAL] Use Buffer Level for ABR (reloads player)
     </label>
     <label>
+      <input id=exact-manifest-timings type="checkbox">
+      [EXPERIMENTAL] Use exact manifest timings for segment choices (reloads player)
+    </label>
+    <label>
       <input id=override-native type="checkbox" checked>
       Override Native (reloads player)
     </label>

--- a/scripts/index-demo-page.js
+++ b/scripts/index-demo-page.js
@@ -245,6 +245,7 @@
     'type',
     'keysystems',
     'buffer-water',
+    'exact-manifest-timings',
     'override-native',
     'preload',
     'mirror-source'
@@ -314,6 +315,13 @@
       stateEls.minified.dispatchEvent(newEvent('change'));
     });
 
+    stateEls['exact-manifest-timings'].addEventListener('change', function(event) {
+      saveState();
+
+      // reload the player and scripts
+      stateEls.minified.dispatchEvent(newEvent('change'));
+    });
+
     stateEls['override-native'].addEventListener('change', function(event) {
       saveState();
 
@@ -377,7 +385,8 @@
             vhs: {
               overrideNative: getInputValue(stateEls['override-native']),
               experimentalBufferBasedABR: getInputValue(stateEls['buffer-water']),
-              experimentalLLHLS: getInputValue(stateEls.llhls)
+              experimentalLLHLS: getInputValue(stateEls.llhls),
+              experimentalExactManifestTimings: getInputValue(stateEls['exact-manifest-timings'])
             }
           }
         });

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -232,7 +232,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       inbandTextTracks: this.inbandTextTracks_,
       cacheEncryptionKeys,
       sourceUpdater: this.sourceUpdater_,
-      timelineChangeController: this.timelineChangeController_
+      timelineChangeController: this.timelineChangeController_,
+      experimentalExactManifestTimings: options.experimentalExactManifestTimings
     };
 
     // The source type check not only determines whether a special DASH playlist loader

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -6,7 +6,6 @@
 import videojs from 'video.js';
 import window from 'global/window';
 import {isAudioCodec} from '@videojs/vhs-utils/es/codecs.js';
-import {TIME_FUDGE_FACTOR} from './ranges.js';
 
 const {createTimeRange} = videojs;
 
@@ -415,8 +414,7 @@ export const getMediaInfoForTime = function({
 
         time += partAndSegment.duration;
 
-        // TODO: consider not using TIME_FUDGE_FACTOR at all here
-        if ((time + TIME_FUDGE_FACTOR) > 0) {
+        if (time > 0) {
           return {
             partIndex: partAndSegment.partIndex,
             segmentIndex: partAndSegment.segmentIndex,
@@ -464,8 +462,7 @@ export const getMediaInfoForTime = function({
 
     time -= partAndSegment.duration;
 
-    // TODO: consider not using TIME_FUDGE_FACTOR at all here
-    if ((time - TIME_FUDGE_FACTOR) < 0) {
+    if (time < 0) {
       return {
         partIndex: partAndSegment.partIndex,
         segmentIndex: partAndSegment.segmentIndex,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -539,6 +539,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.timelineChangeController_ = settings.timelineChangeController;
     this.shouldSaveSegmentTimingInfo_ = true;
     this.parse708captions_ = settings.parse708captions;
+    this.experimentalExactManifestTimings = settings.experimentalExactManifestTimings;
 
     // private instance variables
     this.checkBufferTimeout_ = null;
@@ -1404,6 +1405,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     } else {
       // Find the segment containing the end of the buffer or current time.
       const {segmentIndex, startTime, partIndex} = Playlist.getMediaInfoForTime({
+        experimentalExactManifestTimings: this.experimentalExactManifestTimings,
         playlist: this.playlist_,
         currentTime: this.fetchAtBuffer_ ? bufferedEnd : this.currentTime_(),
         startingPartIndex: this.syncPoint_.partIndex,

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -681,7 +681,8 @@ class VhsHandler extends Component {
       'initialPlaylistSelector',
       'experimentalBufferBasedABR',
       'liveRangeSafeTimeDelta',
-      'experimentalLLHLS'
+      'experimentalLLHLS',
+      'experimentalExactManifestTimings'
     ].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];


### PR DESCRIPTION
Remove TIME_FUDGE_FACTOR from our calculations and just use manifest values.
