### PR TITLE
fix: update vhs-utils to correctly detect mp4 starting with moof/moov

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,9 +1382,9 @@
       }
     },
     "@videojs/vhs-utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.2.tgz",
-      "integrity": "sha512-r8Yas1/tNGsGRNoIaDJuiWiQgM0P2yaEnobgzw5JcBiEqxnS8EXoUm4QtKH7nJtnppZ1yqBx1agBZCvBMKXA2w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.3.tgz",
+      "integrity": "sha512-bU7daxDHhzcTDbmty1cXjzsTYvx2cBGbA8hG5H2Gvpuk4sdfuvkZtMCwtCqL59p6dsleMPspyaNS+7tWXx2Y0A==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/vhs-utils": "^3.0.2",
+    "@videojs/vhs-utils": "3.0.3",
     "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",


### PR DESCRIPTION
## Description
Correctly detects mp4's that start with moof/moov instead of ftyp/styp.