### PR TITLE
test: fix tests in chrome 92 by disposing media elements/ blob url

### DIFF
--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -317,7 +317,9 @@ QUnit.module('Configuration - Options', {
     this.env.restore();
     videojs.Vhs.supportsNativeHls = this.old.NativeHlsSupport;
 
-    this.player.dispose();
+    if (this.player) {
+      this.player.dispose();
+    }
     videojs.options.vhs = {};
 
   }

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -2,6 +2,7 @@ import QUnit from 'qunit';
 import videojs from 'video.js';
 import xhrFactory from '../src/xhr';
 import Config from '../src/config';
+import document from 'global/document';
 import {
   playlistWithDuration,
   useFakeEnvironment,
@@ -63,8 +64,18 @@ export const LoaderCommonHooks = {
     this.syncController = new SyncController();
     this.decrypter = new Decrypter();
     this.timelineChangeController = new TimelineChangeController();
+
+    this.video = document.createElement('video');
+
+    this.setupMediaSource = (a, b, c) => {
+      return setupMediaSource(a, b, videojs.mergeOptions({videoEl: this.video}, c));
+    };
   },
   afterEach(assert) {
+    this.video.src = '';
+    this.video.removeAttribute('src');
+    this.video = null;
+
     this.env.restore();
     this.decrypter.terminate();
     this.sourceUpdater.dispose();
@@ -195,7 +206,7 @@ export const LoaderCommonFactory = ({
     });
 
     QUnit.test('calling load should unpause', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(20));
         loader.pause();
 
@@ -233,7 +244,7 @@ export const LoaderCommonFactory = ({
     });
 
     QUnit.test('regularly checks the buffer while unpaused', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(90));
 
@@ -268,7 +279,7 @@ export const LoaderCommonFactory = ({
     });
 
     QUnit.test('does not check the buffer while paused', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(90));
 
         loader.load();
@@ -296,7 +307,7 @@ export const LoaderCommonFactory = ({
       const segment = testData();
       const segmentBytes = segment.byteLength;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(10));
 
@@ -459,7 +470,7 @@ export const LoaderCommonFactory = ({
           progresses++;
         });
 
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
           loader.playlist(playlistWithDuration(20));
           loader.load();
@@ -512,7 +523,7 @@ export const LoaderCommonFactory = ({
 
     if (initSegments) {
       QUnit.test('downloads init segments if specified', function(assert) {
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
           const playlist = playlistWithDuration(20);
           const map = {
             resolvedUri: 'mainInitSegment',
@@ -558,7 +569,7 @@ export const LoaderCommonFactory = ({
       });
 
       QUnit.test('detects init segment changes and downloads it', function(assert) {
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
           const playlist = playlistWithDuration(20);
           const buffered = videojs.createTimeRanges();
 
@@ -665,7 +676,7 @@ export const LoaderCommonFactory = ({
     });
 
     QUnit.test('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(50, {
           mediaSequence: 0,
@@ -750,7 +761,7 @@ export const LoaderCommonFactory = ({
         });
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         // Setting currentTime to 31 so that we start requesting at segment #3
         this.currentTime = 31;
@@ -825,7 +836,7 @@ export const LoaderCommonFactory = ({
     // only main/fmp4 segment loaders use async appends and parts/partIndex
     if (usesAsyncAppends) {
       QUnit.test('playlist change before any appends does not error', function(assert) {
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           loader.playlist(playlistWithDuration(50, {
             uri: 'bar-720.m3u8',
             mediaSequence: 0,
@@ -855,7 +866,7 @@ export const LoaderCommonFactory = ({
       });
 
       QUnit.test('mediaIndex and partIndex are used', function(assert) {
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           loader.playlist(playlistWithDuration(50, {
             mediaSequence: 0,
             endList: false,
@@ -874,7 +885,7 @@ export const LoaderCommonFactory = ({
       });
 
       QUnit.test('mediaIndex and partIndex survive playlist change', function(assert) {
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           loader.playlist(playlistWithDuration(50, {
             mediaSequence: 0,
             endList: false,
@@ -903,7 +914,7 @@ export const LoaderCommonFactory = ({
 
       QUnit.test('drops partIndex if playlist update drops parts', function(assert) {
         loader.duration_ = () => Infinity;
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           loader.playlist(playlistWithDuration(50, {
             mediaSequence: 0,
             endList: false,
@@ -1009,7 +1020,7 @@ export const LoaderCommonFactory = ({
     });
 
     QUnit.test('dispose cleans up outstanding work', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(20));
 
@@ -1204,7 +1215,7 @@ export const LoaderCommonFactory = ({
     QUnit.test(
       'does not skip over segment if live playlist update occurs while processing',
       function(assert) {
-        return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           const playlist = playlistWithDuration(40);
 
           playlist.endList = false;
@@ -1271,7 +1282,7 @@ export const LoaderCommonFactory = ({
         handleAppendsDone_();
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         const playlist = playlistWithDuration(40);
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -67,8 +67,10 @@ export const LoaderCommonHooks = {
 
     this.video = document.createElement('video');
 
-    this.setupMediaSource = (a, b, c) => {
-      return setupMediaSource(a, b, videojs.mergeOptions({videoEl: this.video}, c));
+    this.setupMediaSource = (mediaSource, sourceUpdater, options) => {
+      return setupMediaSource(mediaSource, sourceUpdater, videojs.mergeOptions({
+        videoEl: this.video
+      }, options));
     };
   },
   afterEach(assert) {

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -151,6 +151,8 @@ QUnit.test('changing sources does not break ability to skip gap at beginning of 
   let vhsGapSkipEvents = 0;
   let hlsGapSkipEvents = 0;
 
+  this.player.dispose();
+
   this.player = createPlayer({
     html5: {
       vhs: {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -15,7 +15,6 @@ import mp4probe from 'mux.js/lib/mp4/probe';
 import {
   playlistWithDuration,
   standardXHRResponse,
-  setupMediaSource,
   MockTextTrack
 } from './test-helpers.js';
 import {
@@ -831,7 +830,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('only appends one segment at a time', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(10));
         loader.load();
@@ -866,7 +865,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         return ogPost.call(loader.transmuxer_, message);
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -926,7 +925,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         return retval;
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -954,7 +953,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('segmentKey will cache new encrypted keys with cacheEncryptionKeys true', function(assert) {
       loader.cacheEncryptionKeys_ = true;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(10, { isEncrypted: true }));
         loader.load();
         this.clock.tick(1);
@@ -975,7 +974,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('segmentKey will not cache encrypted keys with cacheEncryptionKeys false', function(assert) {
       loader.cacheEncryptionKeys_ = false;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(10, { isEncrypted: true }));
         loader.load();
         this.clock.tick(1);
@@ -993,7 +992,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('new segment requests will use cached keys', function(assert) {
       loader.cacheEncryptionKeys_ = true;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1045,7 +1044,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('new segment request keys every time', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1089,7 +1088,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('triggers syncinfoupdate before attempting a resync', function(assert) {
       let syncInfoUpdates = 0;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(20));
         loader.load();
         this.clock.tick(1);
@@ -1127,7 +1126,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('abort does not cancel segment appends in progress', function(assert) {
       const done = assert.async();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.one('appending', () => {
           loader.abort();
           this.clock.tick(1);
@@ -1147,7 +1146,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('appendsdone happens after appends complete', function(assert) {
       const done = assert.async();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(20));
         loader.load();
         this.clock.tick(1);
@@ -1163,7 +1162,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('appendsdone does not happen after abort during append', function(assert) {
       const done = assert.async();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         let appendsdone = false;
 
         loader.one('appendsdone', () => {
@@ -1213,7 +1212,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       playlist.discontinuityStarts = [1];
       playlist.segments[1].timeline = 1;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1245,7 +1244,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       // represents the same (and a valid) case.
       loader.currentTime_ = () => 70;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlist);
         loader.load();
         this.clock.tick(1);
@@ -1279,7 +1278,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       playlist.discontinuityStarts = [1];
       playlist.segments[1].timeline = 1;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1319,7 +1318,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       playlist.discontinuityStarts = [1];
       playlist.segments[1].timeline = 1;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1360,7 +1359,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       playlist.discontinuityStarts = [1];
       playlist.segments[1].timeline = 1;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1409,7 +1408,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       let ranFinish = false;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const origFinish = loader.segmentRequestFinished_.bind(loader);
 
         // Although overriding the internal function isn't the cleanest way to test, it's
@@ -1464,7 +1463,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       playlist.discontinuityStarts = [1];
       playlist.segments[1].timeline = 1;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlist);
         // demuxed
         loader.setAudio(false);
@@ -1525,7 +1524,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('main loader updates main and audio timeline changes on appends when muxed', function(assert) {
       const playlist = playlistWithDuration(20);
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlist);
         loader.load();
         this.clock.tick(1);
@@ -1581,7 +1580,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('main loader updates only main timeline changes on appends when demuxed', function(assert) {
       const playlist = playlistWithDuration(20);
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlist);
         // demuxed
         loader.setAudio(false);
@@ -1646,7 +1645,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       this.fakeMainTimelineChange();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -1699,7 +1698,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         timestampOffsetEvents++;
       });
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, { isVideoOnly: true }).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, { isVideoOnly: true }).then(() => {
 
         // The transmuxer's timestamp offset is set at different times than the source
         // buffers' timestamp offsets. Since keepOriginalTimestamps is set to true, the
@@ -1856,7 +1855,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         origSaveSegmentTimingInfo({ segmentInfo, shouldSaveTimelineMapping });
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlist);
         loader.load();
         this.clock.tick(1);
@@ -1876,7 +1875,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('main loader saves timeline mapping', function(assert) {
       const syncController = loader.syncController_;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(20));
         loader.load();
         this.clock.tick(1);
@@ -1903,7 +1902,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       const syncController = loader.syncController_;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
 
           loader.one('appended', resolve);
@@ -1923,7 +1922,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('tracks segment end times as they are buffered', function(assert) {
       const playlist = playlistWithDuration(20);
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlist);
         loader.load();
@@ -1952,7 +1951,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         addCue: addCueSpy
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(50));
         loader.load();
@@ -1996,7 +1995,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         addCue: addCueSpy
       };
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(50));
         loader.load();
 
@@ -2033,7 +2032,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       }];
       const addCueSpy = sinon.spy();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.on('appending', () => {
           // Simulate an id3Frame event happening that will call handleId3_
           loader.handleId3_(loader.pendingSegment_, metadataCues, dispatchType);
@@ -2088,7 +2087,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       }];
       const addCueSpy = sinon.spy();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.on('appending', () => {
           // Simulate a caption event happening that will call handleCaptions_
           loader.handleCaptions_(loader.pendingSegment_, captions);
@@ -2137,7 +2136,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       const addCueSpy = sinon.spy();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.on('appending', () => {
           // Simulate a caption event happening that will call handleCaptions_
           const dispatchType = 0x10;
@@ -2186,7 +2185,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('fires ended at the end of a playlist', function(assert) {
       let endOfStreams = 0;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.on('ended', () => endOfStreams++);
         loader.playlist(playlistWithDuration(10));
         loader.load();
@@ -2209,7 +2208,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       let endOfStreams = 0;
       let bandwidthupdates = 0;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.on('ended', () => endOfStreams++);
 
         loader.on('bandwidthupdate', () => {
@@ -2244,7 +2243,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('live playlists do not trigger ended', function(assert) {
       let endOfStreams = 0;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(10);
 
         loader.on('ended', () => endOfStreams++);
@@ -2271,7 +2270,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       const playlistUpdated = playlistWithDuration(40);
       const playlist = playlistWithDuration(40);
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         playlist.endList = false;
 
@@ -2334,7 +2333,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       // playlist updated during waiting
       const playlistUpdated = playlistWithDuration(40);
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         playlist.endList = false;
 
         loader.playlist(playlist);
@@ -2399,7 +2398,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
     QUnit.test('errors when trying to switch from audio and video to audio only', function(assert) {
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -2435,7 +2434,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
     QUnit.test('errors when trying to switch from audio only to audio and video', function(assert) {
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
 
           loader.one('appended', resolve);
@@ -2476,7 +2475,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       loader.on('error', () => errors.push(loader.error()));
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         const playlist = playlistWithDuration(40);
 
@@ -2506,7 +2505,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('dispose cleans up transmuxer', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         loader.playlist(playlistWithDuration(20));
         const transmuxer = loader.transmuxer_;
 
@@ -2529,7 +2528,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('calling remove removes cues', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         const playlist = playlistWithDuration(40);
 
@@ -2577,7 +2576,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('calling remove handles absence of cues (null)', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -2607,7 +2606,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('only removes video when audio disabled', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         const playlist = playlistWithDuration(40);
 
@@ -2645,7 +2644,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('removes audio when audio disabled', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         const playlist = playlistWithDuration(40);
 
@@ -2684,7 +2683,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       let audioRemoves = 0;
       let videoRemoves = 0;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -2722,7 +2721,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       let audioRemoves = 0;
       let videoRemoves = 0;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -2760,7 +2759,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('triggers appenderror when append errors', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appenderror', resolve);
           loader.one('error', reject);
@@ -2793,7 +2792,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('appends init segments initially', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -2824,7 +2823,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('does not append init segments after first', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -2869,7 +2868,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('does not re-append audio init segment when audio only', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, { isAudioOnly: true }).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, { isAudioOnly: true }).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -2909,7 +2908,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('re-appends audio init segment on playlist changes', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isAudioOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isAudioOnly: true}).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -2958,7 +2957,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('re-appends video init segment on playlist changes', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -3007,7 +3006,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       const appends = [];
       const logs = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
 
         // set the mediaSource duration as it is usually set by
         // master playlist controller, which is not present here
@@ -3073,7 +3072,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('re-appends init segments on discontinuity', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -3119,7 +3118,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       const appends = [];
       const oldTrackInfo = loader.handleTrackInfo_;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -3174,7 +3173,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       }), {});
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isAudioOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isAudioOnly: true}).then(() => {
         const origAppendToSourceBuffer = loader.appendToSourceBuffer_.bind(loader);
 
         loader.appendToSourceBuffer_ = (config) => {
@@ -3288,7 +3287,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     QUnit.test('stores and reuses video init segments from map tag', function(assert) {
       const appends = [];
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_, {isVideoOnly: true}).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -3405,7 +3404,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         return { track: { addCue: () => {} } };
       };
 
-      return setupMediaSource(loader.mediaSource_, sourceUpdater).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, sourceUpdater).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -3516,7 +3515,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       loader.buffered_ = () => buffered;
 
-      return setupMediaSource(loader.mediaSource_, sourceUpdater).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, sourceUpdater).then(() => {
         const origAudioTimestampOffset =
           sourceUpdater.audioTimestampOffset.bind(sourceUpdater);
         const origVideoTimestampOffset =
@@ -3618,7 +3617,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('main buffered uses video buffer when audio disabled', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -3656,7 +3655,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('main buffered uses video buffer when video only', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -3694,7 +3693,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('main buffered uses audio buffer when audio only', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -3736,7 +3735,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       this.fakeMainTimelineChange();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           loader.one('appended', resolve);
           loader.one('error', reject);
@@ -3776,7 +3775,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       this.fakeMainTimelineChange();
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -3808,7 +3807,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('can get buffered between playlists', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -3931,7 +3930,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       } = loader;
       const mediaSettings = { isVideoOnly: true };
 
-      return setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
+      return this.setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
         loader.playlist(playlist);
         loader.load();
 
@@ -3990,7 +3989,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       } = loader;
       const mediaSettings = { isVideoOnly: true };
 
-      return setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
+      return this.setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
         loader.playlist(playlist);
         loader.load();
 
@@ -4059,7 +4058,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       } = loader;
       const mediaSettings = { isAudioOnly: true };
 
-      return setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
+      return this.setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
         loader.playlist(playlist);
         loader.load();
 
@@ -4118,7 +4117,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       } = loader;
       const mediaSettings = { isAudioOnly: true };
 
-      return setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
+      return this.setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
         loader.playlist(playlist);
         loader.load();
 
@@ -4227,7 +4226,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       } = loader;
       const mediaSettings = { isVideoOnly: true };
 
-      return setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
+      return this.setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
         loader.playlist(playlist1);
 
         // uses private property of sync controller because there isn't a great way
@@ -4336,7 +4335,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       } = loader;
       const mediaSettings = { isVideoOnly: true };
 
-      return setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
+      return this.setupMediaSource(mediaSource, sourceUpdater, mediaSettings).then(() => {
         loader.playlist(playlist1);
         loader.load();
 
@@ -4415,7 +4414,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('QUOTA_EXCEEDED_ERR no loader error triggered', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -4436,7 +4435,7 @@ QUnit.module('SegmentLoader', function(hooks) {
     });
 
     QUnit.test('QUOTA_EXCEEDED_ERR triggers error if no room for single segment', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         return new Promise((resolve, reject) => {
           const playlist = playlistWithDuration(40);
 
@@ -4474,7 +4473,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       const removeAudioCalls = [];
       let origAppendBuffer;
 
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const playlist = playlistWithDuration(40);
 
         loader.playlist(playlist);
@@ -4602,7 +4601,7 @@ QUnit.module('SegmentLoader: FMP4', function(hooks) {
     });
 
     QUnit.test('CaptionParser messages sent as expected', function(assert) {
-      return setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
         const actions = {};
 
         loader.transmuxer_.postMessage = ({action}) => {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -186,8 +186,13 @@ export const useFakeEnvironment = function(assert) {
   const realXMLHttpRequest = videojs.xhr.XMLHttpRequest;
 
   const fakeEnvironment = {
+    objurls: [],
     requests: [],
     restore() {
+      fakeEnvironment.objurls.forEach(function(objurl) {
+        window.URL.revokeObjectURL(objurl);
+      });
+      window.URL.createObjectURL = realCreateObjectURL;
       this.clock.restore();
       videojs.xhr.XMLHttpRequest = realXMLHttpRequest;
       this.xhr.restore();
@@ -244,6 +249,14 @@ export const useFakeEnvironment = function(assert) {
     fakeEnvironment.requests.push(xhr);
   };
   videojs.xhr.XMLHttpRequest = fakeEnvironment.xhr;
+
+  window.URL.createObjectURL = (object) => {
+    const objurl = realCreateObjectURL(object);
+
+    fakeEnvironment.objurls.push(objurl);
+
+    return objurl;
+  };
 
   return fakeEnvironment;
 };

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -739,13 +739,14 @@ QUnit.test('codecs are passed to the source buffer', function(assert) {
 });
 
 QUnit.test('including HLS as a tech does not error', function(assert) {
-  const player = createPlayer({
+  this.player.dispose();
+  this.player = createPlayer({
     techOrder: ['vhs', 'html5']
   });
 
   this.clock.tick(1);
 
-  assert.ok(player, 'created the player');
+  assert.ok(this.player, 'created the player');
   assert.equal(this.env.log.warn.calls, 2, 'logged two warnings for deprecations');
 });
 
@@ -5040,6 +5041,7 @@ QUnit[testOrSkip](
       useBandwidthFromLocalStorage: true
     };
     // values must be stored before player is created, otherwise defaults are provided
+    this.player.dispose();
     this.player = createPlayer();
     this.player.tech_.on('usage', usageListener);
     this.player.src({


### PR DESCRIPTION
## Description
Chrome 92 requires media elements to be torn down completely before they are removed from memory. This includes unsetting the src property and removing the src attribute. 

This is only an issue when a lot of players are created and disposed on a page. For us this mostly happens in tests.

The error in question:
Blocked attempt to create a WebMediaPlayer as there are too many WebMediaPlayers already in existence. See crbug.com/1144736#c27
