### PR TITLE
fix: Generate the correct number of segments for segment template multi period dash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6540,9 +6540,9 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.17.0.tgz",
-      "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.18.0.tgz",
+      "integrity": "sha512-5Y/JDuuTP/0cQCiDdP18zqD7g5woaBegcH2lCezuc26YHpY2XovI8exYKbJQ115U5+7Xnv0N9EjI8c+x0MR85A==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",
-    "mpd-parser": "0.17.0",
+    "mpd-parser": "0.18.0",
     "mux.js": "5.12.2",
     "video.js": "^6 || ^7"
   },

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -242,6 +242,32 @@ QUnit[testFn]('Live DASH', function(assert) {
   });
 });
 
+QUnit[testFn]('Multiperiod dash works and can end', function(assert) {
+  const done = assert.async();
+
+  assert.expect(2);
+  const player = this.player;
+
+  playFor(player, 2, function() {
+    assert.ok(true, 'played for at least two seconds');
+    assert.equal(player.error(), null, 'has no player errors');
+
+    player.one('ended', () => {
+      assert.ok(true, 'triggered ended event');
+      done();
+    });
+
+    player.currentTime(player.duration() - 0.5);
+
+    done();
+  });
+
+  player.src({
+    src: 'https://media.axprod.net/TestVectors/v7-Clear/Manifest_MultiPeriod.mpd',
+    type: 'application/dash+xml'
+  });
+});
+
 // These videos don't work on firefox consistenly. Seems like
 // firefox has lower performance or more aggressive throttling than chrome
 // which causes a variety of issues.


### PR DESCRIPTION
This is done via an update to version v0.18.0 of mpd-parser. see the [mpd-parser changelog](https://github.com/videojs/mpd-parser/blob/main/CHANGELOG.md)

Fixes sources like `Axinom Clear MultiPeriod - DASH, 4k, HEVC`