### PR TITLE
fix: Keep media update timeout alive so live playlists can recover

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -63,18 +63,23 @@ const shouldSwitchToMedia = function({
 
   const sharedLogLine = `allowing switch ${currentPlaylist && currentPlaylist.id || 'null'} -> ${nextPlaylist.id}`;
 
+  if (!currentPlaylist) {
+    log(`${sharedLogLine} as current playlist is not set`);
+    return true;
+  }
+
+  // no need to switch if playlist is the same
+  if (nextPlaylist.id === currentPlaylist.id) {
+    return false;
+  }
+
   // If the playlist is live, then we want to not take low water line into account.
   // This is because in LIVE, the player plays 3 segments from the end of the
   // playlist, and if `BUFFER_LOW_WATER_LINE` is greater than the duration availble
   // in those segments, a viewer will never experience a rendition upswitch.
-  if (!currentPlaylist) {
-    log(`${sharedLogLine} as current playlist ` + (!currentPlaylist ? 'is not set' : 'is live'));
+  if (!currentPlaylist.endList) {
+    log(`${sharedLogLine} as current playlist is live`);
     return true;
-  }
-
-  // no need to switch playlist is the same
-  if (nextPlaylist.id === currentPlaylist.id) {
-    return false;
   }
 
   const maxBufferLowWaterLine = experimentalBufferBasedABR ?
@@ -351,7 +356,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
   checkABR_() {
     const nextPlaylist = this.selectPlaylist();
 
-    if (this.shouldSwitchToMedia_(nextPlaylist)) {
+    if (nextPlaylist && this.shouldSwitchToMedia_(nextPlaylist)) {
       this.switchMedia_(nextPlaylist, 'abr');
     }
   }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -67,7 +67,7 @@ const shouldSwitchToMedia = function({
   // This is because in LIVE, the player plays 3 segments from the end of the
   // playlist, and if `BUFFER_LOW_WATER_LINE` is greater than the duration availble
   // in those segments, a viewer will never experience a rendition upswitch.
-  if (!currentPlaylist || !currentPlaylist.endList) {
+  if (!currentPlaylist) {
     log(`${sharedLogLine} as current playlist ` + (!currentPlaylist ? 'is not set' : 'is live'));
     return true;
   }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -613,6 +613,11 @@ export default class PlaylistLoader extends EventTarget {
       return;
     }
 
+    // We update/set the timeout here so that live playlists
+    // that are not a media change will "start" the loader as expected.
+    // We expect that this function will start the media update timeout
+    // cycle again. This also prevents a playlist switch failure from
+    // causing us to stall during live.
     this.updateMediaUpdateTimeout_(refreshDelay(playlist, true));
 
     // switching to the active playlist is a no-op

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -705,6 +705,10 @@ export default class PlaylistLoader extends EventTarget {
    * start loading of the playlist
    */
   load(shouldDelay) {
+    if (this.mediaUpdateTimeout) {
+      window.clearTimeout(this.mediaUpdateTimeout);
+      this.mediaUpdateTimeout = null;
+    }
     const media = this.media();
 
     if (shouldDelay) {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2033,6 +2033,36 @@ QUnit.test(
 
     mediaChanges.length = 0;
 
+    endList = false;
+    currentTime = 100;
+    currentPlaylistBandwidth = 1000;
+    nextPlaylistBandwidth = 1001;
+    buffered = [];
+    this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
+    assert.equal(
+      mediaChanges.length,
+      1,
+      'changes live media when no buffer and higher bandwidth playlist'
+    );
+    buffered = [[0, 100], [100, 109]];
+    this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
+    assert.equal(
+      mediaChanges.length,
+      2,
+      'changes live media when insufficient forward buffer and higher ' +
+               'bandwidth playlist'
+    );
+    buffered = [[0, 100], [100, 130]];
+    this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
+    assert.equal(
+      mediaChanges.length,
+      3,
+      'changes live media when sufficient forward buffer and higher ' +
+               'bandwidth playlist'
+    );
+
+    mediaChanges.length = 0;
+
     endList = true;
     currentTime = 9;
     duration = 18;
@@ -5852,6 +5882,15 @@ QUnit.test('true if a no current playlist', function(assert) {
   const nextPlaylist = {id: 'foo', endList: true};
 
   assert.ok(mpc.shouldSwitchToMedia_(nextPlaylist), 'should switch without currentPlaylist');
+});
+
+QUnit.test('true if current playlist is live', function(assert) {
+  const mpc = this.masterPlaylistController;
+
+  mpc.masterPlaylistLoader_.media = () => ({endList: false, id: 'bar'});
+  const nextPlaylist = {id: 'foo', endList: true};
+
+  assert.ok(mpc.shouldSwitchToMedia_(nextPlaylist), 'should switch with live currentPlaylist');
 });
 
 QUnit.test('true if duration < 30', function(assert) {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2033,36 +2033,6 @@ QUnit.test(
 
     mediaChanges.length = 0;
 
-    endList = false;
-    currentTime = 100;
-    currentPlaylistBandwidth = 1000;
-    nextPlaylistBandwidth = 1001;
-    buffered = [];
-    this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
-    assert.equal(
-      mediaChanges.length,
-      1,
-      'changes live media when no buffer and higher bandwidth playlist'
-    );
-    buffered = [[0, 100], [100, 109]];
-    this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
-    assert.equal(
-      mediaChanges.length,
-      2,
-      'changes live media when insufficient forward buffer and higher ' +
-               'bandwidth playlist'
-    );
-    buffered = [[0, 100], [100, 130]];
-    this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
-    assert.equal(
-      mediaChanges.length,
-      3,
-      'changes live media when sufficient forward buffer and higher ' +
-               'bandwidth playlist'
-    );
-
-    mediaChanges.length = 0;
-
     endList = true;
     currentTime = 9;
     duration = 18;
@@ -5882,15 +5852,6 @@ QUnit.test('true if a no current playlist', function(assert) {
   const nextPlaylist = {id: 'foo', endList: true};
 
   assert.ok(mpc.shouldSwitchToMedia_(nextPlaylist), 'should switch without currentPlaylist');
-});
-
-QUnit.test('true if current playlist is live', function(assert) {
-  const mpc = this.masterPlaylistController;
-
-  mpc.masterPlaylistLoader_.media = () => ({endList: false, id: 'bar'});
-  const nextPlaylist = {id: 'foo', endList: true};
-
-  assert.ok(mpc.shouldSwitchToMedia_(nextPlaylist), 'should switch with live currentPlaylist');
 });
 
 QUnit.test('true if duration < 30', function(assert) {

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -683,6 +683,22 @@ QUnit.module('Playlist Loader', function(hooks) {
     );
   });
 
+  QUnit.test('can delay load', function(assert) {
+    const loader = new PlaylistLoader('master.m3u8', this.fakeVhs);
+
+    assert.notOk(loader.mediaUpdateTimeout, 'no media update timeout');
+
+    loader.load(true);
+
+    assert.ok(loader.mediaUpdateTimeout, 'have a media update timeout now');
+    assert.strictEqual(this.requests.length, 0, 'have no requests');
+
+    this.clock.tick(5000);
+
+    assert.notOk(loader.mediaUpdateTimeout, 'media update timeout is gone');
+    assert.strictEqual(this.requests.length, 1, 'playlist request after delay');
+  });
+
   QUnit.test('starts without any metadata', function(assert) {
     const loader = new PlaylistLoader('master.m3u8', this.fakeVhs);
 

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -2101,7 +2101,7 @@ QUnit.module('Playlist Loader', function(hooks) {
     );
   });
 
-  QUnit.test('mediaupdatetimeout works as expeted for live playlists', function(assert) {
+  QUnit.test('mediaupdatetimeout works as expected for live playlists', function(assert) {
     const loader = new PlaylistLoader('master.m3u8', this.fakeVhs);
     let media =
       '#EXTM3U\n' +


### PR DESCRIPTION
## Description
Right now for live hls streams we can be stuck buffering even though we should have recovered because we don't attempt to retry requests. You can reproduce this:

1. Select `Unified Streaming Live HLS` 
2. Play
3. Set network to offline in dev tools
4. Wait for the player to stall
5. Set network back to normal in dev tools
6. Player will never recover

This happens because we exclude and pause the current playlist loader when it fails a request.  Then we switch to same playlist again and since it is the same playlist we don't try to request it again. So now we have no mediaUpdateTimeout and we did not request the playlist again.

## The fix
1. We need a way to make sure that we start a mediaUpdateTimeout in `media`
2. We need mediaUpdateTimeouts to create media update timeouts 
3. We do not need to **always** return `true` in `shouldSwitchToMedia` for live playlists if the playlist is the same. This gave us state we have now as we were relying on abr to refresh live playlists in some scenarios.