### PR TITLE
feat: use new mpd-parser API for handling live DASH refreshes

### DIFF
--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -2260,6 +2260,35 @@ QUnit.test('returns to HAVE_METADATA after refreshing the playlist', function(as
   assert.strictEqual(loader.state, 'HAVE_METADATA', 'the state is correct');
 });
 
+QUnit.test('refreshes of live playlists are relative to old ones', function(assert) {
+  const loader = new DashPlaylistLoader('dash-live-refresh-1.mpd', this.fakeVhs);
+
+  loader.load();
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.equal(
+    loader.master.playlists[0].mediaSequence,
+    0,
+    'created manifest relative to start'
+  );
+
+  // 2s, one minimum update period
+  this.clock.tick(2 * 1000);
+
+  // dash-live-refresh-1 uses Location to change to dash-live-refresh-2
+  assert.ok(
+    this.requests[0].url.endsWith('dash-live-refresh-2.mpd'),
+    'requesting refreshed manifest'
+  );
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.equal(
+    loader.master.playlists[0].mediaSequence,
+    1,
+    'created manifest relative to original'
+  );
+});
+
 QUnit.test('triggers an event when the active media changes', function(assert) {
   // NOTE: this test relies upon calls to media behaving as though they are
   // asynchronous operations.

--- a/test/manifests/dash-live-refresh-1.mpd
+++ b/test/manifests/dash-live-refresh-1.mpd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:cenc="urn:mpeg:cenc:2013"
+  availabilityStartTime="2021-03-18T20:00:36Z"
+  maxSegmentDuration="PT2S"
+  minBufferTime="PT2S"
+  minimumUpdatePeriod="PT2S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  publishTime="2021-03-18T20:32:55Z"
+  suggestedPresentationDelay="PT6S"
+  timeShiftBufferDepth="PT180.000S"
+  type="dynamic"
+  xmlns="urn:mpeg:dash:schema:mpd:2011">
+    <Location>dash-live-refresh-2.mpd</Location>
+    <Period id="100" start="PT100S">
+        <AdaptationSet
+          audioSamplingRate="48000"
+          contentType="audio"
+          group="1"
+          lang="en"
+          mimeType="audio/mp4"
+          segmentAlignment="true"
+          startWithSAP="1">
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+            <Representation bandwidth="129262" codecs="mp4a.40.5" id="v0">
+                <AudioChannelConfiguration
+                  schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+                  value="2" />
+                <BaseURL>http://example.com/audio/1</BaseURL>
+                <SegmentTemplate
+                  initialization="init.mp4"
+                  media="$Number%03d$.m4f"
+                  startNumber="500"
+                  timescale="1">
+                    <SegmentTimeline>
+                        <S d="1" r="1" t="0" />
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet
+          contentType="video"
+          id="1"
+          maxFrameRate="60.0"
+          maxHeight="720"
+          maxWidth="1280"
+          mimeType="video/mp4"
+          segmentAlignment="true"
+          startWithSAP="1">
+            <Representation
+              bandwidth="2942295"
+              codecs="avc1.4d001f"
+              frameRate="30.0"
+              height="720"
+              id="A"
+              scanType="progressive"
+              width="1280">
+                <BaseURL>http://example.com/video/D/</BaseURL>
+                <SegmentTemplate
+                  initialization="$RepresentationID$_init.mp4"
+                  media="$RepresentationID$$Number%03d$.m4f"
+                  startNumber="500"
+                  timescale="1">
+                    <SegmentTimeline>
+                        <S d="1" r="1" t="0" />
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/test/manifests/dash-live-refresh-2.mpd
+++ b/test/manifests/dash-live-refresh-2.mpd
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:cenc="urn:mpeg:cenc:2013"
+  availabilityStartTime="2021-03-18T20:00:36Z"
+  maxSegmentDuration="PT2S"
+  minBufferTime="PT2S"
+  minimumUpdatePeriod="PT2S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  publishTime="2021-03-18T20:32:55Z"
+  suggestedPresentationDelay="PT6S"
+  timeShiftBufferDepth="PT180.000S"
+  type="dynamic"
+  xmlns="urn:mpeg:dash:schema:mpd:2011">
+    <Period id="100" start="PT101S">
+        <AdaptationSet
+          audioSamplingRate="48000"
+          contentType="audio"
+          group="1"
+          lang="en"
+          mimeType="audio/mp4"
+          segmentAlignment="true"
+          startWithSAP="1">
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+            <Representation bandwidth="129262" codecs="mp4a.40.5" id="v0">
+                <AudioChannelConfiguration
+                  schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+                  value="2" />
+                <BaseURL>http://example.com/audio/1</BaseURL>
+                <SegmentTemplate
+                  initialization="init.mp4"
+                  media="$Number%03d$.m4f"
+                  startNumber="500"
+                  timescale="1">
+                    <SegmentTimeline>
+                        <S d="1" t="0" />
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet
+          contentType="video"
+          id="1"
+          maxFrameRate="60.0"
+          maxHeight="720"
+          maxWidth="1280"
+          mimeType="video/mp4"
+          segmentAlignment="true"
+          startWithSAP="1">
+            <Representation
+              bandwidth="2942295"
+              codecs="avc1.4d001f"
+              frameRate="30.0"
+              height="720"
+              id="A"
+              scanType="progressive"
+              width="1280">
+                <BaseURL>http://example.com/video/D/</BaseURL>
+                <SegmentTemplate
+                  initialization="$RepresentationID$_init.mp4"
+                  media="$RepresentationID$$Number%03d$.m4f"
+                  startNumber="500"
+                  timescale="1">
+                    <SegmentTimeline>
+                        <S d="1" t="0" />
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>


### PR DESCRIPTION
In order to support the new mpd-parser API, anytime a live DASH manifest
refreshes, the prior parsed manifest object needs to be passed in as
`lastMpd`. This change adds support for that.

NOTE: this is to support an upcoming feature in mpd-parser: https://github.com/videojs/mpd-parser/pull/144

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
