### PR TITLE
fix: only register reloadSourceOnError once

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1264,10 +1264,10 @@ if (!videojs.use) {
 videojs.options.vhs = videojs.options.vhs || {};
 videojs.options.hls = videojs.options.hls || {};
 
-if (videojs.registerPlugin) {
-  videojs.registerPlugin('reloadSourceOnError', reloadSourceOnError);
-} else {
-  videojs.plugin('reloadSourceOnError', reloadSourceOnError);
+if (!videojs.getPlugin || !videojs.getPlugin('reloadSourceOnError')) {
+  const registerPlugin = videojs.registerPlugin || videojs.plugin;
+
+  registerPlugin('reloadSourceOnError', reloadSourceOnError);
 }
 
 export {


### PR DESCRIPTION
Only register our reloadSourceOnError plugin once.

See https://github.com/brightcove/player-loader/issues/78