### PR TITLE
feat: Add ability to pass encoding value for 708 captions via captionServices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+<a name="2.10.2"></a>
+## [2.10.2](https://github.com/videojs/http-streaming/compare/v2.10.1...v2.10.2) (2021-08-24)
+
+### Bug Fixes
+
+* update mpd-parser and mux.js to fix an xmldom vulnerability ([#1190](https://github.com/videojs/http-streaming/issues/1190)) ([37b4b04](https://github.com/videojs/http-streaming/commit/37b4b04))
+
+<a name="2.10.1"></a>
+## [2.10.1](https://github.com/videojs/http-streaming/compare/v2.10.0...v2.10.1) (2021-08-17)
+
+### Bug Fixes
+
+* keep media update timeout alive so live playlists can recover from network issues ([#1176](https://github.com/videojs/http-streaming/issues/1176)) ([8b3533c](https://github.com/videojs/http-streaming/commit/8b3533c))
+
+### Chores
+
+* add a github-release action to automate github releases on version tags ([#1182](https://github.com/videojs/http-streaming/issues/1182)) ([e8230a9](https://github.com/videojs/http-streaming/commit/e8230a9))
+* consistent source selection on demo start ([#1185](https://github.com/videojs/http-streaming/issues/1185)) ([ff34277](https://github.com/videojs/http-streaming/commit/ff34277))
+* update the demo page ([#1184](https://github.com/videojs/http-streaming/issues/1184)) ([55f0bde](https://github.com/videojs/http-streaming/commit/55f0bde))
+* various demo page fixes and enhancements ([#1186](https://github.com/videojs/http-streaming/issues/1186)) ([eef29d4](https://github.com/videojs/http-streaming/commit/eef29d4))
+
 <a name="2.10.1"></a>
 ## [2.10.1](https://github.com/videojs/http-streaming/compare/v2.10.0...v2.10.1) (2021-08-17)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Video.js Compatibility: 6.0, 7.0
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
   - [NPM](#npm)
   - [CDN](#cdn)
@@ -482,6 +481,9 @@ This option defaults to `false`.
 The captionServices options object has properties that map to the caption services. Each property is an object itself that includes several properties, like a label or language.
 
 For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 captions, the service names are `SERVICEn` where `n` is a digit between `1` and `63`.
+
+For 708 caption services, you may additionally provide an `encoding` value that will be used by the transmuxer to decode the captions using an instance of [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder). This is to permit and is required for legacy multi-byte encodings. Please review the `TextDecoder` documentation for accepted encoding labels.
+
 ###### Format
 ```js
 {
@@ -490,7 +492,8 @@ For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 
       [serviceName]: {
         language: String, // optional
         label: String, // optional
-        default: boolean // optional
+        default: boolean, // optional,
+        encoding: String // optional, 708 services only
       }
     }
   }
@@ -508,7 +511,8 @@ For 608 captions, the service names are `CC1`, `CC2`, `CC3`, and `CC4`. For 708 
       SERVICE1: {
         langauge: 'kr',
         label: 'Korean',
-        default: true
+        encoding: 'euc-kr'
+        default: true,
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@videojs/http-streaming",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6487,9 +6487,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.13.0.tgz",
-      "integrity": "sha512-PkmnzHcTQjUBEHp3KRPQAFoNkJtKlpCEvsYtXDfDrC+/WqbMuxHvoYfmAbHVAH7Sa/KliPVU0dT1ureO8wilog==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.14.0.tgz",
+      "integrity": "sha512-zrOH4TYQrVWWDnLMYzi5LxDMAb8PootOEh4mc6EU0SyYRYLPdaI12Lg0ZLBjlvY7Fmtg3qX16Cu8zaokE1NaRg==",
       "requires": {
         "@babel/runtime": "^7.11.2"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",
     "mpd-parser": "0.19.0",
-    "mux.js": "5.13.0",
+    "mux.js": "5.14.0",
     "video.js": "^6 || ^7"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videojs/http-streaming",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Play back HLS and DASH with Video.js, even where it's not natively supported",
   "main": "dist/videojs-http-streaming.cjs.js",
   "module": "dist/videojs-http-streaming.es.js",

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -150,7 +150,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       sourceType,
       cacheEncryptionKeys,
       experimentalBufferBasedABR,
-      experimentalLeastPixelDiffSelector
+      experimentalLeastPixelDiffSelector,
+      captionServices
     } = options;
 
     if (!src) {
@@ -175,6 +176,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.blacklistDuration = blacklistDuration;
     this.maxPlaylistRetries = maxPlaylistRetries;
     this.enableLowInitialPlaylist = enableLowInitialPlaylist;
+
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack(
         'metadata',
@@ -222,9 +224,20 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.inbandTextTracks_ = {};
     this.timelineChangeController_ = new TimelineChangeController();
 
+    const captionServiceEncodings = {};
+
+    Object.keys(captionServices).forEach(serviceName => {
+      const serviceProps = captionServices[serviceName];
+
+      if (/^SERVICE/.test(serviceName)) {
+        captionServiceEncodings[serviceName] = serviceProps.encoding;
+      }
+    });
+
     const segmentLoaderSettings = {
       vhs: this.vhs_,
       parse708captions: options.parse708captions,
+      captionServiceEncodings,
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
       seekable: () => this.seekable(),

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -224,20 +224,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.inbandTextTracks_ = {};
     this.timelineChangeController_ = new TimelineChangeController();
 
-    const captionServiceEncodings = {};
-
-    Object.keys(captionServices).forEach(serviceName => {
-      const serviceProps = captionServices[serviceName];
-
-      if (/^SERVICE/.test(serviceName)) {
-        captionServiceEncodings[serviceName] = serviceProps.encoding;
-      }
-    });
-
     const segmentLoaderSettings = {
       vhs: this.vhs_,
       parse708captions: options.parse708captions,
-      captionServiceEncodings,
+      captionServices,
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
       seekable: () => this.seekable(),

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -539,6 +539,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.timelineChangeController_ = settings.timelineChangeController;
     this.shouldSaveSegmentTimingInfo_ = true;
     this.parse708captions_ = settings.parse708captions;
+    this.captionServiceEncodings_ = settings.captionServiceEncodings;
     this.experimentalExactManifestTimings = settings.experimentalExactManifestTimings;
 
     // private instance variables
@@ -660,7 +661,8 @@ export default class SegmentLoader extends videojs.EventTarget {
       remux: false,
       alignGopsAtEnd: this.safeAppend_,
       keepOriginalTimestamps: true,
-      parse708captions: this.parse708captions_
+      parse708captions: this.parse708captions_,
+      captionServiceEncodings: this.captionServiceEncodings_
     });
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -539,7 +539,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.timelineChangeController_ = settings.timelineChangeController;
     this.shouldSaveSegmentTimingInfo_ = true;
     this.parse708captions_ = settings.parse708captions;
-    this.captionServiceEncodings_ = settings.captionServiceEncodings;
+    this.captionServices_ = settings.captionServices;
     this.experimentalExactManifestTimings = settings.experimentalExactManifestTimings;
 
     // private instance variables
@@ -662,7 +662,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       alignGopsAtEnd: this.safeAppend_,
       keepOriginalTimestamps: true,
       parse708captions: this.parse708captions_,
-      captionServiceEncodings: this.captionServiceEncodings_
+      captionServices: this.captionServices_
     });
   }
 


### PR DESCRIPTION
## Description
Complementary Mux.js PR: https://github.com/videojs/mux.js/pull/398

The 708 implementation of mux will soon support multibyte character encodings, so this PR adds a way to pass the option to the transmuxer. using the existing `captionServices` options block.
