### PR TITLE
Pr for media sequence

### DIFF
--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -6,6 +6,10 @@ import {sumDurations, getPartsAndSegments} from './playlist';
 import videojs from 'video.js';
 import logger from './util/logger';
 
+// The maximum gap allowed between two media sequence tags when trying to
+// synchronize expired playlist segments.
+const MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC = 1000;
+
 export const syncPointStrategies = [
   // Stategy "VOD": Handle the VOD-case where the sync-point is *always*
   //                the equivalence display-time 0 === segment-index 0
@@ -363,6 +367,11 @@ export default class SyncController extends videojs.EventTarget {
    */
   saveExpiredSegmentInfo(oldPlaylist, newPlaylist) {
     const mediaSequenceDiff = newPlaylist.mediaSequence - oldPlaylist.mediaSequence;
+
+    // Ignore large media sequence gaps
+    if (mediaSequenceDiff > MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC) {
+      return;
+    }
 
     // When a segment expires from the playlist and it has a start time
     // save that information as a possible sync-point reference in future

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -370,6 +370,7 @@ export default class SyncController extends videojs.EventTarget {
 
     // Ignore large media sequence gaps
     if (mediaSequenceDiff > MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC) {
+      videojs.log.warn('Ignoring sync for large media sequence gap');
       return;
     }
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -8,7 +8,10 @@ import logger from './util/logger';
 
 // The maximum gap allowed between two media sequence tags when trying to
 // synchronize expired playlist segments.
-const MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC = 1000;
+// the max media sequence diff is 48 hours of live stream 
+// content with two second segments. Anything larger than that
+// will likely be invalid.
+const MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC = 86400;
 
 export const syncPointStrategies = [
   // Stategy "VOD": Handle the VOD-case where the sync-point is *always*

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -370,7 +370,7 @@ export default class SyncController extends videojs.EventTarget {
 
     // Ignore large media sequence gaps
     if (mediaSequenceDiff > MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC) {
-      videojs.log.warn('Ignoring sync for large media sequence gap');
+      videojs.log.warn('Ignoring sync for large media sequence gap: ' + mediaSequenceDiff);
       return;
     }
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -370,7 +370,7 @@ export default class SyncController extends videojs.EventTarget {
 
     // Ignore large media sequence gaps
     if (mediaSequenceDiff > MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC) {
-      videojs.log.warn('Ignoring sync for large media sequence gap: ' + mediaSequenceDiff);
+      videojs.log.warn(`Not saving expired segment info. Media sequence gap ${mediaSequenceDiff} is too large.`);
       return;
     }
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -8,7 +8,7 @@ import logger from './util/logger';
 
 // The maximum gap allowed between two media sequence tags when trying to
 // synchronize expired playlist segments.
-// the max media sequence diff is 48 hours of live stream 
+// the max media sequence diff is 48 hours of live stream
 // content with two second segments. Anything larger than that
 // will likely be invalid.
 const MAX_MEDIA_SEQUENCE_DIFF_FOR_SYNC = 86400;

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -446,7 +446,7 @@ QUnit.test('skips save of expired segment info if media sequence gap too large',
   const newPlaylist = playlistWithDuration(50);
 
   oldPlaylist.mediaSequence = 100;
-  newPlaylist.mediaSequence = 2000;
+  newPlaylist.mediaSequence = 86501;
 
   oldPlaylist.segments[0].start = 390;
   oldPlaylist.segments[1].start = 400;

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -441,6 +441,24 @@ QUnit.test('saves expired info onto new playlist for sync point', function(asser
   );
 });
 
+QUnit.test('skips save of expired segment info if media sequence gap too large', function(assert) {
+  const oldPlaylist = playlistWithDuration(50);
+  const newPlaylist = playlistWithDuration(50);
+
+  oldPlaylist.mediaSequence = 100;
+  newPlaylist.mediaSequence = 2000;
+
+  oldPlaylist.segments[0].start = 390;
+  oldPlaylist.segments[1].start = 400;
+
+  this.syncController.saveExpiredSegmentInfo(oldPlaylist, newPlaylist);
+
+  assert.strictEqual(
+    typeof newPlaylist.syncInfo, 'undefined',
+    'skipped saving sync info onto new playlist'
+  );
+});
+
 QUnit.test('saves segment timing info', function(assert) {
   const syncCon = this.syncController;
   const playlist = playlistWithDuration(60);


### PR DESCRIPTION
## Description

The browser tab running video.js would show a "Page Unresponsive" dialog in Chrome when the EXT-X-MEDIA-SEQUENCE tag increased by a large number between subsequent m3u8 files. This happened because the saveExpiredSegmentInfo function was iterating over this large number.

This behaviour was raised in [issue 1197](https://github.com/videojs/http-streaming/issues/1197)

## Proposed Solution

The proposed solution is to avoid the browser becoming unresponsive by only iterating over the media sequence difference if it is within a reasonable threshold. 

To determine a reasonable threshold, I looked at Apple's ["Live Playlist (Sliding Window) Construction" page](https://developer.apple.com/documentation/http_live_streaming/example_playlists_for_http_live_streaming/live_playlist_sliding_window_construction) which states:

> The EXT-X-MEDIA-SEQUENCE tag value must be incremented by 1 for every media URI that's removed from the playlist file.

Based on this, I have used a threshold of 1000.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
