### PR TITLE
fix: reset transmuxer in resetEverything

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1146,6 +1146,11 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.transmuxer_.postMessage({
         action: 'clearAllMp4Captions'
       });
+
+      // reset the cache in the transmuxer
+      this.transmuxer_.postMessage({
+        action: 'reset'
+      });
     }
   }
 
@@ -1516,13 +1521,15 @@ export default class SegmentLoader extends videojs.EventTarget {
       segmentInfo.audioAppendStart = audioBufferedEnd - this.sourceUpdater_.audioTimestampOffset();
     }
 
-    segmentInfo.gopsToAlignWith = gopsSafeToAlignWith(
-      this.gopBuffer_,
-      // since the transmuxer is using the actual timing values, but the time is
-      // adjusted by the timestmap offset, we must adjust the value here
-      this.currentTime_() - this.sourceUpdater_.videoTimestampOffset(),
-      this.timeMapping_
-    );
+    if (this.sourceUpdater_.videoBuffered().length) {
+      segmentInfo.gopsToAlignWith = gopsSafeToAlignWith(
+        this.gopBuffer_,
+        // since the transmuxer is using the actual timing values, but the time is
+        // adjusted by the timestmap offset, we must adjust the value here
+        this.currentTime_() - this.sourceUpdater_.videoTimestampOffset(),
+        this.timeMapping_
+      );
+    }
 
     return segmentInfo;
   }


### PR DESCRIPTION
## Description
After a call to `resetEverything` we won't have a videoBuffer. This means that we do not set `segmentInfo.gopsToAlignWith = undefined` as we check for a `videoBuffer` before setting it. Which means that we are still using the previous `gopsToAlignWith` in the transmuxer, which won't be correct. This will cause us to throw out valid video data.
