### PR TITLE
Add an option to calculate bandwidth by using Chromium's networkInfo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Video.js Compatibility: 6.0, 7.0
       - [cacheEncryptionKeys](#cacheencryptionkeys)
       - [handlePartialData](#handlepartialdata)
       - [liveRangeSafeTimeDelta](#liverangesafetimedelta)
+      - [useNetworkInformationApi](#usenetworkinformationapi)
       - [captionServices](#captionservices)
         - [Format](#format)
         - [Example](#example)
@@ -472,6 +473,11 @@ This option defaults to `false`.
 * Type: `number`,
 * Default: [`SAFE_TIME_DELTA`](https://github.com/videojs/http-streaming/blob/e7cb63af010779108336eddb5c8fd138d6390e95/src/ranges.js#L17)
 * Allow to  re-define length (in seconds) of time delta when you compare current time and the end of the buffered range.
+
+##### useNetworkInformationApi
+* Type: `boolean`,
+* Default: `false`
+* Use [window.networkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink) to estimate the network's bandwidth
 
 ##### captionServices
 * Type: `object`

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ This option defaults to `false`.
 ##### useNetworkInformationApi
 * Type: `boolean`,
 * Default: `false`
-* Use [window.networkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink) to estimate the network's bandwidth
+* Use [window.networkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink) to estimate the network's bandwidth. Per mdn, _The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure_. Given this, if bandwidth estimates from both the player and networkInfo are >= 10 Mbps, the player will use the larger of the two values as its bandwidth estimate.
 
 ##### captionServices
 * Type: `object`

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 
         <div class="form-check">
           <input id=network-info type="checkbox" class="form-check-input">
-          <label class="form-check-label" for="network-info">[EXPERIMENTAL] Use networkInfo API for bandwidth estimations (reloads player)</label>
+          <label class="form-check-label" for="network-info">Use networkInfo API for bandwidth estimations (reloads player)</label>
         </div>
 
         <div class="form-check">

--- a/index.html
+++ b/index.html
@@ -167,6 +167,11 @@
         </div>
 
         <div class="form-check">
+          <input id=network-info type="checkbox" class="form-check-input">
+          <label class="form-check-label" for="network-info">[EXPERIMENTAL] Use networkInfo API for bandwidth estimations (reloads player)</label>
+        </div>
+
+        <div class="form-check">
           <input id=override-native type="checkbox" class="form-check-input" checked>
           <label class="form-check-label" for="override-native">Override Native (reloads player)</label>
         </div>

--- a/index.html
+++ b/index.html
@@ -147,6 +147,11 @@
         </div>
 
         <div class="form-check">
+          <input id=network-info type="checkbox" class="form-check-input">
+          <label class="form-check-label" for="network-info">Use networkInfo API for bandwidth estimations (reloads player)</label>
+        </div>
+
+        <div class="form-check">
           <input id=llhls type="checkbox" class="form-check-input">
           <label class="form-check-label" for="llhls">[EXPERIMENTAL] Enables support for ll-hls (reloads player)</label>
         </div>
@@ -164,11 +169,6 @@
         <div class="form-check">
           <input id=pixel-diff-selector type="checkbox" class="form-check-input">
           <label class="form-check-label" for="pixel-diff-selector">[EXPERIMENTAL] Use the Pixel difference resolution selector (reloads player)</label>
-        </div>
-
-        <div class="form-check">
-          <input id=network-info type="checkbox" class="form-check-input">
-          <label class="form-check-label" for="network-info">Use networkInfo API for bandwidth estimations (reloads player)</label>
         </div>
 
         <div class="form-check">

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -447,6 +447,7 @@
     'buffer-water',
     'exact-manifest-timings',
     'pixel-diff-selector',
+    'network-info',
     'override-native',
     'preload',
     'mirror-source'
@@ -499,6 +500,7 @@
       'override-native',
       'liveui',
       'pixel-diff-selector',
+      'network-info',
       'exact-manifest-timings'
     ].forEach(function(name) {
       stateEls[name].addEventListener('change', function(event) {
@@ -565,7 +567,8 @@
               experimentalBufferBasedABR: getInputValue(stateEls['buffer-water']),
               experimentalLLHLS: getInputValue(stateEls.llhls),
               experimentalExactManifestTimings: getInputValue(stateEls['exact-manifest-timings']),
-              experimentalLeastPixelDiffSelector: getInputValue(stateEls['pixel-diff-selector'])
+              experimentalLeastPixelDiffSelector: getInputValue(stateEls['pixel-diff-selector']),
+              useNetworkInformation: getInputValue(stateEls['network-info'])
             }
           }
         });

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -568,7 +568,7 @@
               experimentalLLHLS: getInputValue(stateEls.llhls),
               experimentalExactManifestTimings: getInputValue(stateEls['exact-manifest-timings']),
               experimentalLeastPixelDiffSelector: getInputValue(stateEls['pixel-diff-selector']),
-              useNetworkInformation: getInputValue(stateEls['network-info'])
+              useNetworkInformationApi: getInputValue(stateEls['network-info'])
             }
           }
         });

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -797,13 +797,16 @@ class VhsHandler extends Component {
         get() {
           let bandwidthEst = this.masterPlaylistController_.mainSegmentLoader_.bandwidth;
 
-          // NetworkInfo.downlink maxes out at 10 Mbps. In the event that the player estimates a bandwidth
-          // greater than 10 Mbps, use the larger value to ensure that high quality streams are not
-          // accidentally filtered out
-          if (this.options_.useNetworkInformationApi && this.networkInformation) {
-            // Downlink property returns Mbps https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink
+          const  networkInformation = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+
+          if (this.options_.useNetworkInformationApi && networkInformation) {
+            // downlink returns Mbps
+            // https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink
             const effectiveBandwidthBitsPerSec = this.networkInformation.downlink * 1000 * 1000;
 
+            // downlink maxes out at 10 Mbps. In the event that the player estimates a bandwidth
+            // greater than 10 Mbps, use the larger value to ensure that high quality streams are not
+            // filtered out.
             bandwidthEst = Math.max(bandwidthEst, effectiveBandwidthBitsPerSec);
           }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -563,6 +563,7 @@ class VhsHandler extends Component {
     this.source_ = source;
     this.stats = {};
     this.ignoreNextSeekingEvent_ = false;
+    this.effectiveBandwidthInBits_ = 0;
     this.setOptions_();
 
     if (this.options_.overrideNative &&
@@ -621,9 +622,11 @@ class VhsHandler extends Component {
     if (this.options_.useNetworkInformation) {
       this.networkInformation = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
 
-      this.networkInformation.addEventListener('change', () => this.setNetworkInformationStats_());
+      if (this.networkInformation) {
+        this.networkInformation.addEventListener('change', () => this.setNetworkInformationStats_());
 
-      this.setNetworkInformationStats_();
+        this.setNetworkInformationStats_();
+      }
     }
   }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -617,10 +617,6 @@ class VhsHandler extends Component {
     });
 
     this.on(this.tech_, 'play', this.play);
-
-    if (this.options_.useNetworkInformationApi) {
-      this.networkInformation = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
-    }
   }
 
   setOptions_() {
@@ -797,12 +793,12 @@ class VhsHandler extends Component {
         get() {
           let bandwidthEst = this.masterPlaylistController_.mainSegmentLoader_.bandwidth;
 
-          const  networkInformation = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+          const networkInformation = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
 
           if (this.options_.useNetworkInformationApi && networkInformation) {
             // downlink returns Mbps
             // https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink
-            const effectiveBandwidthBitsPerSec = this.networkInformation.downlink * 1000 * 1000;
+            const effectiveBandwidthBitsPerSec = networkInformation.downlink * 1000 * 1000;
 
             // downlink maxes out at 10 Mbps. In the event that the player estimates a bandwidth
             // greater than 10 Mbps, use the larger value to ensure that high quality streams are not

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1181,7 +1181,7 @@ QUnit.module('NetworkInformationApi', hooks => {
   });
 
   QUnit.test(
-    'systemBandwidth retrieves bandwidth from networkInformation when option is enabled',
+    'bandwidth returns networkInformation.downlink when useNetworkInformationApi option is enabled',
     function(assert) {
       this.resetNavigatorConnection({
         downlink: 200000
@@ -1194,19 +1194,17 @@ QUnit.module('NetworkInformationApi', hooks => {
 
       this.clock.tick(1);
 
-      this.player.tech_.vhs.throughput = 20e10;
       // downlink in bits = 200000 * 1000000 = 20e10
-      // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
       assert.strictEqual(
-        this.player.tech_.vhs.systemBandwidth,
-        10e10,
-        'systemBandwidth is the combination of networkInfo.downlink and throughput'
+        this.player.tech_.vhs.bandwidth,
+        20e10,
+        'bandwidth equals networkInfo.downlink represented as bits per second'
       );
     }
   );
 
   QUnit.test(
-    'systemBandwidth uses player-estimated bandwidth when its value is greater than networkInformation.downLink',
+    'bandwidth uses player-estimated bandwidth when its value is greater than networkInformation.downLink',
     function(assert) {
       this.resetNavigatorConnection({
         downlink: 100000
@@ -1220,18 +1218,16 @@ QUnit.module('NetworkInformationApi', hooks => {
       this.clock.tick(1);
 
       this.player.tech_.vhs.bandwidth = 20e10;
-      this.player.tech_.vhs.throughput = 20e10;
-      // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
       assert.strictEqual(
-        this.player.tech_.vhs.systemBandwidth,
-        10e10,
-        'systemBandwidth is the combination of player bandwidth and throughput'
+        this.player.tech_.vhs.bandwidth,
+        20e10,
+        'bandwidth getter returned the player-estimated bandwidth value'
       );
     }
   );
 
   QUnit.test(
-    'systemBandwidth uses player-estimated bandwidth when networkInformation is not supported',
+    'bandwidth uses player-estimated bandwidth when networkInformation is not supported',
     function(assert) {
       // Nullify the `connection` property on Navigator
       this.resetNavigatorConnection(null);
@@ -1244,12 +1240,10 @@ QUnit.module('NetworkInformationApi', hooks => {
       this.clock.tick(1);
 
       this.player.tech_.vhs.bandwidth = 20e10;
-      this.player.tech_.vhs.throughput = 20e10;
-      // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
       assert.strictEqual(
-        this.player.tech_.vhs.systemBandwidth,
-        10e10,
-        'systemBandwidth is the combination of player bandwidth and throughput since networkInformation is not supported'
+        this.player.tech_.vhs.bandwidth,
+        20e10,
+        'bandwidth getter returned the player-estimated bandwidth value'
       );
     }
   );

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1184,7 +1184,7 @@ QUnit.module('NetworkInformationApi', hooks => {
     'bandwidth returns networkInformation.downlink when useNetworkInformationApi option is enabled',
     function(assert) {
       this.resetNavigatorConnection({
-        downlink: 200000
+        downlink: 10
       });
       this.player = createPlayer({ html5: { vhs: { useNetworkInformationApi: true } } });
       this.player.src({
@@ -1194,20 +1194,45 @@ QUnit.module('NetworkInformationApi', hooks => {
 
       this.clock.tick(1);
 
-      // downlink in bits = 200000 * 1000000 = 20e10
+      // downlink in bits = 10 * 1000000 = 10e6
       assert.strictEqual(
         this.player.tech_.vhs.bandwidth,
-        20e10,
+        10e6,
         'bandwidth equals networkInfo.downlink represented as bits per second'
       );
     }
   );
 
   QUnit.test(
-    'bandwidth uses player-estimated bandwidth when its value is greater than networkInformation.downLink',
+    'bandwidth uses player-estimated bandwidth when its value is greater than networkInformation.downLink and both values are >= 10 Mbps',
     function(assert) {
       this.resetNavigatorConnection({
-        downlink: 100000
+        // 10 Mbps or 10e6
+        downlink: 10
+      });
+      this.player = createPlayer({ html5: { vhs: { useNetworkInformationApi: true } } });
+      this.player.src({
+        src: 'manifest/master.m3u8',
+        type: 'application/vnd.apple.mpegurl'
+      });
+
+      this.clock.tick(1);
+
+      this.player.tech_.vhs.bandwidth = 20e6;
+      assert.strictEqual(
+        this.player.tech_.vhs.bandwidth,
+        20e6,
+        'bandwidth getter returned the player-estimated bandwidth value'
+      );
+    }
+  );
+
+  QUnit.test(
+    'bandwidth uses network-information-api bandwidth when its value is less than the player bandwidth and 10 Mbps',
+    function(assert) {
+      this.resetNavigatorConnection({
+        // 9 Mbps or 9e6
+        downlink: 9
       });
       this.player = createPlayer({ html5: { vhs: { useNetworkInformationApi: true } } });
       this.player.src({
@@ -1220,8 +1245,8 @@ QUnit.module('NetworkInformationApi', hooks => {
       this.player.tech_.vhs.bandwidth = 20e10;
       assert.strictEqual(
         this.player.tech_.vhs.bandwidth,
-        20e10,
-        'bandwidth getter returned the player-estimated bandwidth value'
+        9e6,
+        'bandwidth getter returned the network-information-api bandwidth value since it was less than 10 Mbps'
       );
     }
   );

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1160,6 +1160,99 @@ QUnit.test(
   }
 );
 
+QUnit.test(
+  'systemBandwidth retrieves bandwidth from networkInformation when option is enabled',
+  function(assert) {
+    this.player = createPlayer({ html5: { vhs: { useNetworkInformation: true } } });
+    this.player.src({
+      src: 'manifest/master.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+
+    this.clock.tick(1);
+
+    this.player.tech_.vhs.bandwidth = 10e10;
+    this.player.tech_.vhs.effectiveBandwidthInBits_ = 20e10;
+    this.player.tech_.vhs.throughput = 20e10;
+    // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
+    assert.strictEqual(
+      this.player.tech_.vhs.systemBandwidth,
+      10e10,
+      'systemBandwidth is the combination of networkInfo.downlink and throughput'
+    );
+  }
+);
+
+QUnit.test(
+  'systemBandwidth uses player-estimated bandwidth when its value is greater than networkInformation.downLink',
+  function(assert) {
+    this.player = createPlayer({ html5: { vhs: { useNetworkInformation: true } } });
+    this.player.src({
+      src: 'manifest/master.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+
+    this.clock.tick(1);
+
+    this.player.tech_.vhs.bandwidth = 20e10;
+    this.player.tech_.vhs.effectiveBandwidthInBits_ = 10e10;
+    this.player.tech_.vhs.throughput = 20e10;
+    // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
+    assert.strictEqual(
+      this.player.tech_.vhs.systemBandwidth,
+      10e10,
+      'systemBandwidth is the combination of player bandwidth and throughput'
+    );
+  }
+);
+
+QUnit.test(
+  'effectiveBandwidthInBits_ default',
+  function(assert) {
+    this.player.src({
+      src: 'manifest/master.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+
+    this.clock.tick(1);
+
+    assert.strictEqual(
+      this.player.tech_.vhs.effectiveBandwidthInBits_,
+      0,
+      'effectiveBandwidthInBits_ defaults to 0'
+    );
+  }
+);
+
+QUnit.test(
+  'systemBandwidth uses player-estimated bandwidth when networkInformation is not supported',
+  function(assert) {
+    const ogNavigator = window.navigator;
+
+    // Need to delete the property before setting since navigator doesn't have a setter
+    delete window.navigator;
+    window.navigator = {};
+    this.player = createPlayer({ html5: { vhs: { useNetworkInformation: true } } });
+    this.player.src({
+      src: 'manifest/master.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+
+    this.clock.tick(1);
+
+    this.player.tech_.vhs.bandwidth = 20e10;
+    this.player.tech_.vhs.throughput = 20e10;
+    // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
+    assert.strictEqual(
+      this.player.tech_.vhs.systemBandwidth,
+      10e10,
+      'systemBandwidth is the combination of player bandwidth and throughput since networkInformation is not supported'
+    );
+
+    window.navigator = ogNavigator;
+  }
+);
+
 QUnit.test('requests a reasonable rendition to start', function(assert) {
   this.player.src({
     src: 'manifest/master.m3u8',


### PR DESCRIPTION
## Description
We've found that the player's bandwidth estimations provide lower-than-expected values when a particular segment is encoded with a low bitrate relative to other segments in its lane. This is a fairly common phenomenon when a live stream is using a variable bitrate encoding strategy and is broadcasting a static scene (e.g a slide in a slideshow). We believe that this issue is further exacerbated by two factors:

1. Segment size - Vhs estimates bandwidth by measuring how many bits were downloaded in a segment and how long, in seconds, it took to download those bits. This estimate factors in network-layer overhead which means that as the number of bits in a segment decreases (either due to bitrate or segment size), the impact that network overhead has on the bandwidth estimate increases
2. Bandwidth Variance config - Vhs uses a `BANDWIDTH_VARIANCE` value as a multiplier for the advertised bandwidth value in each lane. The filter calculation looks like `lane bandwidth * bandwidth variance < calculatedBandwidth`. When `calculatedBandwidth` is low due to aforementioned reasons, the bandwidth variance default makes it more likely that higher-quality lanes will be filtered out by the player

## Specific Changes proposed
Introduce an experimental option that allows the player to leverage Chromium's [NetworkInfo.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink) API to estimate bandwidth. Note: This API is not available in Firefox or Safari. When enabled, the player will take the max value between its own bandwidth estimation and that provided by NetworkInformation.downlink.

Please see attached screenshots which demonstrate how the player now selects the higher-quality rendition during static scenes. [This demo](http://localhost:9999/?debug=false&autoplay=false&muted=false&fluid=false&minified=false&sync-workers=false&liveui=true&llhls=false&url=https%3A%2F%2Flivectorprodmedia11-usw22.licdn.com%2F0dbd58e9-9111-4f66-a1aa-a4013fc974ef%2FL565f16d44f01c2c000-livemanifest.ism%2Fmanifest(format%3Dm3u8-aapl-v3)&type=application%2Fx-mpegURL&keysystems=&buffer-water=false&exact-manifest-timings=false&pixel-diff-selector=false&network-info=true&override-native=true&preload=auto&mirror-source=true) uses 2-second segments.

<img width="1788" alt="Screen Shot 2021-10-29 at 2 34 06 PM" src="https://user-images.githubusercontent.com/8199672/139492102-4b58a690-037b-4dab-a552-d601cd1300c9.png">


<img width="1757" alt="Screen Shot 2021-10-29 at 2 33 27 PM" src="https://user-images.githubusercontent.com/8199672/139492224-c6112212-7192-4080-8719-e5af4d479274.png">

<img width="1789" alt="Screen Shot 2021-10-29 at 2 05 13 PM" src="https://user-images.githubusercontent.com/8199672/139492283-3e3b9247-e161-4e94-abe9-c8e237980997.png">



<img width="1731" alt="Screen Shot 2021-10-29 at 2 32 46 PM" src="https://user-images.githubusercontent.com/8199672/139492303-646afecd-8c31-4b3b-96cf-316c421a1ba8.png">
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
