### PR TITLE
Fix for Opus audio in fragmented MP4

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -440,7 +440,8 @@ const handleSegmentBytes = ({
     // if we have a audio track, with a codec that is not set to
     // encrypted audio
     if (tracks.audio && tracks.audio.codec && tracks.audio.codec !== 'enca') {
-      trackInfo.audioCodec = tracks.audio.codec;
+      // note Opus box name is capitalized, but things want lowercase for checks
+      trackInfo.audioCodec = tracks.audio.codec.toLowerCase();
     }
 
     // if we have a video track, with a codec that is not set to


### PR DESCRIPTION
The Opus box name is capitalized, but MediaSource expects a lowercase
"opus" codec string, which was causing unexpected failures in Chrome
and Firefox.

Now matches behavior of mux.js for audio tracks by forcing the box
type to lowercase before returning it as a codec string.

## Description

HLS streams with Opus audio tracks in fragmented MP4 weren't working in Chrome and Firefox due to reading the codec string as "Opus" with a capital "O", which MediaSource rejects.

## Specific Changes proposed

Forcing the box name string to lowercase resolves the specific problem with Opus; all other known codec strings are lowercase. mux.js appears to use the same logic when returning codec strings, so this is not expected to be problematic.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
