### PR TITLE
Don't run networkInfo tests against ie11

### DIFF
--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1180,7 +1180,7 @@ QUnit.module('NetworkInformationApi', hooks => {
     window.navigator = this.ogNavigator;
   });
 
-  QUnit.test(
+  QUnit[testOrSkip](
     'bandwidth returns networkInformation.downlink when useNetworkInformationApi option is enabled',
     function(assert) {
       this.resetNavigatorConnection({
@@ -1203,7 +1203,7 @@ QUnit.module('NetworkInformationApi', hooks => {
     }
   );
 
-  QUnit.test(
+  QUnit[testOrSkip](
     'bandwidth uses player-estimated bandwidth when its value is greater than networkInformation.downLink and both values are >= 10 Mbps',
     function(assert) {
       this.resetNavigatorConnection({
@@ -1227,7 +1227,7 @@ QUnit.module('NetworkInformationApi', hooks => {
     }
   );
 
-  QUnit.test(
+  QUnit[testOrSkip](
     'bandwidth uses network-information-api bandwidth when its value is less than the player bandwidth and 10 Mbps',
     function(assert) {
       this.resetNavigatorConnection({
@@ -1251,7 +1251,7 @@ QUnit.module('NetworkInformationApi', hooks => {
     }
   );
 
-  QUnit.test(
+  QUnit[testOrSkip](
     'bandwidth uses player-estimated bandwidth when networkInformation is not supported',
     function(assert) {
       // Nullify the `connection` property on Navigator


### PR DESCRIPTION
## Description
The stubbing of networkInfo doesn't play nicely with ie11 which complains with the following message: `Assignment to read-only properties is not allowed in strict mode`. After speaking with Gary, we've decided to skip these tests in IE.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
