### PR TITLE
Support HLS smoothQualityChange setting on MSE

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -868,6 +868,15 @@ export default class SegmentLoader extends videojs.EventTarget {
                                                          syncPoint.time);
 
       mediaIndex = mediaSourceInfo.mediaIndex;
+      try {
+        if (this.hls_.options_.smoothQualityChange) {
+          // Start from the next segment, so already buffered data isn't overwritten.
+          // This would cause trouble, force an internal reenqueue, force the video
+          // decoders to catch up, and cause glitches on WebKit/WPE browsers on some
+          // embedded platforms with hardware decoders.
+          mediaIndex++;
+        }
+      } catch (e) { }
       startOfSegment = mediaSourceInfo.startTime;
     } else {
       // Find the segment containing currentTime


### PR DESCRIPTION
## Description

See https://github.com/videojs/http-streaming/issues/1224

The current "fast quality switching" policy which clears the buffers and replaces then as fast as possible with others with the new quality is good for fast quality switching on regular desktop systems, which have a software decoder and plenty of CPU.

However, on set-top-boxes using embedded browsers like [WPE WebKit](https://github.com/WebPlatformForEmbedded/WPEWebKit), this causes an internal "flush and reenqueue" on the playback pipeline, which is emptied and has the buffers with new quality enqueued and quickly decoded until the old playback position is reached again. This causes a big stress on the decoder to catch up, and it's even worse on devices with hardware decoders and custom audio-video synchronization mechanisms.

For this reason, those systems would benefit a lot on having the smoothQualityChange setting honored when using Media Source Extensions.

In order to use this feature, the user should configure the player like this:

```
  var player = videojs('videoelementid', {
    html5: {
      hls: {
        overrideNative: true,
        smoothQualityChange: true
      }
    }
  });
```

## Specific Changes proposed

The commit in this PR examines the smoothQualityChange setting and, if set, modifies the SegmentLoader behaviour to start from the next segment to the initially selected. This effectively avoids segment overwriting and fixes the problems described on the affected browser and platform.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
