### PR TITLE
feat: use new mpd-parser API for handling live DASH refreshes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6534,9 +6534,9 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.20.0.tgz",
-      "integrity": "sha512-C8S9xmBfPTNq+J6woMuFYpzqQX97LAlInrUoDYAWGOe3QBMx8TrXahjFFoXh5YTCMbdIA8WNL5mUMDKGSC32Gw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.21.0.tgz",
+      "integrity": "sha512-NbpMJ57qQzFmfCiP1pbL7cGMbVTD0X1hqNgL0VYP1wLlZXLf/HtmvQpNkOA1AHkPVeGQng+7/jEtSvNUzV7Gdg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",
-    "mpd-parser": "0.20.0",
+    "mpd-parser": "0.21.0",
     "mux.js": "6.0.0",
     "video.js": "^6 || ^7"
   },

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -101,16 +101,23 @@ const dashPlaylistUnchanged = function(a, b) {
  * @return {Object}
  *         The parsed mpd manifest object
  */
-export const parseMasterXml = ({ masterXml, srcUrl, clientOffset, sidxMapping }) => {
-  const master = parseMpd(masterXml, {
+export const parseMasterXml = ({
+  masterXml,
+  srcUrl,
+  clientOffset,
+  sidxMapping,
+  previousManifest
+}) => {
+  const manifest = parseMpd(masterXml, {
     manifestUri: srcUrl,
     clientOffset,
-    sidxMapping
+    sidxMapping,
+    previousManifest
   });
 
-  addPropertiesToMaster(master, srcUrl);
+  addPropertiesToMaster(manifest, srcUrl);
 
-  return master;
+  return manifest;
 };
 
 /**
@@ -130,7 +137,8 @@ export const updateMaster = (oldMaster, newMaster, sidxMapping) => {
   let update = mergeOptions(oldMaster, {
     // These are top level properties that can be updated
     duration: newMaster.duration,
-    minimumUpdatePeriod: newMaster.minimumUpdatePeriod
+    minimumUpdatePeriod: newMaster.minimumUpdatePeriod,
+    timelineStarts: newMaster.timelineStarts
   });
 
   // First update the playlists in playlist list
@@ -699,13 +707,15 @@ export default class DashPlaylistLoader extends EventTarget {
     // clear media request
     this.mediaRequest_ = null;
 
+    const oldMaster = this.masterPlaylistLoader_.master;
+
     let newMaster = parseMasterXml({
       masterXml: this.masterPlaylistLoader_.masterXml_,
       srcUrl: this.masterPlaylistLoader_.srcUrl,
       clientOffset: this.masterPlaylistLoader_.clientOffset_,
-      sidxMapping: this.masterPlaylistLoader_.sidxMapping_
+      sidxMapping: this.masterPlaylistLoader_.sidxMapping_,
+      previousManifest: oldMaster
     });
-    const oldMaster = this.masterPlaylistLoader_.master;
 
     // if we have an old master to compare the new master against
     if (oldMaster) {

--- a/test/manifests/dash-live.mpd
+++ b/test/manifests/dash-live.mpd
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:full:2011" minBufferTime="1.5" minimumUpdatePeriod="PT4S" type="dynamic" availabilityStartTime="1970-01-01T00:00:00Z" timeShiftBufferDepth="PT1H0M0S">
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="1.5" minimumUpdatePeriod="PT4S" type="dynamic" availabilityStartTime="1970-01-01T00:00:00Z" timeShiftBufferDepth="PT1H0M0S">
   <Period start="PT0S">
     <BaseURL>main/</BaseURL>
     <AdaptationSet mimeType="video/mp4">


### PR DESCRIPTION
In order to support the new mpd-parser API, whenever a DASH manifest
refreshes, the prior parsed manifest object needs to be passed in as
`previousManifest`. This change adds support for that.

NOTE: this is to support an upcoming feature in mpd-parser:
videojs/mpd-parser#152

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
