### PR TITLE
test: fix failing IE11 test due to late initialize of EME keys

### DIFF
--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4745,11 +4745,21 @@ QUnit.test('eme waitingforkey event triggers another setup', function(assert) {
 
   vhs.masterPlaylistController_.sourceUpdater_.trigger('createdsourcebuffers');
 
-  assert.equal(createKeySessionCalls, 1, 'called createKeySessions_ once');
+  // Since IE11 doesn't initialize media keys early, in this test IE11 will always have
+  // one less call than in other browsers.
+  if (videojs.browser.IE_VERSION === 11) {
+    assert.equal(createKeySessionCalls, 0, 'did not call createKeySessions_ yet');
+  } else {
+    assert.equal(createKeySessionCalls, 1, 'called createKeySessions_ once');
+  }
 
   this.player.tech_.trigger({type: 'waitingforkey', status: 'usable'});
 
-  assert.equal(createKeySessionCalls, 2, 'called createKeySessions_ again');
+  if (videojs.browser.IE_VERSION === 11) {
+    assert.equal(createKeySessionCalls, 1, 'called createKeySessions_ once');
+  } else {
+    assert.equal(createKeySessionCalls, 2, 'called createKeySessions_ again');
+  }
 });
 
 QUnit.test('integration: configures eme for DASH on source buffer creation', function(assert) {


### PR DESCRIPTION
## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
