### PR TITLE
fix(package): update mux.js to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6557,9 +6557,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.0.tgz",
-      "integrity": "sha512-ogKV5CyNlYUuUzrURMvPfIh6Vim+sBw0ztCwba+nRUOFJUkD1tYYquJnUVjn7WfIbnh1EsDvLJ0QVTb1uv/3pA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
+      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "global": "^4.4.0",
     "m3u8-parser": "4.7.0",
     "mpd-parser": "0.21.0",
-    "mux.js": "6.0.0",
+    "mux.js": "6.0.1",
     "video.js": "^6 || ^7"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description
Fixes a syntax error in IE11

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
