### PR TITLE
Fix: retain playlist attributes when refreshing live media playlists

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -334,7 +334,8 @@ export const updateMaster = (master, newMedia, unchangedCheck = isPlaylistUnchan
     }
     for (let i = 0; i < properties.playlists.length; i++) {
       if (newMedia.id === properties.playlists[i].id) {
-        properties.playlists[i] = newMedia;
+        // properties.playlists[i] = newMedia;
+        properties.playlists[i] = mergedPlaylist;
       }
     }
   });

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -334,8 +334,7 @@ export const updateMaster = (master, newMedia, unchangedCheck = isPlaylistUnchan
     }
     for (let i = 0; i < properties.playlists.length; i++) {
       if (newMedia.id === properties.playlists[i].id) {
-        properties.playlists[i] = newMedia;
-        // properties.playlists[i] = mergedPlaylist;
+        properties.playlists[i] = mergedPlaylist;
       }
     }
   });

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -334,8 +334,8 @@ export const updateMaster = (master, newMedia, unchangedCheck = isPlaylistUnchan
     }
     for (let i = 0; i < properties.playlists.length; i++) {
       if (newMedia.id === properties.playlists[i].id) {
-        // properties.playlists[i] = newMedia;
-        properties.playlists[i] = mergedPlaylist;
+        properties.playlists[i] = newMedia;
+        // properties.playlists[i] = mergedPlaylist;
       }
     }
   });

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -795,6 +795,110 @@ QUnit.module('Playlist Loader', function(hooks) {
     assert.deepEqual(result, master, 'playlist updated');
   });
 
+  QUnit.test('updateMaster retains mediaGroup attributes', function(assert) {
+    const master = {
+      mediaGroups: {
+        AUDIO: {
+          'GROUP-ID': {
+            default: {
+              default: true,
+              playlists: [{
+                mediaSequence: 0,
+                attributes: {
+                  BANDWIDTH: 9,
+                  CODECS: 'mp4a.40.2'
+                },
+                id: 'playlist-0-uri',
+                uri: 'playlist-0-uri',
+                resolvedUri: urlTo('playlist-0-uri'),
+                segments: [{
+                  duration: 10,
+                  uri: 'segment-0-uri',
+                  resolvedUri: urlTo('segment-0-uri')
+                }]
+              }]
+            }
+          }
+        }
+      },
+      playlists: [{
+        mediaSequence: 0,
+        attributes: {
+          BANDWIDTH: 9,
+          CODECS: 'mp4a.40.2'
+        },
+        id: 'playlist-0-uri',
+        uri: 'playlist-0-uri',
+        resolvedUri: urlTo('playlist-0-uri'),
+        segments: [{
+          duration: 10,
+          uri: 'segment-0-uri',
+          resolvedUri: urlTo('segment-0-uri')
+        }]
+      }]
+    };
+    const media = {
+      mediaSequence: 1,
+      attributes: {
+        BANDWIDTH: 9
+      },
+      id: 'playlist-0-uri',
+      uri: 'playlist-0-uri',
+      segments: [{
+        duration: 10,
+        uri: 'segment-0-uri'
+      }]
+    };
+
+    master.playlists[media.id] = master.playlists[0];
+
+    assert.deepEqual(
+      updateMaster(master, media),
+      {
+        mediaGroups: {
+          AUDIO: {
+            'GROUP-ID': {
+              default: {
+                default: true,
+                playlists: [{
+                  mediaSequence: 1,
+                  attributes: {
+                    BANDWIDTH: 9,
+                    CODECS: 'mp4a.40.2'
+                  },
+                  id: 'playlist-0-uri',
+                  uri: 'playlist-0-uri',
+                  resolvedUri: urlTo('playlist-0-uri'),
+                  segments: [{
+                    duration: 10,
+                    uri: 'segment-0-uri',
+                    resolvedUri: urlTo('segment-0-uri')
+                  }]
+                }]
+              }
+            }
+          }
+        },
+        playlists: [{
+          mediaSequence: 1,
+          attributes: {
+            BANDWIDTH: 9,
+            CODECS: 'mp4a.40.2'
+          },
+          id: 'playlist-0-uri',
+          uri: 'playlist-0-uri',
+          resolvedUri: urlTo('playlist-0-uri'),
+          segments: [{
+            duration: 10,
+            uri: 'segment-0-uri',
+            resolvedUri: urlTo('segment-0-uri')
+          }]
+        }]
+      },
+      'updated playlist retains codec attribute'
+    );
+  });
+
   QUnit.test('uses last segment duration for refresh delay', function(assert) {
     const media = { targetDuration: 7, segments: [] };
 


### PR DESCRIPTION
## Description
On a live playlist with media groups, subsequent fetches of the media playlist overwrite the playlist attributes with an empty object. This affects part of the rendiiton selection flow, including the audio only test. On an audio-only stream this impacts playback, as no audio only stream is found. This can result in cycling through the renditions, playing an unnecessarily low rendtion, or for streams with manifest redundancy, that playback stops.

## Specific Changes proposed
Updates th playlist with the merged playlist rather than the unmodifed newly parsed playlist. This should have been the behaviour already.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors