### PR TITLE
test: change source for live DASH playback test to fix test failures

### DIFF
--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -250,7 +250,7 @@ QUnit[testFn]('Live DASH', function(assert) {
   });
 
   player.src({
-    src: 'https://livesim.dashif.org/livesim/mup_30/testpic_2s/Manifest.mpd',
+    src: 'https://livesim.dashif.org/livesim/segtimeline_1/testpic_2s/Manifest.mpd',
     type: 'application/dash+xml'
   });
 


### PR DESCRIPTION
The current live DASH playback test source uses a source where segments
are referenced by a SegmentTemplate and duration, but the server
doesn't have time syncing and appears to be about two minutes behind
local time. This leads to requests for segments beyond expected and
occasional failures.

Until that issue is fixed in VHS, switch to a live source that uses
SegmentTemplate, to be a more reliable basic live DASH playback test.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
