### PR TITLE
fix: output-restricted event handling for unplayable streams

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1062,11 +1062,34 @@ class VhsHandler extends Component {
 
     this.player_.tech_.on('keystatuschange', (e) => {
       if (e.status === 'output-restricted') {
-        this.masterPlaylistController_.blacklistCurrentPlaylist({
-          playlist: this.masterPlaylistController_.media(),
-          message: `DRM keystatus changed to ${e.status}. Playlist will fail to play. Check for HDCP content.`,
-          blacklistDuration: Infinity
-        });
+        const masterPlaylist = this.masterPlaylistController_.media();
+        const excludedHDPlaylists = [];
+
+        if (masterPlaylist && masterPlaylist.playlists) {
+          // Assume all HD streams are unplayable and exclude them from ABR selection, then perform
+          // a fastQualityChange to clear the buffer since it may already contain unplayable segments
+          masterPlaylist.playlists.forEach(playlist => {
+            if (playlist && playlist.attributes && playlist.attributes.RESOLUTION &&
+                playlist.attributes.RESOLUTION.height >= 720) {
+              if (!playlist.excludeUntil || playlist.excludeUntil < Infinity) {
+
+                playlist.excludeUntil = Infinity;
+                excludedHDPlaylists.push(playlist);
+              }
+            }
+          });
+
+          if (excludedHDPlaylists.length) {
+            videojs.log.warn(
+              'DRM keystatus changed to "output-restricted." Removing the following HD playlists ' +
+              'that will most likely fail to play and clearing already buffered HD segments. ' +
+              'Check for HDCP content.',
+              ...excludedHDPlaylists
+            );
+
+            this.masterPlaylistController_.fastQualityChange_();
+          }
+        }
       }
     });
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4617,12 +4617,21 @@ QUnit.test('configures eme for HLS on source buffer creation', function(assert) 
   }, 'set source eme options');
 });
 
-QUnit.test('eme handles keystatuschange where status is output-restricted', function(assert) {
+QUnit.only('eme handles keystatuschange where status is output-restricted', function(assert) {
+  const originalWarn = videojs.log.warn;
+  let warning = '';
+  let qualitySwitches = 0;
+
+  videojs.log.warn = (...text) => {
+    warning += [...text].join('');
+  };
+
   this.player.eme = {
     options: {
       previousSetting: 1
     }
   };
+
   this.player.src({
     src: 'manifest/master.m3u8',
     type: 'application/x-mpegURL',
@@ -4635,36 +4644,63 @@ QUnit.test('eme handles keystatuschange where status is output-restricted', func
 
   this.clock.tick(1);
 
-  const media = {
-    attributes: {
-      CODECS: 'avc1.420015, mp4a.40.2c'
+  const playlists = [
+    {
+      attributes: {
+        RESOLUTION: {
+          width: 1280,
+          height: 720
+        }
+      }
     },
-    contentProtection: {
-      keySystem1: {
-        pssh: 'test'
+    {
+      attributes: {
+        RESOLUTION: {
+          width: 1920,
+          height: 1080
+        }
+      }
+    },
+    {
+      attributes: {
+        RESOLUTION: {
+          width: 848,
+          height: 480
+        }
       }
     }
-  };
+  ];
 
   this.player.tech_.vhs.playlists = {
-    master: { playlists: [media] },
-    media: () => media
+    master: { playlists },
+    media: () => playlists[0]
   };
 
-  const excludes = [];
+  this.player.tech_.vhs.masterPlaylistController_.media = () => {
+    return {
+      playlists
+    };
+  };
 
-  this.player.tech_.vhs.masterPlaylistController_.blacklistCurrentPlaylist = (exclude) => {
-    excludes.push(exclude);
+  this.player.tech_.vhs.masterPlaylistController_.fastQualityChange_ = () => {
+    qualitySwitches++;
   };
 
   this.player.tech_.vhs.masterPlaylistController_.sourceUpdater_.trigger('createdsourcebuffers');
   this.player.tech_.trigger({type: 'keystatuschange', status: 'output-restricted'});
 
-  assert.deepEqual(excludes, [{
-    blacklistDuration: Infinity,
-    message: 'DRM keystatus changed to output-restricted. Playlist will fail to play. Check for HDCP content.',
-    playlist: undefined
-  }], 'excluded playlist');
+  assert.equal(playlists[0].excludeUntil, Infinity, 'first HD playlist excluded');
+  assert.equal(playlists[1].excludeUntil, Infinity, 'second HD playlist excluded');
+  assert.equal(playlists[2].excludeUntil, undefined, 'non-HD playlist not excluded');
+  assert.equal(qualitySwitches, 1, 'fastQualityChange_ called once');
+  assert.equal(
+    warning,
+    'DRM keystatus changed to "output-restricted." Removing the following HD playlists ' +
+    'that will most likely fail to play and clearing already buffered HD segments. ' +
+    'Check for HDCP content.' + [playlists[0], playlists[1]].join('')
+  );
+
+  videojs.log.warn = originalWarn;
 });
 
 QUnit.test('eme handles keystatuschange where status is usable', function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4617,7 +4617,7 @@ QUnit.test('configures eme for HLS on source buffer creation', function(assert) 
   }, 'set source eme options');
 });
 
-QUnit.only('eme handles keystatuschange where status is output-restricted', function(assert) {
+QUnit.test('eme handles keystatuschange where status is output-restricted', function(assert) {
   const originalWarn = videojs.log.warn;
   let warning = '';
   let qualitySwitches = 0;


### PR DESCRIPTION
## Description
This change will improve handling of EME `'keystatuschange'` events of the type `'output-restricted'`. The existing implementation uses `blacklistCurrentPlaylist()` to exclude a single playlist from ABR selection when such an event is encountered, but does not handle cases where there are multiple unplayable streams.

## Specific Changes proposed
I am proposing we do the following:
- When encountering an `'output-restricted'`, we should assume that this is due to HDCP non-compliance and that **all** HD playlists will be unplayable.
- Therefore, exclude all HD playlists from ABR selection.
- Unplayable segments may have already been buffered, so after excluding the HD playlists, perform a `fastQualityChange_()` which will clear the buffer and switch to a playable stream.