### PR TITLE
fix: add Video.js 8 to the dep version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "m3u8-parser": "4.7.1",
     "mpd-parser": "0.21.1",
     "mux.js": "6.0.1",
-    "video.js": "^6 || ^7"
+    "video.js": "^7 || ^8"
   },
   "peerDependencies": {
-    "video.js": "^6 || ^7"
+    "video.js": "^7 || ^8"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^2.3.4",


### PR DESCRIPTION
This adds ^8 in addition to ^7 for the dep and peerDep version ranges.

BREAKING CHANGE: remove ^6 from the dependency version ranges.