### PR TITLE
fix: resume loading on segment timeout for `experimentalBufferBasedABR`

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -365,14 +365,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
   /**
    * Run selectPlaylist and switch to the new playlist if we should
    *
+   * @param {string} [reason=abr] a reason for why the ABR check is made
    * @private
-   *
    */
-  checkABR_() {
+  checkABR_(reason = 'abr') {
     const nextPlaylist = this.selectPlaylist();
 
     if (nextPlaylist && this.shouldSwitchToMedia_(nextPlaylist)) {
-      this.switchMedia_(nextPlaylist, 'abr');
+      this.switchMedia_(nextPlaylist, reason);
     }
   }
 
@@ -770,17 +770,26 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * @private
    */
   setupSegmentLoaderListeners_() {
+    this.mainSegmentLoader_.on('bandwidthupdate', () => {
+      // Whether or not buffer based ABR or another ABR is used, on a bandwidth change it's
+      // useful to check to see if a rendition switch should be made.
+      this.checkABR_('bandwidthupdate');
+      this.tech_.trigger('bandwidthupdate');
+    });
+
+    this.mainSegmentLoader_.on('timeout', () => {
+      if (this.experimentalBufferBasedABR) {
+        // If a rendition change is needed, then it would've be done on `bandwidthupdate`.
+        // Here the only consideration is that for buffer based ABR there's no guarantee
+        // of an immediate switch (since the bandwidth is averaged with a timeout
+        // bandwidth value of 1), so force a load on the segment loader to keep it going.
+        this.mainSegmentLoader_.load();
+      }
+    });
+
+    // `progress` events are not reliable enough of a bandwidth measure to trigger buffer
+    // based ABR.
     if (!this.experimentalBufferBasedABR) {
-      this.mainSegmentLoader_.on('bandwidthupdate', () => {
-        const nextPlaylist = this.selectPlaylist();
-
-        if (this.shouldSwitchToMedia_(nextPlaylist)) {
-          this.switchMedia_(nextPlaylist, 'bandwidthupdate');
-        }
-
-        this.tech_.trigger('bandwidthupdate');
-      });
-
       this.mainSegmentLoader_.on('progress', () => {
         this.trigger('progress');
       });

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -2634,6 +2634,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.bandwidth = 1;
     this.roundTrip = NaN;
     this.trigger('bandwidthupdate');
+    this.trigger('timeout');
   }
 
   /**

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -363,6 +363,22 @@ export const LoaderCommonFactory = ({
       assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
     });
 
+    QUnit.test('segment request timeout triggers timeout event', function(assert) {
+      let timeoutEvents = 0;
+
+      loader.on('timeout', () => timeoutEvents++);
+      loader.playlist(playlistWithDuration(10));
+
+      loader.load();
+      this.clock.tick(1);
+
+      this.requests[0].timedout = true;
+      // arbitrary length of time that should lead to a timeout
+      this.clock.tick(100 * 1000);
+
+      assert.equal(timeoutEvents, 1, 'triggered timeout event');
+    });
+
     QUnit.test('progress on segment requests are redispatched', function(assert) {
       let progressEvents = 0;
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1817,11 +1817,8 @@ QUnit.test('selects a playlist after main/combined segment downloads', function(
 });
 
 QUnit.test('does not select a playlist after segment downloads if only one playlist', function(assert) {
-  const origWarn = videojs.log.warn;
   let calls = 0;
-  const warnings = [];
 
-  videojs.log.warn = (text) => warnings.push(text);
   this.masterPlaylistController.selectPlaylist = () => {
     calls++;
     return null;
@@ -1836,15 +1833,6 @@ QUnit.test('does not select a playlist after segment downloads if only one playl
   // "downloaded" a segment
   this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
   assert.strictEqual(calls, 2, 'selects after the initial segment');
-
-  assert.equal(warnings.length, 1, 'one warning logged');
-  assert.equal(
-    warnings[0],
-    'We received no playlist to switch to. Please check your stream.',
-    'we logged the correct warning'
-  );
-
-  videojs.log.warn = origWarn;
 });
 
 QUnit.test('re-triggers bandwidthupdate events on the tech', function(assert) {
@@ -5862,15 +5850,38 @@ QUnit.test('Determines if playlist should change on bandwidthupdate/progress fro
 
   // "downloaded" a segment
   this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
-  assert.strictEqual(calls, 1, 'does not select after segment download');
+  assert.strictEqual(calls, 2, 'selects after segment download');
 
   this.clock.tick(250);
-  assert.strictEqual(calls, 2, 'selects after clock tick');
+  assert.strictEqual(calls, 3, 'selects after clock tick');
   this.clock.tick(1000);
-  assert.strictEqual(calls, 6, 'selects after clock tick, 1000 is 4x250');
+  assert.strictEqual(calls, 7, 'selects after clock tick, 1000 is 4x250');
 
   // verify stats
   assert.equal(this.player.tech_.vhs.stats.bandwidth, 4194304, 'default bandwidth');
+});
+
+QUnit.test('loads main segment loader on timeout', function(assert) {
+  const mainSegmentLoader = this.masterPlaylistController.mainSegmentLoader_;
+
+  this.masterPlaylistController.mediaSource.trigger('sourceopen');
+
+  // master
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  let loadCalls = 0;
+
+  mainSegmentLoader.load = () => loadCalls++;
+
+  this.masterPlaylistController.mainSegmentLoader_.trigger('bandwidthupdate');
+
+  assert.equal(loadCalls, 0, 'does not call load');
+
+  this.masterPlaylistController.mainSegmentLoader_.trigger('timeout');
+
+  assert.equal(loadCalls, 1, 'calls load');
 });
 
 QUnit.module('MasterPlaylistController shouldSwitchToMedia', sharedHooks);


### PR DESCRIPTION
Previously, if there was a segment timeout and `experimentalBufferBasedABR` was set to `true`, then the main segment loader would stay in a `READY` state and never resume loading segments. This is because the buffer based ABR path doesn't follow the same flow as non buffer based ABR, where a new playlist would be loaded immediately and it would trigger a load. Buffer based ABR may determine that no rendition change should be made, despite the timeout, leading to nothing happening. This change makes the call to load explicit, but only for buffer based ABR on timeouts.

This addresses https://github.com/videojs/http-streaming/issues/1287

# Test Changes

### Changed
* Updated test to show that `experimentalBufferBasedABR` does make a playlist selection on `bandwidthupdate`
* Updated test to remove warning logged on a `bandwidthupdate` when there's only one playlist. This warning doesn't always make sense, as a timeout that causes a `bandwidthupdate` would be a connection issue, rather than a stream issue.

### Added

* Added test that segment-loader fires `timeout` event on timeout
* Added test that master-playlist-controller reloads segment loader on `timeout` if experimentalBufferBasedABR

# Testing

1. Open the [demo page](https://videojs-http-streaming.netlify.app/?debug=false&autoplay=false&muted=false&fluid=false&minified=false&sync-workers=false&liveui=true&llhls=false&url=https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fbipbop_16x9_variant.m3u8&type=application%2Fx-mpegurl&keysystems=&buffer-water=true&exact-manifest-timings=false&pixel-diff-selector=false&network-info=false&dts-offset=false&override-native=true&preload=none&mirror-source=true). Enable `[EXPERIMENTAL] Use Buffer Level for ABR (reloads player)` and set `preload` to `none`.
2. In Chrome Devtools use a very slow connection (I manually created a 10kbps profile).
3. Press play
4. Without the change, after the segment request times out (16.5 seconds for the first bipbop stream, no more requests are made and the buffering spinner remains. The video never starts, even if changing the network connectivity back to something reasonable.
5. With the change, a new segment is requested and playback resumes (if changing network connectivity to something reasonable).

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
