### PR TITLE
Account for MPEGTS rollover when adjusting vtt cues

### DIFF
--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -476,11 +476,13 @@ export default class VTTSegmentLoader extends SegmentLoader {
 
     const timestampmap = segmentInfo.timestampmap;
     const diff = (timestampmap.MPEGTS / ONE_SECOND_IN_TS) - timestampmap.LOCAL + mappingObj.mapping;
+    const mpegTsRollover = Math.floor((2 ** 33) / ONE_SECOND_IN_TS);
 
     segmentInfo.cues.forEach((cue) => {
       // First convert cue time to TS time using the timestamp-map provided within the vtt
-      cue.startTime += diff;
-      cue.endTime += diff;
+      // Also account for mpegts rollover
+      cue.startTime = (cue.startTime % mpegTsRollover) + diff;
+      cue.endTime = (cue.endTime % mpegTsRollover) + diff;
     });
 
     if (!playlist.syncInfo) {


### PR DESCRIPTION
## Description
This fixes an issue with a long running stream where the cue start times are larger than the maximum mpegts timestamp of ~27 hours.

## Specific Changes proposed
VTT cue start and end times are adjusted to ensure that they are within the range of mpeg ts PTS which has a max size of 2^33.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
