### PR TITLE
fix: Restart masterPlaylistLoader after media change

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -614,6 +614,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
         this.requestOptions_.timeout = requestTimeout;
       }
 
+      this.masterPlaylistLoader_.load();
+
       // TODO: Create a new event on the PlaylistLoader that signals
       // that the segments have changed in some way and use that to
       // update the SegmentLoader instead of doing it twice here and


### PR DESCRIPTION
## Description
Whenever a playlist is excluded for any reason, we pause the `masterPlaylistLoader` and never restart it. We have noticed this causing timeouts with live DASH playback which relies on regular MPD refreshes.

If, for example, a single MPD or segment request fails for whatever reason, the `minimumUpdatePeriod` timeout [gets cleared](https://github.com/videojs/http-streaming/blob/main/src/dash-playlist-loader.js#L531) permanently, which halts any further MPD refreshes. This is a side-effect of `blacklistCurrentPlaylist()` , which gets called on all MPL and MSL errors. The MPC eventually picks up on the fact that the MPD is no longer updating and starts a cascade of futile [playlist switches](https://github.com/videojs/http-streaming/blob/main/src/master-playlist-controller.js#L644-L651) which ultimately result in a timeout (futile because the lack of MPD refreshes means _none_ of the playlists are updating).

This may also be causing problems with HLS, although they are less apparent since the media playlist loaders continue fetching media playlists even when the `masterPlaylistLoader` is paused. I haven't spent much time yet thinking through the implications for HLS-- I'd appreciate some input there.

## Tentative Changes Proposed
Other loaders that are paused during the playlist exclusion process (ex. `AUDIO`, `SUBTITLES`) get restarted on `'mediachange'`, so it seems to make sense to do the same for the `masterPlaylistLoader`.

**Note:** There was already a bit of discussion on Slack about this and there was some skepticism that this `'mediachange'` handler is the best place to put the `load()` call. I've spent some time investigating better alternatives, but haven't yet come up with anything.  I'm leaving this as a draft for now so we can discuss further.
