### PR TITLE
feat: Remove remnants of IE and old Edge

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -905,18 +905,12 @@ export class PlaylistController extends videojs.EventTarget {
 
     // Delete all buffered data to allow an immediate quality switch, then seek to give
     // the browser a kick to remove any cached frames from the previous rendtion (.04 seconds
-    // ahead is roughly the minimum that will accomplish this across a variety of content
+    // ahead was roughly the minimum that will accomplish this across a variety of content
     // in IE and Edge, but seeking in place is sufficient on all other browsers)
     // Edge/IE bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14600375/
     // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=651904
     this.mainSegmentLoader_.resetEverything(() => {
-      // Since this is not a typical seek, we avoid the seekTo method which can cause segments
-      // from the previously enabled rendition to load before the new playlist has finished loading
-      if (videojs.browser.IE_VERSION || videojs.browser.IS_EDGE) {
-        this.tech_.setCurrentTime(this.tech_.currentTime() + 0.04);
-      } else {
-        this.tech_.setCurrentTime(this.tech_.currentTime());
-      }
+      this.tech_.setCurrentTime(this.tech_.currentTime());
     });
 
     // don't need to reset audio as it is reset when media changes
@@ -972,19 +966,6 @@ export class PlaylistController extends videojs.EventTarget {
       if (!seekable.length) {
         // without a seekable range, the player cannot seek to begin buffering at the live
         // point
-        return false;
-      }
-
-      if (videojs.browser.IE_VERSION &&
-          this.tech_.readyState() === 0) {
-        // IE11 throws an InvalidStateError if you try to set currentTime while the
-        // readyState is 0, so it must be delayed until the tech fires loadedmetadata.
-        this.tech_.one('loadedmetadata', () => {
-          this.trigger('firstplay');
-          this.tech_.setCurrentTime(seekable.end(0));
-          this.hasPlayed_ = true;
-        });
-
         return false;
       }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -576,7 +576,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // TODO possibly move gopBuffer and timeMapping info to a separate controller
     this.gopBuffer_ = [];
     this.timeMapping_ = 0;
-    this.safeAppend_ = videojs.browser.IE_VERSION >= 11;
+    this.safeAppend_ = false;
     this.appendInitSegment_ = {
       audio: true,
       video: true

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -468,11 +468,9 @@ export default class SourceUpdater extends videojs.EventTarget {
    *          if removeSourceBuffer can be called.
    */
   canRemoveSourceBuffer() {
-    // IE reports that it supports removeSourceBuffer, but often throws
-    // errors when attempting to use the function. So we report that it
-    // does not support removeSourceBuffer. As of Firefox 83 removeSourceBuffer
-    // throws errors, so we report that it does not support this as well.
-    return !videojs.browser.IE_VERSION && !videojs.browser.IS_FIREFOX && window.MediaSource &&
+    // As of Firefox 83 removeSourceBuffer
+    // throws errors, so we report that it does not support this.
+    return !videojs.browser.IS_FIREFOX && window.MediaSource &&
       window.MediaSource.prototype &&
       typeof window.MediaSource.prototype.removeSourceBuffer === 'function';
   }

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -287,8 +287,8 @@ export const waitForKeySessionCreation = ({
   const keySessionCreatedPromises = [];
 
   // Since PSSH values are interpreted as initData, EME will dedupe any duplicates. The
-  // only place where it should not be deduped is for ms-prefixed APIs, but the early
-  // return for IE11 above, and the existence of modern EME APIs in addition to
+  // only place where it should not be deduped is for ms-prefixed APIs, but
+  // the existence of modern EME APIs in addition to
   // ms-prefixed APIs on Edge should prevent this from being a concern.
   // initializeMediaKeys also won't use the webkit-prefixed APIs.
   keySystemsOptionsArr.forEach((keySystemsOptions) => {
@@ -1058,9 +1058,7 @@ class VhsHandler extends Component {
     this.handleWaitingForKey_ = this.handleWaitingForKey_.bind(this);
     this.player_.tech_.on('waitingforkey', this.handleWaitingForKey_);
 
-    // In IE11 this is too early to initialize media keys, and IE11 does not support
-    // promises.
-    if (videojs.browser.IE_VERSION === 11 || !didSetupEmeOptions) {
+    if (!didSetupEmeOptions) {
       // If EME options were not set up, we've done all we could to initialize EME.
       this.playlistController_.sourceUpdater_.initializedEme();
       return;

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1,5 +1,4 @@
 import QUnit from 'qunit';
-import videojs from 'video.js';
 import xhrFactory from '../src/xhr';
 import Config from '../src/config';
 import document from 'global/document';
@@ -925,16 +924,7 @@ export const LoaderCommonFactory = ({
 
     // only main/fmp4 segment loaders use async appends and parts/partIndex
     if (usesAsyncAppends) {
-      let testFn = 'test';
-
-      if (videojs.browser.IE_VERSION) {
-        testFn = 'skip';
-      }
-
-      // this test has a race condition on ie 11 that causes it to fail some of the time.
-      // Since IE 11 isn't really a priority and it only fails some of the time we decided to
-      // skip this on IE 11.
-      QUnit[testFn]('playlist change before any appends does not error', function(assert) {
+      QUnit.test('playlist change before any appends does not error', function(assert) {
         return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
           loader.playlist(playlistWithDuration(50, {
             uri: 'bar-720.m3u8',

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -34,13 +34,6 @@ const playFor = function(player, time, cb) {
   checkPlayerTime();
 };
 
-let testFn = 'test';
-
-// TODO: get these tests working, right now we just one the one basic test
-if (videojs.browser.IE_VERSION || videojs.browser.IS_EDGE) {
-  testFn = 'skip';
-}
-
 QUnit.module('Playback', {
   beforeEach(assert) {
     assert.timeout(50000);
@@ -117,7 +110,7 @@ QUnit.test('Advanced Bip Bop', function(assert) {
   });
 });
 
-QUnit[testFn]('replay', function(assert) {
+QUnit.test('replay', function(assert) {
   const done = assert.async();
 
   assert.expect(2);
@@ -145,7 +138,7 @@ QUnit[testFn]('replay', function(assert) {
   });
 });
 
-QUnit[testFn]('playlist with fmp4 segments', function(assert) {
+QUnit.test('playlist with fmp4 segments', function(assert) {
   const done = assert.async();
 
   assert.expect(2);
@@ -164,7 +157,7 @@ QUnit[testFn]('playlist with fmp4 segments', function(assert) {
   });
 });
 
-QUnit[testFn]('playlist with fmp4 and ts segments', function(assert) {
+QUnit.test('playlist with fmp4 and ts segments', function(assert) {
   const done = assert.async();
 
   assert.expect(2);
@@ -183,7 +176,7 @@ QUnit[testFn]('playlist with fmp4 and ts segments', function(assert) {
   });
 });
 
-QUnit[testFn]('Advanced Bip Bop preload=none', function(assert) {
+QUnit.test('Advanced Bip Bop preload=none', function(assert) {
   const done = assert.async();
 
   assert.expect(2);
@@ -204,7 +197,7 @@ QUnit[testFn]('Advanced Bip Bop preload=none', function(assert) {
   });
 });
 
-QUnit[testFn]('Big Buck Bunny', function(assert) {
+QUnit.test('Big Buck Bunny', function(assert) {
   const done = assert.async();
 
   assert.expect(2);
@@ -223,7 +216,7 @@ QUnit[testFn]('Big Buck Bunny', function(assert) {
   });
 });
 
-QUnit[testFn]('Live DASH', function(assert) {
+QUnit.test('Live DASH', function(assert) {
   const done = assert.async();
   const player = this.player;
 
@@ -257,7 +250,7 @@ QUnit[testFn]('Live DASH', function(assert) {
   player.play();
 });
 
-QUnit[testFn]('Multiperiod dash works and can end', function(assert) {
+QUnit.test('Multiperiod dash works and can end', function(assert) {
   const done = assert.async();
 
   assert.expect(2);
@@ -287,7 +280,7 @@ QUnit[testFn]('Multiperiod dash works and can end', function(assert) {
 // firefox has lower performance or more aggressive throttling than chrome
 // which causes a variety of issues.
 if (!videojs.browser.IS_FIREFOX) {
-  QUnit[testFn]('Big Buck Bunny audio only, groups & renditions same uri', function(assert) {
+  QUnit.test('Big Buck Bunny audio only, groups & renditions same uri', function(assert) {
     const done = assert.async();
 
     assert.expect(2);
@@ -306,7 +299,7 @@ if (!videojs.browser.IS_FIREFOX) {
     });
   });
 
-  QUnit[testFn]('Big Buck Bunny Demuxed av, audio only rendition same as group', function(assert) {
+  QUnit.test('Big Buck Bunny Demuxed av, audio only rendition same as group', function(assert) {
     const done = assert.async();
 
     assert.expect(2);
@@ -325,7 +318,7 @@ if (!videojs.browser.IS_FIREFOX) {
     });
   });
 
-  QUnit[testFn]('DASH sidx', function(assert) {
+  QUnit.test('DASH sidx', function(assert) {
     const done = assert.async();
     const player = this.player;
 
@@ -349,7 +342,7 @@ if (!videojs.browser.IS_FIREFOX) {
     });
   });
 
-  QUnit[testFn]('DASH sidx with alt audio should end', function(assert) {
+  QUnit.test('DASH sidx with alt audio should end', function(assert) {
     const done = assert.async();
     const player = this.player;
 
@@ -376,7 +369,7 @@ if (!videojs.browser.IS_FIREFOX) {
     });
   });
 
-  QUnit[testFn]('DRM Dash', function(assert) {
+  QUnit.test('DRM Dash', function(assert) {
     const done = assert.async();
     const player = this.player;
 
@@ -419,7 +412,7 @@ if (!videojs.browser.IS_FIREFOX) {
 
   // TODO: why does this make the next test
   // throw an "The operation was aborted." on firefox
-  QUnit[testFn]('loops', function(assert) {
+  QUnit.test('loops', function(assert) {
     const done = assert.async();
     const player = this.player;
 
@@ -444,7 +437,7 @@ if (!videojs.browser.IS_FIREFOX) {
   });
 }
 
-QUnit[testFn]('zero-length id3 segment', function(assert) {
+QUnit.test('zero-length id3 segment', function(assert) {
   const done = assert.async();
   const player = this.player;
 
@@ -465,7 +458,7 @@ QUnit[testFn]('zero-length id3 segment', function(assert) {
 
 const hlsDataUri = 'data:application/x-mpegurl;charset=utf-8,%23EXTM3U%0D%0A%0D%0A%23EXT-X-MEDIA%3ATYPE%3DAUDIO%2CGROUP-ID%3D%22bipbop_audio%22%2CLANGUAGE%3D%22eng%22%2CNAME%3D%22BipBop%20Audio%201%22%2CAUTOSELECT%3DYES%2CDEFAULT%3DYES%0D%0A%23EXT-X-MEDIA%3ATYPE%3DAUDIO%2CGROUP-ID%3D%22bipbop_audio%22%2CLANGUAGE%3D%22eng%22%2CNAME%3D%22BipBop%20Audio%202%22%2CAUTOSELECT%3DNO%2CDEFAULT%3DNO%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Falternate_audio_aac_sinewave%2Fprog_index.m3u8%22%0D%0A%0D%0A%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22English%22%2CDEFAULT%3DYES%2CAUTOSELECT%3DYES%2CFORCED%3DNO%2CLANGUAGE%3D%22en%22%2CCHARACTERISTICS%3D%22public.accessibility.transcribes-spoken-dialog%2C%20public.accessibility.describes-music-and-sound%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Feng%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22English%20%28Forced%29%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DNO%2CFORCED%3DYES%2CLANGUAGE%3D%22en%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Feng_forced%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22Fran%C3%83%C2%A7ais%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DYES%2CFORCED%3DNO%2CLANGUAGE%3D%22fr%22%2CCHARACTERISTICS%3D%22public.accessibility.transcribes-spoken-dialog%2C%20public.accessibility.describes-music-and-sound%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Ffra%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22Fran%C3%83%C2%A7ais%20%28Forced%29%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DNO%2CFORCED%3DYES%2CLANGUAGE%3D%22fr%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Ffra_forced%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22Espa%C3%83%C2%B1ol%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DYES%2CFORCED%3DNO%2CLANGUAGE%3D%22es%22%2CCHARACTERISTICS%3D%22public.accessibility.transcribes-spoken-dialog%2C%20public.accessibility.describes-music-and-sound%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Fspa%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22Espa%C3%83%C2%B1ol%20%28Forced%29%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DNO%2CFORCED%3DYES%2CLANGUAGE%3D%22es%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Fspa_forced%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22%C3%A6%C2%97%C2%A5%C3%A6%C2%9C%C2%AC%C3%A8%C2%AA%C2%9E%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DYES%2CFORCED%3DNO%2CLANGUAGE%3D%22ja%22%2CCHARACTERISTICS%3D%22public.accessibility.transcribes-spoken-dialog%2C%20public.accessibility.describes-music-and-sound%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Fjpn%2Fprog_index.m3u8%22%0D%0A%23EXT-X-MEDIA%3ATYPE%3DSUBTITLES%2CGROUP-ID%3D%22subs%22%2CNAME%3D%22%C3%A6%C2%97%C2%A5%C3%A6%C2%9C%C2%AC%C3%A8%C2%AA%C2%9E%20%28Forced%29%22%2CDEFAULT%3DNO%2CAUTOSELECT%3DNO%2CFORCED%3DYES%2CLANGUAGE%3D%22ja%22%2CURI%3D%22https%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fsubtitles%2Fjpn_forced%2Fprog_index.m3u8%22%0D%0A%0D%0A%0D%0A%23EXT-X-STREAM-INF%3ABANDWIDTH%3D263851%2CCODECS%3D%22mp4a.40.2%2C%20avc1.4d400d%22%2CRESOLUTION%3D416x234%2CAUDIO%3D%22bipbop_audio%22%2CSUBTITLES%3D%22subs%22%0D%0Ahttps%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fgear1%2Fprog_index.m3u8%0D%0A%0D%0A%23EXT-X-STREAM-INF%3ABANDWIDTH%3D577610%2CCODECS%3D%22mp4a.40.2%2C%20avc1.4d401e%22%2CRESOLUTION%3D640x360%2CAUDIO%3D%22bipbop_audio%22%2CSUBTITLES%3D%22subs%22%0D%0Ahttps%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fgear2%2Fprog_index.m3u8%0D%0A%0D%0A%23EXT-X-STREAM-INF%3ABANDWIDTH%3D915905%2CCODECS%3D%22mp4a.40.2%2C%20avc1.4d401f%22%2CRESOLUTION%3D960x540%2CAUDIO%3D%22bipbop_audio%22%2CSUBTITLES%3D%22subs%22%0D%0Ahttps%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fgear3%2Fprog_index.m3u8%0D%0A%0D%0A%23EXT-X-STREAM-INF%3ABANDWIDTH%3D1030138%2CCODECS%3D%22mp4a.40.2%2C%20avc1.4d401f%22%2CRESOLUTION%3D1280x720%2CAUDIO%3D%22bipbop_audio%22%2CSUBTITLES%3D%22subs%22%0D%0Ahttps%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fgear4%2Fprog_index.m3u8%0D%0A%0D%0A%23EXT-X-STREAM-INF%3ABANDWIDTH%3D1924009%2CCODECS%3D%22mp4a.40.2%2C%20avc1.4d401f%22%2CRESOLUTION%3D1920x1080%2CAUDIO%3D%22bipbop_audio%22%2CSUBTITLES%3D%22subs%22%0D%0Ahttps%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fgear5%2Fprog_index.m3u8%0D%0A%0D%0A%23EXT-X-STREAM-INF%3ABANDWIDTH%3D41457%2CCODECS%3D%22mp4a.40.2%22%2CAUDIO%3D%22bipbop_audio%22%2CSUBTITLES%3D%22subs%22%0D%0Ahttps%3A%2F%2Fd2zihajmogu5jn.cloudfront.net%2Fbipbop-advanced%2Fgear0%2Fprog_index.m3u8';
 
-QUnit[testFn]('hls data uri', function(assert) {
+QUnit.test('hls data uri', function(assert) {
   const done = assert.async();
   const player = this.player;
 
@@ -488,7 +481,7 @@ QUnit[testFn]('hls data uri', function(assert) {
 
 const dashDataUri = 'data:application/dash+xml;charset=utf-8,%3CMPD%20mediaPresentationDuration=%22PT634.566S%22%20minBufferTime=%22PT2.00S%22%20profiles=%22urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011%22%20type=%22static%22%20xmlns=%22urn:mpeg:dash:schema:mpd:2011%22%20xmlns:xsi=%22http://www.w3.org/2001/XMLSchema-instance%22%20xsi:schemaLocation=%22urn:mpeg:DASH:schema:MPD:2011%20DASH-MPD.xsd%22%3E%20%3CBaseURL%3Ehttps://dash.akamaized.net/akamai/bbb_30fps/%3C/BaseURL%3E%20%3CPeriod%3E%20%20%3CAdaptationSet%20mimeType=%22video/mp4%22%20contentType=%22video%22%20subsegmentAlignment=%22true%22%20subsegmentStartsWithSAP=%221%22%20par=%2216:9%22%3E%20%20%20%3CSegmentTemplate%20duration=%22120%22%20timescale=%2230%22%20media=%22$RepresentationID$/$RepresentationID$_$Number$.m4v%22%20startNumber=%221%22%20initialization=%22$RepresentationID$/$RepresentationID$_0.m4v%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_1024x576_2500k%22%20codecs=%22avc1.64001f%22%20bandwidth=%223134488%22%20width=%221024%22%20height=%22576%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_1280x720_4000k%22%20codecs=%22avc1.64001f%22%20bandwidth=%224952892%22%20width=%221280%22%20height=%22720%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_1920x1080_8000k%22%20codecs=%22avc1.640028%22%20bandwidth=%229914554%22%20width=%221920%22%20height=%221080%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_320x180_200k%22%20codecs=%22avc1.64000d%22%20bandwidth=%22254320%22%20width=%22320%22%20height=%22180%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_320x180_400k%22%20codecs=%22avc1.64000d%22%20bandwidth=%22507246%22%20width=%22320%22%20height=%22180%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_480x270_600k%22%20codecs=%22avc1.640015%22%20bandwidth=%22759798%22%20width=%22480%22%20height=%22270%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_640x360_1000k%22%20codecs=%22avc1.64001e%22%20bandwidth=%221254758%22%20width=%22640%22%20height=%22360%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_640x360_800k%22%20codecs=%22avc1.64001e%22%20bandwidth=%221013310%22%20width=%22640%22%20height=%22360%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_768x432_1500k%22%20codecs=%22avc1.64001e%22%20bandwidth=%221883700%22%20width=%22768%22%20height=%22432%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_30fps_3840x2160_12000k%22%20codecs=%22avc1.640033%22%20bandwidth=%2214931538%22%20width=%223840%22%20height=%222160%22%20frameRate=%2230%22%20sar=%221:1%22%20scanType=%22progressive%22/%3E%20%20%3C/AdaptationSet%3E%20%20%3CAdaptationSet%20mimeType=%22audio/mp4%22%20contentType=%22audio%22%20subsegmentAlignment=%22true%22%20subsegmentStartsWithSAP=%221%22%3E%20%20%20%3CAccessibility%20schemeIdUri=%22urn:tva:metadata:cs:AudioPurposeCS:2007%22%20value=%226%22/%3E%20%20%20%3CRole%20schemeIdUri=%22urn:mpeg:dash:role:2011%22%20value=%22main%22/%3E%20%20%20%3CSegmentTemplate%20duration=%22192512%22%20timescale=%2248000%22%20media=%22$RepresentationID$/$RepresentationID$_$Number$.m4a%22%20startNumber=%221%22%20initialization=%22$RepresentationID$/$RepresentationID$_0.m4a%22/%3E%20%20%20%3CRepresentation%20id=%22bbb_a64k%22%20codecs=%22mp4a.40.5%22%20bandwidth=%2267071%22%20audioSamplingRate=%2248000%22%3E%20%20%20%20%3CAudioChannelConfiguration%20schemeIdUri=%22urn:mpeg:dash:23003:3:audio_channel_configuration:2011%22%20value=%222%22/%3E%20%20%20%3C/Representation%3E%20%20%3C/AdaptationSet%3E%20%3C/Period%3E%3C/MPD%3E';
 
-QUnit[testFn]('dash data uri', function(assert) {
+QUnit.test('dash data uri', function(assert) {
   const done = assert.async();
   const player = this.player;
 
@@ -504,7 +497,7 @@ QUnit[testFn]('dash data uri', function(assert) {
   });
 });
 
-QUnit[testFn]('dash manifest object', function(assert) {
+QUnit.test('dash manifest object', function(assert) {
   const done = assert.async();
   const player = this.player;
 
@@ -519,7 +512,7 @@ QUnit[testFn]('dash manifest object', function(assert) {
   });
 });
 
-QUnit[testFn]('hls manifest object', function(assert) {
+QUnit.test('hls manifest object', function(assert) {
   const done = assert.async();
   const player = this.player;
 

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -1,5 +1,4 @@
 import QUnit from 'qunit';
-import videojs from 'video.js';
 import {
   default as PlaylistLoader,
   updateSegments,
@@ -2422,435 +2421,433 @@ QUnit.module('Playlist Loader', function(hooks) {
     assert.equal(this.requests.length, 1, 'playlist re-requested');
   });
 
-  if (!videojs.browser.IE_VERSION) {
-    QUnit.module('llhls', {
-      beforeEach() {
-        this.fakeVhs.options_ = {llhls: true};
-        this.loader = new PlaylistLoader('http://example.com/media.m3u8', this.fakeVhs);
-
-        this.loader.load();
-
-      },
-      afterEach() {
-        this.loader.dispose();
-      }
-    });
-
-    QUnit.test('#EXT-X-SKIP does not add initial empty segments', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SKIP:SKIPPED-SEGMENTS=10\n' +
-        '#EXTINF:2\n' +
-        'low-1.ts\n'
-      );
-      assert.equal(this.loader.media().segments.length, 1, 'only 1 segment');
-    });
-
-    QUnit.test('#EXT-X-SKIP merges skipped segments', function(assert) {
-      let playlist =
-        '#EXTM3U\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n';
-
-      for (let i = 0; i < 10; i++) {
-        playlist += '#EXTINF:2\n';
-        playlist += `segment-${i}.ts\n`;
-      }
-
-      this.requests.shift().respond(200, null, playlist);
-      assert.equal(this.loader.media().segments.length, 10, '10 segments');
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      const skippedPlaylist =
-        '#EXTM3U\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SKIP:SKIPPED-SEGMENTS=10\n' +
-        '#EXTINF:2\n' +
-        'segment-10.ts\n';
-
-      this.requests.shift().respond(200, null, skippedPlaylist);
-
-      assert.equal(this.loader.media().segments.length, 11, '11 segments');
-
-      this.loader.media().segments.forEach(function(s, i) {
-        if (i < 10) {
-          assert.ok(s.hasOwnProperty('skipped'), 'has skipped property');
-          assert.false(s.skipped, 'skipped property is false');
-        }
-
-        assert.equal(s.uri, `segment-${i}.ts`, 'segment uri as expected');
-      });
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      const skippedPlaylist2 =
-        '#EXTM3U\n' +
-        '#EXT-X-MEDIA-SEQUENCE:1\n' +
-        '#EXT-X-SKIP:SKIPPED-SEGMENTS=10\n' +
-        '#EXTINF:2\n' +
-        'segment-11.ts\n';
-
-      this.requests.shift().respond(200, null, skippedPlaylist2);
-
-      this.loader.media().segments.forEach(function(s, i) {
-        if (i < 10) {
-          assert.ok(s.hasOwnProperty('skipped'), 'has skipped property');
-          assert.false(s.skipped, 'skipped property is false');
-        }
-
-        assert.equal(s.uri, `segment-${i + 1}.ts`, 'segment uri as expected');
-      });
-    });
-
-    QUnit.test('#EXT-X-PRELOAD with parts to added to segment list', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXTINF:2\n' +
-        'low-1.ts\n' +
-        '#EXT-X-PART:URI="part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="part2.ts",DURATION=1\n'
-      );
-      const media = this.loader.media();
-
-      assert.equal(media.segments.length, 2, '2 segments');
-      assert.deepEqual(
-        media.preloadSegment,
-        media.segments[media.segments.length - 1],
-        'last segment is preloadSegment'
-      );
-    });
-
-    QUnit.test('#EXT-X-PRELOAD without parts not added to segment list', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXTINF:2\n' +
-        'low-1.ts\n' +
-        '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="part1.ts"\n'
-      );
-      const media = this.loader.media();
-
-      assert.equal(media.segments.length, 1, '1 segment');
-      assert.notDeepEqual(
-        media.preloadSegment,
-        media.segments[media.segments.length - 1],
-        'last segment is not preloadSegment'
-      );
-    });
-
-    QUnit.test('#EXT-X-PART added to segments', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXT-X-PART:URI="segment1-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment1-part2.ts",DURATION=1\n' +
-        'segment1.ts\n' +
-        '#EXT-X-PART:URI="segment2-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment2-part2.ts",DURATION=1\n' +
-        'segment2.ts\n' +
-        '#EXT-X-PART:URI="segment3-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment3-part2.ts",DURATION=1\n' +
-        'segment3.ts\n'
-      );
-      const segments = this.loader.media().segments;
-
-      assert.equal(segments.length, 4, '4 segments');
-      assert.notOk(segments[0].parts, 'no parts for first segment');
-      assert.equal(segments[1].parts.length, 2, 'parts for second segment');
-      assert.equal(segments[2].parts.length, 2, 'parts for third segment');
-      assert.equal(segments[3].parts.length, 2, 'parts for forth segment');
-    });
-
-    QUnit.test('Adds _HLS_skip=YES to url when CAN-SKIP-UNTIL is set', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=3\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment8-part2.ts",DURATION=1\n' +
-        'segment8.ts\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_skip=YES');
-    });
-
-    QUnit.test('Adds _HLS_skip=v2 to url when CAN-SKIP-UNTIL/CAN-SKIP-DATERANGES is set', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=3,CAN-SKIP-DATERANGES=YES\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment8-part2.ts",DURATION=1\n' +
-        'segment8.ts\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_skip=v2');
-    });
-
-    QUnit.test('Adds _HLS_part= and _HLS_msn= when we have a part preload hints and parts', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
-        '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part2.ts"\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=8&_HLS_part=1');
-    });
-
-    QUnit.test('Adds _HLS_part= and _HLS_msn= when we have only a part preload hint', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part1.ts"\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=7&_HLS_part=0');
-    });
-
-    QUnit.test('does not add _HLS_part= when we have only a preload parts without preload hints', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=8');
-    });
-
-    QUnit.test('Adds only _HLS_msn= when we have segment info', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment8-part2.ts",DURATION=1\n' +
-        'segment8.ts\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=9');
-    });
-
-    QUnit.test('can add all query directives', function(assert) {
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,CAN-SKIP-UNTIL=3\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
-        '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part2.ts"\n'
-      );
-
-      this.loader.trigger('mediaupdatetimeout');
-
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_skip=YES&_HLS_msn=8&_HLS_part=1');
-    });
-
-    QUnit.test('works with existing query directives', function(assert) {
-      // clear existing requests
-      this.requests.length = 0;
-
-      this.loader.dispose();
-      this.loader = new PlaylistLoader('http://example.com/media.m3u8?foo=test', this.fakeVhs);
+  QUnit.module('llhls', {
+    beforeEach() {
+      this.fakeVhs.options_ = {llhls: true};
+      this.loader = new PlaylistLoader('http://example.com/media.m3u8', this.fakeVhs);
 
       this.loader.load();
 
-      this.requests.shift().respond(
-        200, null,
-        '#EXTM3U\n' +
-        '#EXT-X-PART-INF:PART-TARGET=1\n' +
-        '#EXT-X-MEDIA-SEQUENCE:0\n' +
-        '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,CAN-SKIP-UNTIL=3\n' +
-        '#EXTINF:2\n' +
-        'segment0.ts\n' +
-        '#EXTINF:2\n' +
-        'segment1.ts\n' +
-        '#EXTINF:2\n' +
-        'segment2.ts\n' +
-        '#EXTINF:2\n' +
-        'segment3.ts\n' +
-        '#EXTINF:2\n' +
-        'segment4.ts\n' +
-        '#EXTINF:2\n' +
-        'segment5.ts\n' +
-        '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
-        'segment6.ts\n' +
-        '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
-        '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
-        'segment7.ts\n' +
-        '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
-        '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part2.ts"\n'
-      );
+    },
+    afterEach() {
+      this.loader.dispose();
+    }
+  });
 
-      this.loader.trigger('mediaupdatetimeout');
+  QUnit.test('#EXT-X-SKIP does not add initial empty segments', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SKIP:SKIPPED-SEGMENTS=10\n' +
+      '#EXTINF:2\n' +
+      'low-1.ts\n'
+    );
+    assert.equal(this.loader.media().segments.length, 1, 'only 1 segment');
+  });
 
-      assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?foo=test&_HLS_skip=YES&_HLS_msn=8&_HLS_part=1');
+  QUnit.test('#EXT-X-SKIP merges skipped segments', function(assert) {
+    let playlist =
+      '#EXTM3U\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n';
+
+    for (let i = 0; i < 10; i++) {
+      playlist += '#EXTINF:2\n';
+      playlist += `segment-${i}.ts\n`;
+    }
+
+    this.requests.shift().respond(200, null, playlist);
+    assert.equal(this.loader.media().segments.length, 10, '10 segments');
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    const skippedPlaylist =
+      '#EXTM3U\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SKIP:SKIPPED-SEGMENTS=10\n' +
+      '#EXTINF:2\n' +
+      'segment-10.ts\n';
+
+    this.requests.shift().respond(200, null, skippedPlaylist);
+
+    assert.equal(this.loader.media().segments.length, 11, '11 segments');
+
+    this.loader.media().segments.forEach(function(s, i) {
+      if (i < 10) {
+        assert.ok(s.hasOwnProperty('skipped'), 'has skipped property');
+        assert.false(s.skipped, 'skipped property is false');
+      }
+
+      assert.equal(s.uri, `segment-${i}.ts`, 'segment uri as expected');
     });
-  }
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    const skippedPlaylist2 =
+      '#EXTM3U\n' +
+      '#EXT-X-MEDIA-SEQUENCE:1\n' +
+      '#EXT-X-SKIP:SKIPPED-SEGMENTS=10\n' +
+      '#EXTINF:2\n' +
+      'segment-11.ts\n';
+
+    this.requests.shift().respond(200, null, skippedPlaylist2);
+
+    this.loader.media().segments.forEach(function(s, i) {
+      if (i < 10) {
+        assert.ok(s.hasOwnProperty('skipped'), 'has skipped property');
+        assert.false(s.skipped, 'skipped property is false');
+      }
+
+      assert.equal(s.uri, `segment-${i + 1}.ts`, 'segment uri as expected');
+    });
+  });
+
+  QUnit.test('#EXT-X-PRELOAD with parts to added to segment list', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXTINF:2\n' +
+      'low-1.ts\n' +
+      '#EXT-X-PART:URI="part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="part2.ts",DURATION=1\n'
+    );
+    const media = this.loader.media();
+
+    assert.equal(media.segments.length, 2, '2 segments');
+    assert.deepEqual(
+      media.preloadSegment,
+      media.segments[media.segments.length - 1],
+      'last segment is preloadSegment'
+    );
+  });
+
+  QUnit.test('#EXT-X-PRELOAD without parts not added to segment list', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXTINF:2\n' +
+      'low-1.ts\n' +
+      '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="part1.ts"\n'
+    );
+    const media = this.loader.media();
+
+    assert.equal(media.segments.length, 1, '1 segment');
+    assert.notDeepEqual(
+      media.preloadSegment,
+      media.segments[media.segments.length - 1],
+      'last segment is not preloadSegment'
+    );
+  });
+
+  QUnit.test('#EXT-X-PART added to segments', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXT-X-PART:URI="segment1-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment1-part2.ts",DURATION=1\n' +
+      'segment1.ts\n' +
+      '#EXT-X-PART:URI="segment2-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment2-part2.ts",DURATION=1\n' +
+      'segment2.ts\n' +
+      '#EXT-X-PART:URI="segment3-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment3-part2.ts",DURATION=1\n' +
+      'segment3.ts\n'
+    );
+    const segments = this.loader.media().segments;
+
+    assert.equal(segments.length, 4, '4 segments');
+    assert.notOk(segments[0].parts, 'no parts for first segment');
+    assert.equal(segments[1].parts.length, 2, 'parts for second segment');
+    assert.equal(segments[2].parts.length, 2, 'parts for third segment');
+    assert.equal(segments[3].parts.length, 2, 'parts for forth segment');
+  });
+
+  QUnit.test('Adds _HLS_skip=YES to url when CAN-SKIP-UNTIL is set', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=3\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment8-part2.ts",DURATION=1\n' +
+      'segment8.ts\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_skip=YES');
+  });
+
+  QUnit.test('Adds _HLS_skip=v2 to url when CAN-SKIP-UNTIL/CAN-SKIP-DATERANGES is set', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=3,CAN-SKIP-DATERANGES=YES\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment8-part2.ts",DURATION=1\n' +
+      'segment8.ts\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_skip=v2');
+  });
+
+  QUnit.test('Adds _HLS_part= and _HLS_msn= when we have a part preload hints and parts', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
+      '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part2.ts"\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=8&_HLS_part=1');
+  });
+
+  QUnit.test('Adds _HLS_part= and _HLS_msn= when we have only a part preload hint', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part1.ts"\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=7&_HLS_part=0');
+  });
+
+  QUnit.test('does not add _HLS_part= when we have only a preload parts without preload hints', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=8');
+  });
+
+  QUnit.test('Adds only _HLS_msn= when we have segment info', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment8-part2.ts",DURATION=1\n' +
+      'segment8.ts\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_msn=9');
+  });
+
+  QUnit.test('can add all query directives', function(assert) {
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,CAN-SKIP-UNTIL=3\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
+      '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part2.ts"\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?_HLS_skip=YES&_HLS_msn=8&_HLS_part=1');
+  });
+
+  QUnit.test('works with existing query directives', function(assert) {
+    // clear existing requests
+    this.requests.length = 0;
+
+    this.loader.dispose();
+    this.loader = new PlaylistLoader('http://example.com/media.m3u8?foo=test', this.fakeVhs);
+
+    this.loader.load();
+
+    this.requests.shift().respond(
+      200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-PART-INF:PART-TARGET=1\n' +
+      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,CAN-SKIP-UNTIL=3\n' +
+      '#EXTINF:2\n' +
+      'segment0.ts\n' +
+      '#EXTINF:2\n' +
+      'segment1.ts\n' +
+      '#EXTINF:2\n' +
+      'segment2.ts\n' +
+      '#EXTINF:2\n' +
+      'segment3.ts\n' +
+      '#EXTINF:2\n' +
+      'segment4.ts\n' +
+      '#EXTINF:2\n' +
+      'segment5.ts\n' +
+      '#EXT-X-PART:URI="segment6-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment6-part2.ts",DURATION=1\n' +
+      'segment6.ts\n' +
+      '#EXT-X-PART:URI="segment7-part1.ts",DURATION=1\n' +
+      '#EXT-X-PART:URI="segment7-part2.ts",DURATION=1\n' +
+      'segment7.ts\n' +
+      '#EXT-X-PART:URI="segment8-part1.ts",DURATION=1\n' +
+      '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="segment8-part2.ts"\n'
+    );
+
+    this.loader.trigger('mediaupdatetimeout');
+
+    assert.equal(this.requests[0].uri, 'http://example.com/media.m3u8?foo=test&_HLS_skip=YES&_HLS_msn=8&_HLS_part=1');
+  });
 });

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -2,7 +2,6 @@ import Playlist from '../src/playlist';
 import PlaylistLoader from '../src/playlist-loader';
 import QUnit from 'qunit';
 import xhrFactory from '../src/xhr';
-import videojs from 'video.js';
 import { useFakeEnvironment } from './test-helpers';
 // needed for plugin registration
 import '../src/videojs-http-streaming';
@@ -1463,56 +1462,54 @@ QUnit.module('Playlist', function() {
       }
     );
 
-    if (!videojs.browser.IE_VERSION) {
-      QUnit.test('can return a partIndex', function(assert) {
-        this.fakeVhs.options_ = {llhls: true};
-        const loader = new PlaylistLoader('media.m3u8', this.fakeVhs);
+    QUnit.test('can return a partIndex', function(assert) {
+      this.fakeVhs.options_ = {llhls: true};
+      const loader = new PlaylistLoader('media.m3u8', this.fakeVhs);
 
-        loader.load();
+      loader.load();
 
-        this.requests.shift().respond(
-          200, null,
-          '#EXTM3U\n' +
-          '#EXT-X-MEDIA-SEQUENCE:1001\n' +
-          '#EXTINF:4,\n' +
-          '1001.ts\n' +
-          '#EXTINF:5,\n' +
-          '1002.ts\n' +
-          '#EXT-X-PART:URI="1003.part1.ts",DURATION=1\n' +
-          '#EXT-X-PART:URI="1003.part2.ts",DURATION=1\n' +
-          '#EXT-X-PART:URI="1003.part3.ts",DURATION=1\n' +
-          '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="1003.part4.ts"\n'
-        );
+      this.requests.shift().respond(
+        200, null,
+        '#EXTM3U\n' +
+        '#EXT-X-MEDIA-SEQUENCE:1001\n' +
+        '#EXTINF:4,\n' +
+        '1001.ts\n' +
+        '#EXTINF:5,\n' +
+        '1002.ts\n' +
+        '#EXT-X-PART:URI="1003.part1.ts",DURATION=1\n' +
+        '#EXT-X-PART:URI="1003.part2.ts",DURATION=1\n' +
+        '#EXT-X-PART:URI="1003.part3.ts",DURATION=1\n' +
+        '#EXT-X-PRELOAD-HINT:TYPE="PART",URI="1003.part4.ts"\n'
+      );
 
-        const media = loader.media();
+      const media = loader.media();
 
-        this.defaults = {
-          playlist: media,
-          currentTime: 0,
-          startingSegmentIndex: 0,
-          startingPartIndex: null,
-          startTime: 0
-        };
+      this.defaults = {
+        playlist: media,
+        currentTime: 0,
+        startingSegmentIndex: 0,
+        startingPartIndex: null,
+        startTime: 0
+      };
 
-        assert.deepEqual(
-          this.getMediaInfoForTime({currentTime: 10, startTime: 0}),
-          {segmentIndex: 2, startTime: 9, partIndex: 0},
-          'returns expected part/segment'
-        );
+      assert.deepEqual(
+        this.getMediaInfoForTime({currentTime: 10, startTime: 0}),
+        {segmentIndex: 2, startTime: 9, partIndex: 0},
+        'returns expected part/segment'
+      );
 
-        assert.deepEqual(
-          this.getMediaInfoForTime({currentTime: 11, startTime: 0}),
-          {segmentIndex: 2, startTime: 10, partIndex: 1},
-          'returns expected part/segment'
-        );
+      assert.deepEqual(
+        this.getMediaInfoForTime({currentTime: 11, startTime: 0}),
+        {segmentIndex: 2, startTime: 10, partIndex: 1},
+        'returns expected part/segment'
+      );
 
-        assert.deepEqual(
-          this.getMediaInfoForTime({currentTime: 11, segmentIndex: -15}),
-          {segmentIndex: 2, startTime: 10, partIndex: 1},
-          'returns expected part/segment'
-        );
-      });
-    }
+      assert.deepEqual(
+        this.getMediaInfoForTime({currentTime: 11, segmentIndex: -15}),
+        {segmentIndex: 2, startTime: 10, partIndex: 1},
+        'returns expected part/segment'
+      );
+    });
 
     QUnit.test('liveEdgeDelay works as expected', function(assert) {
       const media = {

--- a/test/sanity.test.js
+++ b/test/sanity.test.js
@@ -11,11 +11,7 @@ QUnit.test('the environment is sane', function(assert) {
   assert.strictEqual(typeof sinon, 'object', 'sinon exists');
   assert.strictEqual(typeof videojs, 'function', 'videojs exists');
   assert.strictEqual(typeof window.MediaSource, 'function', 'MediaSource is a function');
-  if (videojs.browser.IE_VERSION) {
-    assert.strictEqual(typeof window.URL, 'object', 'URL is an object');
-  } else {
-    assert.strictEqual(typeof window.URL, 'function', 'URL is a function');
-  }
+  assert.strictEqual(typeof window.URL, 'function', 'URL is a function');
   assert.strictEqual(typeof videojs.Vhs, 'object', 'Vhs is an object');
   assert.strictEqual(
     typeof videojs.VhsSourceHandler,

--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -9,20 +9,8 @@ import { QUOTA_EXCEEDED_ERR } from '../src/error-codes';
 import {createTimeRanges} from '../src/util/vjs-compat';
 
 const checkInitialDuration = function({duration}) {
-  // ie sometimes sets duration to infinity earlier then expected
-  if (videojs.browser.IS_EDGE || videojs.browser.IE_VERSION) {
-    QUnit.assert.ok(Number.isNaN(duration) || !Number.isFinite(duration), 'starting duration as expected');
-  } else {
-    QUnit.assert.ok(Number.isNaN(duration), 'starting duration as expected');
-  }
+  QUnit.assert.ok(Number.isNaN(duration), 'starting duration as expected');
 };
-
-let testOrSkip = 'test';
-
-// some tests just don't work reliably on ie11 or edge
-if (videojs.browser.IS_EDGE || videojs.browser.IE_VERSION) {
-  testOrSkip = 'skip';
-}
 
 const concatSegments = (...segments) => {
   let byteLength = segments.reduce((acc, cv) => {
@@ -962,7 +950,7 @@ QUnit.test(
   }
 );
 
-QUnit[testOrSkip]('setDuration waits for audio buffer to finish updating', function(assert) {
+QUnit.test('setDuration waits for audio buffer to finish updating', function(assert) {
   const done = assert.async();
 
   assert.expect(5);
@@ -1013,50 +1001,48 @@ QUnit.test('setDuration waits for video buffer to finish updating', function(ass
   assert.ok(this.sourceUpdater.updating(), 'updating during appends');
 });
 
-if (!videojs.browser.IS_EDGE) {
-  QUnit.test(
-    'setDuration waits for both audio and video buffers to finish updating',
-    function(assert) {
-      const done = assert.async();
-      let appendsFinished = 0;
+QUnit.test(
+  'setDuration waits for both audio and video buffers to finish updating',
+  function(assert) {
+    const done = assert.async();
+    let appendsFinished = 0;
 
-      assert.expect(7);
+    assert.expect(7);
 
-      this.sourceUpdater.createSourceBuffers({
-        audio: 'mp4a.40.2',
-        video: 'avc1.4D001E'
-      });
+    this.sourceUpdater.createSourceBuffers({
+      audio: 'mp4a.40.2',
+      video: 'avc1.4D001E'
+    });
 
-      assert.notOk(this.sourceUpdater.updating(), 'not updating by default');
+    assert.notOk(this.sourceUpdater.updating(), 'not updating by default');
 
-      const checkDuration = () => {
-        // duration is set to infinity if content is appended before an explicit duration is
-        // set https://w3c.github.io/media-source/#sourcebuffer-init-segment-received
-        assert.equal(this.mediaSource.duration, Infinity, 'duration not set on media source');
+    const checkDuration = () => {
+      // duration is set to infinity if content is appended before an explicit duration is
+      // set https://w3c.github.io/media-source/#sourcebuffer-init-segment-received
+      assert.equal(this.mediaSource.duration, Infinity, 'duration not set on media source');
 
-        if (appendsFinished === 0) {
-          // try to set the duration while one of the buffers is still updating, this should
-          // happen after the other setDuration call
-          this.sourceUpdater.setDuration(12, () => {
-            assert.equal(this.mediaSource.duration, 12, 'set duration on media source');
-            done();
-          });
-        }
+      if (appendsFinished === 0) {
+        // try to set the duration while one of the buffers is still updating, this should
+        // happen after the other setDuration call
+        this.sourceUpdater.setDuration(12, () => {
+          assert.equal(this.mediaSource.duration, 12, 'set duration on media source');
+          done();
+        });
+      }
 
-        appendsFinished++;
-      };
+      appendsFinished++;
+    };
 
-      this.sourceUpdater.appendBuffer({type: 'video', bytes: mp4VideoTotal()}, checkDuration);
-      this.sourceUpdater.appendBuffer({type: 'audio', bytes: mp4AudioTotal()}, checkDuration);
-      this.sourceUpdater.setDuration(11, () => {
-        assert.equal(this.mediaSource.duration, 11, 'set duration on media source');
-      });
+    this.sourceUpdater.appendBuffer({type: 'video', bytes: mp4VideoTotal()}, checkDuration);
+    this.sourceUpdater.appendBuffer({type: 'audio', bytes: mp4AudioTotal()}, checkDuration);
+    this.sourceUpdater.setDuration(11, () => {
+      assert.equal(this.mediaSource.duration, 11, 'set duration on media source');
+    });
 
-      checkInitialDuration(this.mediaSource);
-      assert.ok(this.sourceUpdater.updating(), 'updating during appends');
-    }
-  );
-}
+    checkInitialDuration(this.mediaSource);
+    assert.ok(this.sourceUpdater.updating(), 'updating during appends');
+  }
+);
 
 QUnit.test(
   'setDuration blocks audio and video queue entries until it finishes',
@@ -1318,7 +1304,7 @@ QUnit.test('dispose removes sourceopen listener', function(assert) {
   });
 });
 
-QUnit[testOrSkip]('audio appends are delayed until video append for the first append', function(assert) {
+QUnit.test('audio appends are delayed until video append for the first append', function(assert) {
   const done = assert.async();
   let audioAppend = false;
   let videoAppend = false;


### PR DESCRIPTION
## Description
Removes most remaining IE specific code, in part to be able to remove `videojs.browser.IE_VERSION`.
Also removes some legacy Edge checks.  

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
