### PR TITLE
fix: Linear DASH multiperiod label issue

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -87,14 +87,14 @@ const dashPlaylistUnchanged = function(a, b) {
 };
 
 /**
- * Use the representation IDs from the mpd object to create groupIDs, this allows for continuous playout across periods
- * with the same representation IDs (continuous periods as defined in DASH-IF 3.2.12). This is assumed in the mpd-parser
- * as well. If we want to support periods without continuous playback this function may need modification as well as the
- * parser.
+ * Use the representation IDs from the mpd object to create groupIDs, the NAME is set to mandatory representation
+ * ID in the parser. This allows for continuous playout across periods with the same representation IDs
+ * (continuous periods as defined in DASH-IF 3.2.12). This is assumed in the mpd-parser as well. If we want to support
+ * periods without continuous playback this function may need modification as well as the parser.
  */
 const dashGroupId = (type, group, label, playlist) => {
-  // NAME is set to the id in the parser.
-  const playlistId = playlist.attributes && playlist.attributes.NAME ? playlist.attributes.NAME : label;
+  // If the manifest somehow does not have an ID (non-dash compliant), use the label.
+  const playlistId = playlist.attributes.NAME || label;
 
   return `placeholder-uri-${type}-${group}-${playlistId}`;
 };

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -143,7 +143,7 @@ export const parseMainXml = ({
  *         The new mpd object
  */
 const removeOldMediaGroupLabels = (update, newMain) => {
-  forEachMediaGroup(update, (_, type, group, label) => {
+  forEachMediaGroup(update, (properties, type, group, label) => {
     if (!(label in newMain.mediaGroups[type][group])) {
       delete update.mediaGroups[type][group][label];
     }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -87,8 +87,10 @@ const dashPlaylistUnchanged = function(a, b) {
 };
 
 /**
- * Use the representation ids from the mpd object to create groupIDs, this allows for continuity across periods
- * regardless of the current label.
+ * Use the representation IDs from the mpd object to create groupIDs, this allows for continuous playout across periods
+ * with the same representation IDs (continuous periods as defined in DASH-IF 3.2.12). This is assumed in the mpd-parser
+ * as well. If we want to support periods without continuous playback this function may need modification as well as the
+ * parser.
  */
 const dashGroupId = (type, group, label, playlist) => {
   // NAME is set to the id in the parser.

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -86,6 +86,13 @@ const dashPlaylistUnchanged = function(a, b) {
   return true;
 };
 
+// DASH playlist playlistIDs should be the same accross period regardless of the mediaGroup label
+const dashGroupId = (type, group, label, playlist) => {
+  const playlistId = playlist.attributes && playlist.attributes.NAME ? playlist.attributes.NAME : label;
+
+  return `placeholder-uri-${type}-${group}-${playlistId}`;
+};
+
 /**
  * Parses the main XML string and updates playlist URI references.
  *
@@ -116,7 +123,7 @@ export const parseMainXml = ({
     previousManifest
   });
 
-  addPropertiesToMain(manifest, srcUrl);
+  addPropertiesToMain(manifest, srcUrl, dashGroupId);
 
   return manifest;
 };
@@ -170,6 +177,9 @@ export const updateMain = (oldMain, newMain, sidxMapping) => {
 
       if (playlistUpdate) {
         update = playlistUpdate;
+        if (!(label in update.mediaGroups[type][group])) {
+          update.mediaGroups[type][group][label] = properties;
+        }
         // update the playlist reference within media groups
         update.mediaGroups[type][group][label].playlists[0] = update.playlists[id];
         noChanges = false;

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -10,6 +10,10 @@ export const createPlaylistID = (index, uri) => {
   return `${index}-${uri}`;
 };
 
+const groupID = (type, group, label, _) => {
+  return `placeholder-uri-${type}-${group}-${label}`;
+};
+
 /**
  * Parses a given m3u8 playlist
  *
@@ -266,7 +270,7 @@ export const mainForMedia = (media, uri) => {
  * @param {string} uri
  *        The source URI
  */
-export const addPropertiesToMain = (main, uri) => {
+export const addPropertiesToMain = (main, uri, createGroupID = groupID) => {
   main.uri = uri;
 
   for (let i = 0; i < main.playlists.length; i++) {
@@ -282,8 +286,6 @@ export const addPropertiesToMain = (main, uri) => {
   const audioOnlyMain = isAudioOnly(main);
 
   forEachMediaGroup(main, (properties, mediaType, groupKey, labelKey) => {
-    const groupId = `placeholder-uri-${mediaType}-${groupKey}-${labelKey}`;
-
     // add a playlist array under properties
     if (!properties.playlists || !properties.playlists.length) {
       // If the manifest is audio only and this media group does not have a uri, check
@@ -303,6 +305,7 @@ export const addPropertiesToMain = (main, uri) => {
     }
 
     properties.playlists.forEach(function(p, i) {
+      const groupId = createGroupID(mediaType, groupKey, labelKey, p);
       const id = createPlaylistID(i, groupId);
 
       if (p.uri) {

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -10,7 +10,8 @@ export const createPlaylistID = (index, uri) => {
   return `${index}-${uri}`;
 };
 
-const groupID = (type, group, label, _) => {
+// default function for creating a group id
+const groupID = (type, group, label) => {
   return `placeholder-uri-${type}-${group}-${label}`;
 };
 
@@ -269,6 +270,8 @@ export const mainForMedia = (media, uri) => {
  *        main manifest object
  * @param {string} uri
  *        The source URI
+ * @param {function} createGroupID
+ *        A function to determine how to create the groupID for mediaGroups
  */
 export const addPropertiesToMain = (main, uri, createGroupID = groupID) => {
   main.uri = uri;

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -557,7 +557,7 @@ QUnit.test('filterChangedSidxMappings: removes change sidx info from mapping', f
   );
   const playlists = loader.main.playlists;
   const oldVideoKey = generateSidxKey(playlists['0-placeholder-uri-0'].sidx);
-  const oldAudioEnKey = generateSidxKey(playlists['0-placeholder-uri-AUDIO-audio-en'].sidx);
+  const oldAudioEnKey = generateSidxKey(playlists['0-placeholder-uri-AUDIO-audio-audio'].sidx);
 
   let mainXml = loader.mainXml_.replace(/(indexRange)=\"\d+-\d+\"/, '$1="201-400"');
   // should change the video playlist
@@ -1394,7 +1394,7 @@ QUnit.test('haveMain: sets media on child loader', function(assert) {
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  const childPlaylist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-main'];
+  const childPlaylist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-audio'];
   const childLoader = new DashPlaylistLoader(childPlaylist, this.fakeVhs, false, loader);
 
   const mediaStub = sinon.stub(childLoader, 'media');
@@ -2031,7 +2031,7 @@ QUnit.test('hasPendingRequest: returns true if async code is running in child lo
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  const childPlaylist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-main'];
+  const childPlaylist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-audio'];
   const childLoader = new DashPlaylistLoader(childPlaylist, this.fakeVhs, false, loader);
 
   assert.notOk(childLoader.hasPendingRequest(), 'no pending requests on construction');
@@ -2192,7 +2192,7 @@ QUnit.test('child loader moves to HAVE_METADATA when initialized with a main pla
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  const playlist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-main'];
+  const playlist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-audio'];
   const childLoader = new DashPlaylistLoader(playlist, this.fakeVhs, false, loader);
 
   childLoader.on('loadedplaylist', function() {
@@ -2225,7 +2225,7 @@ QUnit.test('child playlist moves to HAVE_METADATA when initialized with a live m
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  const playlist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-main'];
+  const playlist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-audio'];
   const childLoader = new DashPlaylistLoader(playlist, this.fakeVhs, false, loader);
 
   childLoader.on('loadedplaylist', function() {
@@ -2463,14 +2463,14 @@ QUnit.test(
     );
     assert.equal(
       loader.main.mediaGroups.AUDIO.audio.main.playlists[0].uri,
-      'placeholder-uri-AUDIO-audio-main', 'setup phony uri for media groups'
+      'placeholder-uri-AUDIO-audio-audio', 'setup phony uri for media groups'
     );
     assert.equal(
       loader.main.mediaGroups.AUDIO.audio.main.playlists[0].id,
-      '0-placeholder-uri-AUDIO-audio-main', 'setup phony id for media groups'
+      '0-placeholder-uri-AUDIO-audio-audio', 'setup phony id for media groups'
     );
     assert.strictEqual(
-      loader.main.playlists['0-placeholder-uri-AUDIO-audio-main'],
+      loader.main.playlists['0-placeholder-uri-AUDIO-audio-audio'],
       loader.main.mediaGroups.AUDIO.audio.main.playlists[0],
       'set reference by uri for easy access'
     );
@@ -2699,7 +2699,7 @@ QUnit.test('child loaders wait for async action before moving to HAVE_MAIN_MANIF
 
   loader.load();
   this.standardXHRResponse(this.requests.shift());
-  const childPlaylist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-main'];
+  const childPlaylist = loader.main.playlists['0-placeholder-uri-AUDIO-audio-audio'];
   const childLoader = new DashPlaylistLoader(childPlaylist, this.fakeVhs, false, loader);
 
   childLoader.load();

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -2860,3 +2860,131 @@ QUnit.test('updateMain: merges in top level timelineStarts', function(assert) {
 
   assert.deepEqual(update.timelineStarts, [2], 'updated timelineStarts');
 });
+
+QUnit.test('updateMain: updates playlists and mediaGroups when labels change', function(assert) {
+  const main = {
+    duration: 10,
+    minimumUpdatePeriod: 0,
+    timelineStarts: [],
+    mediaGroups: {
+      AUDIO: {
+        audio: {
+          main: {
+            playlists: [{
+              mediaSequence: 0,
+              attributes: {},
+              id: 'audio-0-uri',
+              uri: 'audio-0-uri',
+              resolvedUri: urlTo('audio-0-uri'),
+              segments: [{
+                duration: 10,
+                uri: 'audio-segment-0-uri',
+                resolvedUri: urlTo('audio-segment-0-uri')
+              }]
+            }]
+          }
+        }
+      }
+    },
+    playlists: [{
+      mediaSequence: 0,
+      attributes: {
+        BANDWIDTH: 9
+      },
+      id: 'playlist-0-uri',
+      uri: 'playlist-0-uri',
+      resolvedUri: urlTo('playlist-0-uri'),
+      segments: [{
+        duration: 10,
+        uri: 'segment-0-uri',
+        resolvedUri: urlTo('segment-0-uri')
+      }]
+    }]
+  };
+  const update = {
+    duration: 20,
+    minimumUpdatePeriod: 0,
+    timelineStarts: [],
+    mediaGroups: {
+      AUDIO: {
+        audio: {
+          update: {
+            playlists: [{
+              mediaSequence: 1,
+              attributes: {},
+              id: 'audio-0-uri',
+              uri: 'audio-0-uri',
+              resolvedUri: urlTo('audio-0-uri'),
+              segments: [{
+                duration: 10,
+                uri: 'audio-segment-0-uri',
+                resolvedUri: urlTo('audio-segment-0-uri')
+              }]
+            }]
+          }
+        }
+      }
+    },
+    playlists: [{
+      mediaSequence: 1,
+      attributes: {
+        BANDWIDTH: 9
+      },
+      id: 'playlist-0-uri',
+      uri: 'playlist-0-uri',
+      resolvedUri: urlTo('playlist-0-uri'),
+      segments: [{
+        duration: 10,
+        uri: 'segment-0-uri',
+        resolvedUri: urlTo('segment-0-uri')
+      }]
+    }]
+  };
+
+  main.playlists['playlist-0-uri'] = main.playlists[0];
+  main.playlists['audio-0-uri'] = main.mediaGroups.AUDIO.audio.main.playlists[0];
+
+  assert.deepEqual(
+    updateMain(main, update),
+    {
+      duration: 20,
+      minimumUpdatePeriod: 0,
+      timelineStarts: [],
+      mediaGroups: {
+        AUDIO: {
+          audio: {
+            update: {
+              playlists: [{
+                mediaSequence: 1,
+                attributes: {},
+                id: 'audio-0-uri',
+                uri: 'audio-0-uri',
+                resolvedUri: urlTo('audio-0-uri'),
+                segments: [{
+                  duration: 10,
+                  uri: 'audio-segment-0-uri',
+                  resolvedUri: urlTo('audio-segment-0-uri')
+                }]
+              }]
+            }
+          }
+        }
+      },
+      playlists: [{
+        mediaSequence: 1,
+        attributes: {
+          BANDWIDTH: 9
+        },
+        id: 'playlist-0-uri',
+        uri: 'playlist-0-uri',
+        resolvedUri: urlTo('playlist-0-uri'),
+        segments: [{
+          duration: 10,
+          uri: 'segment-0-uri',
+          resolvedUri: urlTo('segment-0-uri')
+        }]
+      }]
+    },
+    'updates playlists and media groups'
+  );
+});


### PR DESCRIPTION
## Description
Fixes [Linear DASH SSAI Label Issue](https://github.com/videojs/http-streaming/issues/1351)
Linear multi-period DASH with `<Label>` elements that roll in and out of continuous `AdaptationSet`s cause the stream to stall because we use the value of the `<Label>` as the key for the `mediaGroups.type.group.<labelKey>` object _and_ the associated mediaGroup group/playlist ID. When the manifest updates and reaches the period either with a `<Label>` or omitting the `<Label>` we can no longer access that media group or playlists to update the playlist as we rely on the labelKey set from the previous manifest/period to look for new segments in the update.

## Specific Changes proposed

- Change the way we create groupIDs for mediaGroup playlists to allow for DASH playlists to use the representation ID rather than the label from the parser. Per [DASH IF](https://dashif.org/docs/DASH-IF-IOP-v4.2-clean.htm), continuous media in separate periods share the same representation IDs across period boundaries, so this change can easily utilize that feature to ensure our playlistIDs are consistent between continuous periods.
- Add the new `labelKey` to the `mediaGroups.type.group` object and add the playlist reference.
- Remove any old `labelKey`s from the `mediaGroups.type.group` object that no longer exist in the new manifest update.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
