### PR TITLE
2x/fix/in manifest vtt ios mse issue

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -284,7 +284,26 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.subtitleSegmentLoader_ =
       new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
         loaderType: 'vtt',
-        featuresNativeTextTracks: this.tech_.featuresNativeTextTracks
+        featuresNativeTextTracks: this.tech_.featuresNativeTextTracks,
+        loadVttJs: () => new Promise((resolve, reject) => {
+          const tech = this.tech_;
+
+          function onLoad () {
+            tech.off('vttjserror', onError);
+            resolve();
+          }
+
+          function onError () {
+            tech.off('vttjsloaded', onLoad);
+            reject();
+          }
+
+          tech.one('vttjsloaded', onLoad);
+          tech.one('vttjserror', onError);
+
+          // safe to call multiple times, script will be loaded only once:
+          tech.addWebVttScript_();
+        })
       }), options);
 
     this.setupSegmentLoaderListeners_();

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -286,14 +286,12 @@ export class MasterPlaylistController extends videojs.EventTarget {
         loaderType: 'vtt',
         featuresNativeTextTracks: this.tech_.featuresNativeTextTracks,
         loadVttJs: () => new Promise((resolve, reject) => {
-          const tech = this.tech_;
-
-          function onLoad () {
+          function onLoad() {
             tech.off('vttjserror', onError);
             resolve();
           }
 
-          function onError () {
+          function onError() {
             tech.off('vttjsloaded', onLoad);
             reject();
           }

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1286,7 +1286,7 @@ const VhsSourceHandler = {
     tech.vhs.src(source.src, source.type);
     return tech.vhs;
   },
-  canPlayType(type, options = {}) {
+  canPlayType(type, options) {
     const simpleType = simpleTypeFromSourceType(type);
 
     if (!simpleType) {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1287,16 +1287,25 @@ const VhsSourceHandler = {
     return tech.vhs;
   },
   canPlayType(type, options = {}) {
-    const {
-      vhs: { overrideNative = !videojs.browser.IS_ANY_SAFARI } = {},
-      hls: { overrideNative: legacyOverrideNative = false } = {}
-    } = videojs.mergeOptions(videojs.options, options);
+    const simpleType = simpleTypeFromSourceType(type);
 
-    const supportedType = simpleTypeFromSourceType(type);
-    const canUseMsePlayback = supportedType &&
-      (!Vhs.supportsTypeNatively(supportedType) || legacyOverrideNative || overrideNative);
+    if (!simpleType) {
+      return '';
+    }
+
+    const overrideNative = VhsSourceHandler.getOverrideNative(options);
+    const supportsTypeNatively = Vhs.supportsTypeNatively(simpleType);
+    const canUseMsePlayback = !supportsTypeNatively || overrideNative;
 
     return canUseMsePlayback ? 'maybe' : '';
+  },
+  getOverrideNative(options = {}) {
+    const { vhs = {}, hls = {} } = options;
+    const defaultOverrideNative = !(videojs.browser.IS_ANY_SAFARI || videojs.browser.IS_IOS);
+    const { overrideNative = defaultOverrideNative } = vhs;
+    const { overrideNative: legacyOverrideNative = false } = hls;
+
+    return legacyOverrideNative || overrideNative;
   }
 };
 

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -13,6 +13,12 @@ import { ONE_SECOND_IN_TS } from 'mux.js/lib/utils/clock';
 const VTT_LINE_TERMINATORS =
   new Uint8Array('\n\n'.split('').map(char => char.charCodeAt(0)));
 
+class NoVttJsError extends Error {
+  constructor() {
+    super('Trying to parse received VTT cues, but there is no WebVTT. Make sure vtt.js is loaded.');
+  }
+}
+
 /**
  * An object that manages segment loading and appending.
  *
@@ -308,7 +314,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
         .then(
           () => this.segmentRequestFinished_(error, simpleSegment, result),
           () => this.stopForError({ message: 'Error loading vtt.js' })
-        )
+        );
       return;
     }
 
@@ -488,11 +494,5 @@ export default class VTTSegmentLoader extends SegmentLoader {
         time: Math.min(firstStart, lastStart - segment.duration)
       };
     }
-  }
-}
-
-class NoVttJsError extends Error {
-  constructor() {
-    super('Trying to parse received VTT cues, but there is no WebVTT. Make sure vtt.js is loaded.');
   }
 }

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -40,7 +40,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
 
     this.featuresNativeTextTracks_ = settings.featuresNativeTextTracks;
 
-    this.loadVttJs_ = settings.loadVttJs;
+    this.loadVttJs = settings.loadVttJs;
 
     // The VTT segment will have its own time mappings. Saving VTT segment timing info in
     // the sync controller leads to improper behavior.
@@ -306,11 +306,11 @@ export default class VTTSegmentLoader extends SegmentLoader {
     segmentInfo.bytes = simpleSegment.bytes;
 
     // Make sure that vttjs has loaded, otherwise, load it and wait till it finished loading
-    if (typeof window.WebVTT !== 'function' && typeof this.loadVttJs_ === 'function') {
+    if (typeof window.WebVTT !== 'function' && typeof this.loadVttJs === 'function') {
       this.state = 'WAITING_ON_VTTJS';
       // should be fine to call multiple times
       // script will be loaded once but multiple listeners will be added to the queue, which is expected.
-      this.loadVttJs_()
+      this.loadVttJs()
         .then(
           () => this.segmentRequestFinished_(error, simpleSegment, result),
           () => this.stopForError({ message: 'Error loading vtt.js' })

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -34,6 +34,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
 
     this.featuresNativeTextTracks_ = settings.featuresNativeTextTracks;
 
+    this.loadVttJs_ = settings.loadVttJs;
+
     // The VTT segment will have its own time mappings. Saving VTT segment timing info in
     // the sync controller leads to improper behavior.
     this.shouldSaveSegmentTimingInfo_ = false;
@@ -297,29 +299,16 @@ export default class VTTSegmentLoader extends SegmentLoader {
     }
     segmentInfo.bytes = simpleSegment.bytes;
 
-    // Make sure that vttjs has loaded, otherwise, wait till it finished loading
-    if (typeof window.WebVTT !== 'function' &&
-        this.subtitlesTrack_ &&
-        this.subtitlesTrack_.tech_) {
-
-      let loadHandler;
-      const errorHandler = () => {
-        this.subtitlesTrack_.tech_.off('vttjsloaded', loadHandler);
-        this.stopForError({
-          message: 'Error loading vtt.js'
-        });
-        return;
-      };
-
-      loadHandler = () => {
-        this.subtitlesTrack_.tech_.off('vttjserror', errorHandler);
-        this.segmentRequestFinished_(error, simpleSegment, result);
-      };
-
+    // Make sure that vttjs has loaded, otherwise, load it and wait till it finished loading
+    if (typeof window.WebVTT !== 'function' && typeof this.loadVttJs_ === 'function') {
       this.state = 'WAITING_ON_VTTJS';
-      this.subtitlesTrack_.tech_.one('vttjsloaded', loadHandler);
-      this.subtitlesTrack_.tech_.one('vttjserror', errorHandler);
-
+      // should be fine to call multiple times
+      // script will be loaded once but multiple listeners will be added to the queue, which is expected.
+      this.loadVttJs_()
+        .then(
+          () => this.segmentRequestFinished_(error, simpleSegment, result),
+          () => this.stopForError({ message: 'Error loading vtt.js' })
+        )
       return;
     }
 

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -391,6 +391,8 @@ export default class VTTSegmentLoader extends SegmentLoader {
   /**
    * Uses the WebVTT parser to parse the segment response
    *
+   * @throws NoVttJsError
+   *
    * @param {Object} segmentInfo
    *        a segment info object that describes the current segment
    * @private
@@ -398,6 +400,11 @@ export default class VTTSegmentLoader extends SegmentLoader {
   parseVTTCues_(segmentInfo) {
     let decoder;
     let decodeBytesToString = false;
+
+    if (typeof window.WebVTT !== 'function') {
+      // caller is responsible for exception handling.
+      throw new NoVttJsError();
+    }
 
     if (typeof window.TextDecoder === 'function') {
       decoder = new window.TextDecoder('utf8');
@@ -492,5 +499,11 @@ export default class VTTSegmentLoader extends SegmentLoader {
         time: Math.min(firstStart, lastStart - segment.duration)
       };
     }
+  }
+}
+
+class NoVttJsError extends Error {
+  constructor() {
+    super('Trying to parse received VTT cues, but there is no WebVTT. Make sure vtt.js is loaded.');
   }
 }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1,4 +1,5 @@
 import QUnit from 'qunit';
+import sinon from 'sinon';
 import videojs from 'video.js';
 import window from 'global/window';
 import {
@@ -616,6 +617,24 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
   assert.equal(resets, 1, 'resetEverything called if media is changed');
 
   assert.deepEqual(removeFuncArgs, {start: 0, end: 60}, 'remove() called with correct arguments if media is changed');
+});
+
+QUnit.test('loadVttJs should be passed to the vttSegmentLoader and resolved on vttjsloaded', function(assert) {
+  const stub = sinon.stub(this.player.tech_, 'addWebVttScript_').callsFake(() => this.player.tech_.trigger('vttjsloaded'));
+  const controller = new PlaylistController({ src: 'test', tech: this.player.tech_});
+
+  controller.subtitleSegmentLoader_.loadVttJs().then(() => {
+    assert.equal(stub.callCount, 1, 'tech addWebVttScript called once');
+  });
+});
+
+QUnit.test('loadVttJs should be passed to the vttSegmentLoader and rejected on vttjserror', function(assert) {
+  const stub = sinon.stub(this.player.tech_, 'addWebVttScript_').callsFake(() => this.player.tech_.trigger('vttjserror'));
+  const controller = new PlaylistController({ src: 'test', tech: this.player.tech_});
+
+  controller.subtitleSegmentLoader_.loadVttJs().catch(() => {
+    assert.equal(stub.callCount, 1, 'tech addWebVttScript called once');
+  });
 });
 
 QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', function(assert) {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -621,7 +621,7 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
 
 QUnit.test('loadVttJs should be passed to the vttSegmentLoader and resolved on vttjsloaded', function(assert) {
   const stub = sinon.stub(this.player.tech_, 'addWebVttScript_').callsFake(() => this.player.tech_.trigger('vttjsloaded'));
-  const controller = new PlaylistController({ src: 'test', tech: this.player.tech_});
+  const controller = new MasterPlaylistController({ src: 'test', tech: this.player.tech_});
 
   controller.subtitleSegmentLoader_.loadVttJs().then(() => {
     assert.equal(stub.callCount, 1, 'tech addWebVttScript called once');
@@ -630,7 +630,7 @@ QUnit.test('loadVttJs should be passed to the vttSegmentLoader and resolved on v
 
 QUnit.test('loadVttJs should be passed to the vttSegmentLoader and rejected on vttjserror', function(assert) {
   const stub = sinon.stub(this.player.tech_, 'addWebVttScript_').callsFake(() => this.player.tech_.trigger('vttjserror'));
-  const controller = new PlaylistController({ src: 'test', tech: this.player.tech_});
+  const controller = new MasterPlaylistController({ src: 'test', tech: this.player.tech_});
 
   controller.subtitleSegmentLoader_.loadVttJs().catch(() => {
     assert.equal(stub.callCount, 1, 'tech addWebVttScript called once');

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -3312,12 +3312,14 @@ QUnit.test('has no effect if native HLS is available and browser is Safari', fun
   videojs.browser.IS_ANY_SAFARI = origIsAnySafari;
 });
 
-QUnit.test('loads if native HLS is available but browser is not Safari', function(assert) {
+QUnit.test('has no effect if native HLS is available and browser is any non-safari browser on ios', function(assert) {
   const Html5 = videojs.getTech('Html5');
   const oldHtml5CanPlaySource = Html5.canPlaySource;
   const origIsAnySafari = videojs.browser.IS_ANY_SAFARI;
+  const originalIsIos = videojs.browser.IS_IOS;
 
   videojs.browser.IS_ANY_SAFARI = false;
+  videojs.browser.IS_IOS = true;
   Html5.canPlaySource = () => true;
   Vhs.supportsNativeHls = true;
   const player = createPlayer();
@@ -3329,10 +3331,11 @@ QUnit.test('loads if native HLS is available but browser is not Safari', functio
 
   this.clock.tick(1);
 
-  assert.ok(player.tech_.vhs, 'loaded VHS tech');
+  assert.ok(!player.tech_.vhs, 'did not load vhs tech');
   player.dispose();
   Html5.canPlaySource = oldHtml5CanPlaySource;
   videojs.browser.IS_ANY_SAFARI = origIsAnySafari;
+  videojs.browser.IS_IOS = originalIsIos;
 });
 
 QUnit.test(

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -308,11 +308,14 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
     QUnit.test(
       'waits for vtt.js to be loaded before attempting to parse cues',
       function(assert) {
-        let promiseLoadVttJs, resolveLoadVttJs
+        let promiseLoadVttJs; let resolveLoadVttJs;
+
         loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
           loaderType: 'vtt',
           loadVttJs: () => {
-            promiseLoadVttJs = new Promise((resolve) => resolveLoadVttJs = resolve);
+            promiseLoadVttJs = new Promise((resolve) => {
+              resolveLoadVttJs = resolve;
+            });
 
             return promiseLoadVttJs;
           }
@@ -744,11 +747,14 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
     });
 
     QUnit.test('loader triggers error event when vtt.js fails to load', function(assert) {
-      let promiseLoadVttJs, rejectLoadVttJs;
+      let promiseLoadVttJs; let rejectLoadVttJs;
+
       loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'vtt',
         loadVttJs: () => {
-          promiseLoadVttJs = new Promise((resolve, reject) => rejectLoadVttJs = reject);
+          promiseLoadVttJs = new Promise((resolve, reject) => {
+            rejectLoadVttJs = reject;
+          });
 
           return promiseLoadVttJs;
         }

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -12,6 +12,7 @@ import {
   LoaderCommonFactory
 } from './loader-common.js';
 import { encryptionKey, subtitlesEncrypted } from 'create-test-data!segments';
+import sinon from 'sinon';
 
 const oldVTT = window.WebVTT;
 
@@ -364,6 +365,52 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
         });
 
         resolveLoadVttJs();
+      }
+    );
+
+    QUnit.test(
+      'parse should throw if no vtt.js is loaded for any reason',
+      function(assert) {
+        const vttjs = window.WebVTT;
+        const playlist = playlistWithDuration(40);
+        let errors = 0;
+
+        const originalParse = loader.parseVTTCues_.bind(loader);
+
+        loader.parseVTTCues_ = (...args) => {
+          delete window.WebVTT;
+          return originalParse(...args);
+        };
+
+        const spy = sinon.spy(loader, 'error');
+
+        loader.on('error', () => errors++);
+
+        loader.playlist(playlist);
+        loader.track(this.track);
+        loader.load();
+
+        assert.equal(errors, 0, 'no error at loader start');
+
+        this.clock.tick(1);
+
+        // state WAITING for segment response
+        this.requests[0].responseType = 'arraybuffer';
+        this.requests.shift().respond(200, null, new Uint8Array(10).buffer);
+
+        this.clock.tick(1);
+
+        assert.equal(errors, 1, 'triggered error when parser emmitts fatal error');
+        assert.ok(loader.paused(), 'loader paused when encountering fatal error');
+        assert.equal(loader.state, 'READY', 'loader reset after error');
+        assert.ok(
+          spy.withArgs(sinon.match({
+            message: 'Trying to parse received VTT cues, but there is no WebVTT. Make sure vtt.js is loaded.'
+          })).calledOnce,
+          'error method called once with instance of NoVttJsError'
+        );
+
+        window.WebVTT = vttjs;
       }
     );
 


### PR DESCRIPTION
These are cherry-picked commits from this PR: https://github.com/videojs/http-streaming/pull/1360
with fixed conflicts for 2.x

...

## Description
We have a bug with default options setup for HLS in-manifest VTT in chrome iOS (and I assume other non-safari Webkit-based iOS browsers). The problem is that we do not load `vtt.js`, but we use `VHS` to handle playback. `vtt-segment-loader` implicitly depends on `window.WebVTT.Parser`. Since `vtt.js` is not loaded - `window.WebVTT` is `undefined`. It means that we are not able to parse received VTT cues.

## Specific Changes proposed
- Do not override native for all iOS/iPadOS browsers by default.
- Add fallback logic to load `vtt.js` in `vtt-segment-loader` if we do not have it loaded. (eg: force `overrideNative` option case).
- Add exception guard with a specific error message in case we call parse but still do not have vtt.js loaded for any reason.
- Fix/Add tests to cover all listed changes.

> **Note**
> Tested Chrome on iPadOS 16.2:
> default run: (native playback and apple's native text tracks are shown)
> set override Native to true (VHS playback and apple's native text tracks are shown)
> set override Native to true and set native text tracks to false (VHS playback and styled text tracks are shown)


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors

