### PR TITLE
feat: add fmp4 emsg ID3 support

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -462,7 +462,7 @@ const handleSegmentBytes = ({
     // Note that the start time returned by the probe reflects the baseMediaDecodeTime, as
     // that is the true start of the segment (where the playback engine should begin
     // decoding).
-    const finishLoading = (captions) => {
+    const finishLoading = (captions, id3Frames) => {
       // if the track still has audio at this point it is only possible
       // for it to be audio only. See `tracks.video && tracks.audio` if statement
       // above.
@@ -471,6 +471,9 @@ const handleSegmentBytes = ({
         data: bytesAsUint8Array,
         type: trackInfo.hasAudio && !trackInfo.isMuxed ? 'audio' : 'video'
       });
+      if (id3Frames && id3Frames.length) {
+        id3Fn(segment, id3Frames);
+      }
       if (captions && captions.length) {
         captionsFn(segment, captions);
       }
@@ -526,8 +529,7 @@ const handleSegmentBytes = ({
                 // transfer bytes back to us
                 bytes = emsgData.buffer;
                 segment.bytes = bytesAsUint8Array = emsgData;
-                id3Fn(segment, id3Frames);
-                finishLoading(message.captions);
+                finishLoading(message.captions, id3Frames);
               }
             });
           }

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -522,11 +522,11 @@ const handleSegmentBytes = ({
               data: bytesAsUint8Array,
               transmuxer: segment.transmuxer,
               offset: startTime,
-              callback: ({segmentData, emsgId3}) => {
+              callback: ({emsgData, id3Frames}) => {
                 // transfer bytes back to us
-                bytes = segmentData.buffer;
-                segment.bytes = bytesAsUint8Array = segmentData;
-                id3Fn(segment, emsgId3);
+                bytes = emsgData.buffer;
+                segment.bytes = bytesAsUint8Array = emsgData;
+                id3Fn(segment, id3Frames);
                 finishLoading(message.captions);
               }
             });

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -516,7 +516,20 @@ const handleSegmentBytes = ({
             message.logs.forEach(function(log) {
               onTransmuxerLog(merge(log, {stream: 'mp4CaptionParser'}));
             });
-            finishLoading(message.captions);
+
+            workerCallback({
+              action: 'probeEmsgID3',
+              data: bytesAsUint8Array,
+              transmuxer: segment.transmuxer,
+              offset: startTime,
+              callback: ({segmentData, emsgId3}) => {
+                // transfer bytes back to us
+                bytes = segmentData.buffer;
+                segment.bytes = bytesAsUint8Array = segmentData;
+                id3Fn(segment, emsgId3);
+                finishLoading(message.captions);
+              }
+            });
           }
         });
       }

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -228,6 +228,24 @@ class MessageHandlers {
   }
 
   /**
+   * Probes an mp4 segment for EMSG boxes containing ID3 data.
+   * https://aomediacodec.github.io/id3-emsg/
+   *
+   * @param {Uint8Array} data segment data
+   * @param {number} offset segment start time
+   * @return {Object[]} an array of ID3 frames
+   */
+  probeEmsgID3({data, offset}) {
+    const emsgId3 = mp4probe.getEmsgID3(data, offset);
+
+    this.self.postMessage({
+      action: 'probeEmsgID3',
+      emsgId3,
+      data
+    }, [data.buffer]);
+  }
+
+  /**
    * Probe an mpeg2-ts segment to determine the start time of the segment in it's
    * internal "media time," as well as whether it contains video and/or audio.
    *

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -236,12 +236,12 @@ class MessageHandlers {
    * @return {Object[]} an array of ID3 frames
    */
   probeEmsgID3({data, offset}) {
-    const emsgId3 = mp4probe.getEmsgID3(data, offset);
+    const id3Frames = mp4probe.getEmsgID3(data, offset);
 
     this.self.postMessage({
       action: 'probeEmsgID3',
-      emsgId3,
-      data
+      id3Frames,
+      emsgData: data
     }, [data.buffer]);
   }
 

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -1575,3 +1575,133 @@ QUnit.test('non-TS segment will get parsed for captions on next segment request 
   // Simulate receiving the init segment after the media
   this.standardXHRResponse(initReq, mp4VideoInit());
 });
+
+QUnit.test('can get emsg ID3 frames from fmp4 segment', function(assert) {
+  const done = assert.async();
+  let gotEmsgId3 = 0;
+  let gotData = 0;
+  // expected frame data
+  const id3Frames = [{
+    cueTime: 1,
+    duration: 0,
+    frames: [{
+      id: 'TXXX',
+      description: 'foo bar',
+      data: { key: 'value' }
+    },
+    {
+      id: 'PRIV',
+      owner: 'priv-owner@foo.bar',
+      // 'foo'
+      data: new Uint8Array([0x66, 0x6F, 0x6F])
+    }]
+  },
+  {
+    cueTime: 3,
+    duration: 0,
+    frames: [{
+      id: 'PRIV',
+      owner: 'priv-owner@foo.bar',
+      // 'bar'
+      data: new Uint8Array([0x62, 0x61, 0x72])
+    },
+    {
+      id: 'TXXX',
+      description: 'bar foo',
+      data: { key: 'value' }
+    }]
+  }];
+  const transmuxer = new videojs.EventTarget();
+
+  transmuxer.postMessage = (event) => {
+    if (event.action === 'pushMp4Captions') {
+      transmuxer.trigger({
+        type: 'message',
+        data: {
+          action: 'mp4Captions',
+          data: event.data,
+          captions: 'foo bar',
+          logs: []
+        }
+      });
+    }
+
+    if (event.action === 'probeMp4StartTime') {
+      transmuxer.trigger({
+        type: 'message',
+        data: {
+          action: 'probeMp4StartTime',
+          data: event.data,
+          timingInfo: {}
+        }
+      });
+    }
+
+    if (event.action === 'probeMp4Tracks') {
+      transmuxer.trigger({
+        type: 'message',
+        data: {
+          action: 'probeMp4Tracks',
+          data: event.data,
+          tracks: [{type: 'video', codec: 'avc1.4d400d'}]
+        }
+      });
+    }
+
+    if (event.action === 'probeEmsgID3') {
+      transmuxer.trigger({
+        type: 'message',
+        data: {
+          action: 'probeEmsgID3',
+          emsgData: event.data,
+          id3Frames
+        }
+      });
+    }
+  };
+
+  mediaSegmentRequest({
+    xhr: this.xhr,
+    xhrOptions: this.xhrOptions,
+    decryptionWorker: this.mockDecrypter,
+    segment: {
+      transmuxer,
+      resolvedUri: 'mp4Video.mp4',
+      map: {
+        resolvedUri: 'mp4VideoInit.mp4'
+      }
+    },
+    progressFn: this.noop,
+    trackInfoFn: this.noop,
+    timingInfoFn: this.noop,
+    id3Fn: (segment, _id3Frames) => {
+      gotEmsgId3++;
+      assert.deepEqual(_id3Frames, id3Frames, 'got expected emsg id3 data.');
+    },
+    captionsFn: this.noop,
+    dataFn: (segment, segmentData) => {
+      gotData++;
+      assert.ok(segmentData, 'init segment bytes in map');
+      assert.ok(segment.map.tracks, 'added tracks');
+      assert.ok(segment.map.tracks.video, 'added video track');
+    },
+    doneFn: () => {
+      assert.equal(gotEmsgId3, 1, 'received emsg ID3 event');
+      assert.equal(gotData, 1, 'received data event');
+      transmuxer.off();
+      done();
+    }
+  });
+  assert.equal(this.requests.length, 2, 'there are two requests');
+
+  const initReq = this.requests.shift();
+  const segmentReq = this.requests.shift();
+
+  assert.equal(initReq.uri, 'mp4VideoInit.mp4', 'the first request is for the init segment');
+  assert.equal(segmentReq.uri, 'mp4Video.mp4', 'the second request is for a segment');
+
+  // Simulate receiving the media first
+  this.standardXHRResponse(segmentReq, mp4Video());
+  // Simulate receiving the init segment after the media
+  this.standardXHRResponse(initReq, mp4VideoInit());
+});

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -1357,6 +1357,17 @@ QUnit.test('non-TS segment will get parsed for captions', function(assert) {
         }
       });
     }
+
+    if (event.action === 'probeEmsgID3') {
+      transmuxer.trigger({
+        type: 'message',
+        data: {
+          action: 'probeEmsgID3',
+          emsgData: event.data,
+          id3Frames: []
+        }
+      });
+    }
   };
 
   mediaSegmentRequest({
@@ -1495,6 +1506,17 @@ QUnit.test('non-TS segment will get parsed for captions on next segment request 
           action: 'probeMp4Tracks',
           data: event.data,
           tracks: [{type: 'video', codec: 'avc1.4d400d'}]
+        }
+      });
+    }
+
+    if (event.action === 'probeEmsgID3') {
+      transmuxer.trigger({
+        type: 'message',
+        data: {
+          action: 'probeEmsgID3',
+          emsgData: event.data,
+          id3Frames: []
         }
       });
     }


### PR DESCRIPTION
## Description
Currently VHS does not support passing ID3 frames to the text track from fmp4 segment emsg boxes. With some [additional parsing from mux.js](https://github.com/videojs/mux.js/pull/426) and this PR, this enables passing parsed ID3 frame data to the player `textTracks_` for use as timed metadata.

## Specific Changes proposed
Adding a new function to the `transmuxer-worker` that calls `getEmsgId3` on the transmuxer and returns parsed ID3 frames. Calling the worker function and passing the ID3 frames to the `id3Fn` passed in from the mediaSegmentRequest.

> ~Note: This is blocked by the work in the transmuxer being released and integrated. See: https://github.com/videojs/mux.js/pull/426~
Changes are integrated into VHS see PR: https://github.com/videojs/http-streaming/pull/1372

References: 
https://aomediacodec.github.io/id3-emsg/
https://dashif-documents.azurewebsites.net/Events/master/event.html#event-metadata-timing
https://github.com/id3/ID3v2.4/blob/master/id3v2.40-structure.txt

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
