### PR TITLE
chore(package): update mux.js to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6875,9 +6875,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.2.0.tgz",
-      "integrity": "sha512-SKuxIcbmK/aJoz78aQNuoXY8R/uEPm1gQMqWTXL6DNl7oF8UPjdt/AunXGkPQpBouGWKDgL/TzSl2VV5NuboRg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.3.0.tgz",
+      "integrity": "sha512-/QTkbSAP2+w1nxV+qTcumSDN5PA98P0tjrADijIzQHe85oBK3Akhy9AHlH0ne/GombLMz1rLyvVsmrgRxoPDrQ==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "global": "^4.4.0",
     "m3u8-parser": "^6.0.0",
     "mpd-parser": "^1.0.1",
-    "mux.js": "6.2.0",
+    "mux.js": "6.3.0",
     "video.js": "^7 || ^8"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description
Updating mux.js to 6.3.0 to provide the emsg probe functions for [this PR](https://github.com/videojs/http-streaming/pull/1370) which will add emsg ID3 tag support to VHS.

## Specific Changes proposed
Changing the version of mux.js used from 6.2.0 to 6.3.0.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
