### PR TITLE
Fix: CMAF HLS. Source buffer change type is called with wrong codecs sometimes when append segment without init data because of a race condition.

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1725,9 +1725,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
       audio: this.audioSegmentLoader_.getCurrentMediaInfo_() || {}
     };
 
+    const playlist = this.mainSegmentLoader_.getPendingSegmentPlaylist() || this.media();
+
     // set "main" media equal to video
     media.video = media.main;
-    const playlistCodecs = codecsForPlaylist(this.master(), this.media());
+    const playlistCodecs = codecsForPlaylist(this.master(), playlist);
     const codecs = {};
     const usingAudioLoader = !!this.mediaTypes_.AUDIO.activePlaylistLoader;
 
@@ -1748,7 +1750,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // no codecs, no playback.
     if (!codecs.audio && !codecs.video) {
       this.blacklistCurrentPlaylist({
-        playlist: this.media(),
+        playlist,
         message: 'Could not determine codecs for playlist.',
         blacklistDuration: Infinity
       });
@@ -1773,13 +1775,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
       }
     });
 
-    if (usingAudioLoader && unsupportedAudio && this.media().attributes.AUDIO) {
-      const audioGroup = this.media().attributes.AUDIO;
+    if (usingAudioLoader && unsupportedAudio && playlist.attributes.AUDIO) {
+      const audioGroup = playlist.attributes.AUDIO;
 
       this.master().playlists.forEach(variant => {
         const variantAudioGroup = variant.attributes && variant.attributes.AUDIO;
 
-        if (variantAudioGroup === audioGroup && variant !== this.media()) {
+        if (variantAudioGroup === audioGroup && variant !== playlist) {
           variant.excludeUntil = Infinity;
         }
       });
@@ -1800,7 +1802,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       }, '') + '.';
 
       this.blacklistCurrentPlaylist({
-        playlist: this.media(),
+        playlist,
         internal: true,
         message,
         blacklistDuration: Infinity
@@ -1825,7 +1827,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
       if (switchMessages.length) {
         this.blacklistCurrentPlaylist({
-          playlist: this.media(),
+          playlist,
           message: `Codec switching not supported: ${switchMessages.join(', ')}.`,
           blacklistDuration: Infinity,
           internal: true

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1982,6 +1982,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     return this.getCurrentMediaInfo_(segmentInfo) || this.startingMediaInfo_;
   }
 
+  getPendingSegmentPlaylist() {
+    return this.pendingSegment_ ? this.pendingSegment_.playlist : null;
+  }
+
   hasEnoughInfoToAppend_() {
     if (!this.sourceUpdater_.ready()) {
       return false;

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1162,6 +1162,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   resetEverything(done) {
     this.ended_ = false;
+    this.activeInitSegmentId_ = null;
     this.appendInitSegment_ = {
       audio: true,
       video: true

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -5101,6 +5101,7 @@ QUnit.test('Current pending segment\'s playlist codecs take priority over others
   });
 
   const originalGetPendingSegmentPlaylist = this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist.bind(this.mpc.mainSegmentLoader_);
+
   this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist = () => ({attributes: {CODECS: 'avc1.64001f', AUDIO: 'low-quality'}});
 
   const codecs = this.mpc.getCodecsOrExclude_();
@@ -5149,6 +5150,7 @@ QUnit.test('excludes current pending segment\'s playlist without detected audio/
   });
 
   const originalGetPendingSegmentPlaylist = this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist.bind(this.mpc.mainSegmentLoader_);
+
   this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist = () => ({attributes: {CODECS: ''}});
   const codecs = this.mpc.getCodecsOrExclude_();
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -5092,6 +5092,24 @@ QUnit.test('playlist codecs take priority over others', function(assert) {
   assert.deepEqual(codecs, {video: 'avc1.4b400d', audio: 'mp4a.40.20'}, 'codecs returned');
 });
 
+QUnit.test('Current pending segment\'s playlist codecs take priority over others', function(assert) {
+  this.contentSetup({
+    mainStartingMedia: {videoCodec: 'avc1.4c400d', hasVideo: true, hasAudio: false},
+    audioStartingMedia: {audioCodec: 'mp4a.40.5', hasVideo: false, hasAudio: true},
+    mainPlaylist: {attributes: {CODECS: 'avc1.4b400d', AUDIO: 'low-quality'}},
+    audioPlaylist: {attributes: {CODECS: 'mp4a.40.20'}}
+  });
+
+  const originalGetPendingSegmentPlaylist = this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist.bind(this.mpc.mainSegmentLoader_);
+  this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist = () => ({attributes: {CODECS: 'avc1.64001f', AUDIO: 'low-quality'}});
+
+  const codecs = this.mpc.getCodecsOrExclude_();
+
+  assert.deepEqual(this.blacklists, [], 'did not blacklist anything');
+  assert.deepEqual(codecs, {video: 'avc1.64001f', audio: 'mp4a.40.20'}, 'codecs returned');
+  this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist = originalGetPendingSegmentPlaylist;
+});
+
 QUnit.test('uses default codecs if no codecs are found', function(assert) {
   this.contentSetup({
     mainStartingMedia: {hasVideo: true, hasAudio: false},
@@ -5121,6 +5139,26 @@ QUnit.test('excludes playlist without detected audio/video', function(assert) {
     playlist: {attributes: {}}
   }], 'blacklisted playlist');
   assert.deepEqual(codecs, void 0, 'no codecs returned');
+});
+
+QUnit.test('excludes current pending segment\'s playlist without detected audio/video', function(assert) {
+  this.contentSetup({
+    mainStartingMedia: {},
+    audioStartingMedia: {},
+    mainPlaylist: {attributes: {}}
+  });
+
+  const originalGetPendingSegmentPlaylist = this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist.bind(this.mpc.mainSegmentLoader_);
+  this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist = () => ({attributes: {CODECS: ''}});
+  const codecs = this.mpc.getCodecsOrExclude_();
+
+  assert.deepEqual(this.blacklists, [{
+    blacklistDuration: Infinity,
+    message: 'Could not determine codecs for playlist.',
+    playlist: {attributes: {CODECS: ''}}
+  }], 'blacklisted playlist');
+  assert.deepEqual(codecs, void 0, 'no codecs returned');
+  this.mpc.mainSegmentLoader_.getPendingSegmentPlaylist = originalGetPendingSegmentPlaylist;
 });
 
 QUnit.test('excludes unsupported muxer codecs for ts', function(assert) {


### PR DESCRIPTION
## Description
We have a race condition issue that breaks playback during quality switch:
![CleanShot 2023-02-23 at 22 52 47@2x](https://user-images.githubusercontent.com/98566601/221112485-c7191a0e-5ee5-4a3d-97d3-096011c3c05d.png)
![CleanShot 2023-02-23 at 22 55 32@2x](https://user-images.githubusercontent.com/98566601/221112627-7115680e-bf85-4dd1-9439-6944d965bc3d.png)

Here is a visual representation of the race condition:
![CleanShot 2023-02-25 at 23 25 44@2x](https://user-images.githubusercontent.com/98566601/221397804-00a3acb4-5b40-400b-955b-68746ae18e6d.png)

As you can see from the visual representation, we have a pending segment request which is from the previous playlist, because the `seeking` event kick-starts the segment loader before we have a new playlist loaded. But we receive `trackInfo` after the new playlist is loaded. That means that during codec calculation it will get codecs from the new playlist, while the segment loader is about to append a segment from the previous one. Because initialization data is not added and codecs do not match with the source buffer's current codecs setup - the source buffer fails to append this segment.
The problem is reproducible mainly with CMAF HLS since the transport stream is usually self-initialized.

## Specific Changes proposed
I was thinking about possible ways to solve this problem. The first idea was the following:
Do not load segments while we are waiting for a playlist. 
Possible solutions could be: Ignore this seeking event after setting the current time after a segment loader resets everything. Visually it would look like this:
![CleanShot 2023-02-25 at 23 22 27@2x](https://user-images.githubusercontent.com/98566601/221397701-ce3a5068-0fb6-40a6-ba27-ff6967a8e800.png)

It works fine and fixes the issue, but!
Users will always see a loading spinner during the quality switch because the player removes everything from the source buffer and does not append anything. It will append only after the playlist + first segment are loaded.
So, users will lose a seamless quality switching experience.
This problem led me to the second idea: Keep segments loading but ensure that the player always adds initialization data after the quality switch, and the player always uses the segment's playlist for source buffer codecs calculation for consistency.


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [x] Reviewed by Two Core Contributors
