### PR TITLE
Fix: CMAF HLS. Source buffer change type is called with wrong codecs sometimes when append segment without init data because of a race condition.

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1715,9 +1715,11 @@ export class PlaylistController extends videojs.EventTarget {
       audio: this.audioSegmentLoader_.getCurrentMediaInfo_() || {}
     };
 
+    const playlist = this.mainSegmentLoader_.getPendingSegmentPlaylist() || this.media();
+
     // set "main" media equal to video
     media.video = media.main;
-    const playlistCodecs = codecsForPlaylist(this.main(), this.media());
+    const playlistCodecs = codecsForPlaylist(this.main(), playlist);
     const codecs = {};
     const usingAudioLoader = !!this.mediaTypes_.AUDIO.activePlaylistLoader;
 
@@ -1738,7 +1740,7 @@ export class PlaylistController extends videojs.EventTarget {
     // no codecs, no playback.
     if (!codecs.audio && !codecs.video) {
       this.excludePlaylist({
-        playlistToExclude: this.media(),
+        playlistToExclude: playlist,
         error: { message: 'Could not determine codecs for playlist.' },
         playlistExclusionDuration: Infinity
       });
@@ -1763,13 +1765,13 @@ export class PlaylistController extends videojs.EventTarget {
       }
     });
 
-    if (usingAudioLoader && unsupportedAudio && this.media().attributes.AUDIO) {
-      const audioGroup = this.media().attributes.AUDIO;
+    if (usingAudioLoader && unsupportedAudio && playlist.attributes.AUDIO) {
+      const audioGroup = playlist.attributes.AUDIO;
 
       this.main().playlists.forEach(variant => {
         const variantAudioGroup = variant.attributes && variant.attributes.AUDIO;
 
-        if (variantAudioGroup === audioGroup && variant !== this.media()) {
+        if (variantAudioGroup === audioGroup && variant !== playlist) {
           variant.excludeUntil = Infinity;
         }
       });
@@ -1790,7 +1792,7 @@ export class PlaylistController extends videojs.EventTarget {
       }, '') + '.';
 
       this.excludePlaylist({
-        playlistToExclude: this.media(),
+        playlistToExclude: playlist,
         error: {
           internal: true,
           message
@@ -1817,7 +1819,7 @@ export class PlaylistController extends videojs.EventTarget {
 
       if (switchMessages.length) {
         this.excludePlaylist({
-          playlistToExclude: this.media(),
+          playlistToExclude: playlist,
           error: {
             message: `Codec switching not supported: ${switchMessages.join(', ')}.`,
             internal: true

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1163,6 +1163,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   resetEverything(done) {
     this.ended_ = false;
+    this.activeInitSegmentId_ = null;
     this.appendInitSegment_ = {
       audio: true,
       video: true

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1983,6 +1983,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     return this.getCurrentMediaInfo_(segmentInfo) || this.startingMediaInfo_;
   }
 
+  getPendingSegmentPlaylist() {
+    return this.pendingSegment_ ? this.pendingSegment_.playlist : null;
+  }
+
   hasEnoughInfoToAppend_() {
     if (!this.sourceUpdater_.ready()) {
       return false;


### PR DESCRIPTION
> **Note**
> This is a cherry-pick of commits from the [following 2x branch PR](https://github.com/videojs/http-streaming/pull/1374) with adaptations for the `main` branch.



## Description
We have a race condition issue that breaks playback during quality switch:
![CleanShot 2023-02-23 at 22 52 47@2x](https://user-images.githubusercontent.com/98566601/221112485-c7191a0e-5ee5-4a3d-97d3-096011c3c05d.png)
![CleanShot 2023-02-23 at 22 55 32@2x](https://user-images.githubusercontent.com/98566601/221112627-7115680e-bf85-4dd1-9439-6944d965bc3d.png)

Here is a visual representation of the race condition:
![CleanShot 2023-02-25 at 23 25 44@2x](https://user-images.githubusercontent.com/98566601/221397804-00a3acb4-5b40-400b-955b-68746ae18e6d.png)

As you can see from the visual representation, we have a pending segment request which is from the previous playlist, because the `seeking` event kick-starts the segment loader before we have a new playlist loaded. But we receive `trackInfo` after the new playlist is loaded. That means that during codec calculation it will get codecs from the new playlist, while the segment loader is about to append a segment from the previous one. Because initialization data is not added and codecs do not match with the source buffer's current codecs setup - the source buffer fails to append this segment.
The problem is reproducible mainly with CMAF HLS since the transport stream is usually self-initialized.

## Specific Changes proposed
I was thinking about possible ways to solve this problem. The first idea was the following:
Do not load segments while we are waiting for a playlist. 
Possible solutions could be: Ignore this seeking event after setting the current time after a segment loader resets everything. Visually it would look like this:
![CleanShot 2023-02-25 at 23 22 27@2x](https://user-images.githubusercontent.com/98566601/221397701-ce3a5068-0fb6-40a6-ba27-ff6967a8e800.png)

It works fine and fixes the issue, but!
Users will always see a loading spinner during the quality switch because the player removes everything from the source buffer and does not append anything. It will append only after the playlist + first segment are loaded.
So, users will lose a seamless quality switching experience.
This problem led me to the second idea: Keep segments loading but ensure that the player always adds initialization data after the quality switch, and the player always uses the segment's playlist for source buffer codecs calculation for consistency.


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [x] Reviewed by Two Core Contributors
