### PR TITLE
chore: npm publish for release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -37,7 +37,7 @@ jobs:
 
       # publish runs build for us via a prepublishOnly script
       - name: npm release
-        run: npm publish --tag next
+        run: npm publish --tag next-2
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -29,12 +29,17 @@ jobs:
         with:
           node-version: '${{steps.nvm.outputs.NVMRC}}'
           cache: npm
+          # this line is required for the setup-node action to be able to run the npm publish below.
+          registry-url: 'https://registry.npmjs.org'
 
       - name: npm install
         run: npm i --prefer-offline --no-audit
 
-      - name: build
-        run: npm run build-prod --if-present
+      # publish runs build for us via a prepublishOnly script
+      - name: npm release
+        run: npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check if this is a pre-release
         run: echo ::set-output name=IS_PRE_RELEASE::$(npx -p not-prerelease is-prerelease && echo "true" || echo "false")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: github-release
+name: release
 on:
   push:
     tags:
@@ -7,7 +7,7 @@ on:
     # match semver pre-releases
     - "v[0-9]+.[0-9]+.[0-9]+-*"
 jobs:
-  github-release:
+  release:
     env:
       NETLIFY_BASE: 'videojs-http-streaming.netlify.app'
     runs-on: ubuntu-latest
@@ -72,3 +72,5 @@ jobs:
           files: |
             dist/**/*.js
             dist/**/*.css
+          discussion_category_name: Releases
+

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -59,7 +59,7 @@ Install dependencies for the project.
 npm install
 ```
 
-Then, it's mostly a standard npm package release process with running `npm version`, followed by an `npm publish`.
+Update version.
 
 ```sh
 npm version {major|minor|patch}
@@ -71,17 +71,16 @@ See [deciding what type of version release section](#deciding-what-type-of-versi
 Optionally, you can run `git show` now to verify that the version update and CHANGELOG automation worked as expected.
 
 Afterwards, you want to push the commit and the tag to the repo.
-It's necessary to do this before running `npm publish` because our GitHub release automation relies on the commit being available on GitHub.
 
 ```sh
 git push --follow-tags origin main
 ```
 
-Publish to npm.
+After the tag was pushed, GitHub actions will trigger the `release` workflow, which will do the following:
 
-```sh
-npm publish
-```
+* Publish to npm with `next` or `next-{n}` depending on your current major version.
+* Create GitHub release with changelog and Netlify preview.
+* Create a GitHub `releases` discussion linked to the GitHub release.
 
 If it's a large enough release, consider writing a blog post as well.
 


### PR DESCRIPTION
add npm publish step for release workflow
update release documentation

NOTE: `NPM_TOKEN` should be added to the repo secrets.
