### PR TITLE
refactor: remove nested loop from removeDuplicateCuesFromTrack function

### DIFF
--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -285,26 +285,16 @@ export const removeDuplicateCuesFromTrack = function(track) {
     return;
   }
 
-  for (let i = 0; i < cues.length; i++) {
-    const duplicates = [];
-    let occurrences = 0;
+  const uniqueCues = {};
 
-    for (let j = 0; j < cues.length; j++) {
-      if (
-        cues[i].startTime === cues[j].startTime &&
-        cues[i].endTime === cues[j].endTime &&
-        cues[i].text === cues[j].text
-      ) {
-        occurrences++;
+  for (let i = cues.length - 1; i >= 0; i--) {
+    const cue = cues[i];
+    const cueKey = `${cue.startTime}-${cue.endTime}-${cue.text}`;
 
-        if (occurrences > 1) {
-          duplicates.push(cues[j]);
-        }
-      }
-    }
-
-    if (duplicates.length) {
-      duplicates.forEach(dupe => track.removeCue(dupe));
+    if (uniqueCues[cueKey]) {
+      track.removeCue(cue);
+    } else {
+      uniqueCues[cueKey] = cue;
     }
   }
 };


### PR DESCRIPTION
## Description
The `removeDuplicateCuesFromTrack()` function was poorly optimized. The nested loop would run a staggering number of times in cases of very large VTT files. This change accomplishes duplicate cue removal with a single loop.
