### PR TITLE
fix: error on undefined metadata frames

### DIFF
--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -159,6 +159,11 @@ export const addMetadata = ({
       return;
     }
 
+    // If we have no frames, we can't create a cue.
+    if (!metadata.frames || !metadata.frames.length) {
+      return;
+    }
+
     metadata.frames.forEach((frame) => {
       const cue = new Cue(
         time,


### PR DESCRIPTION
## Description
Fixes an issue where an error is thrown when the `frame` of timed metadata is `undefined`

## Specific Changes proposed
Add a check for `!metadata.frames || !metadata.frames.length` with an early return to the `addMetadata` function.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
