### PR TITLE
chore: update mpd-parser to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6835,9 +6835,9 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.0.1.tgz",
-      "integrity": "sha512-3CmVq7af3tcLqpx9SLBSweVnxS0SlpkKr+YBLC7O/wO1bv2L9tsCY350wziPWuMEjE5+x46i898sI4YIY3cmJA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.1.0.tgz",
+      "integrity": "sha512-SYsJHl5NMRRs3I26V6HKS1oqgEAYZBDKfk5RmV5yAHxncaHRP1v8JDR7CcuIpFOM2o27NXFrx2MWwn9LMR0JmA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.5",
@@ -6856,9 +6856,9 @@
           }
         },
         "@xmldom/xmldom": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-          "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ=="
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+          "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
     "m3u8-parser": "^6.0.0",
-    "mpd-parser": "^1.0.1",
+    "mpd-parser": "^1.1.0",
     "mux.js": "6.3.0",
     "video.js": "^7 || ^8"
   },


### PR DESCRIPTION
## Description
Update the mpd-parser version to 1.1.0

## Specific Changes proposed
Change the `mpd-parser` version in the package.json to `^1.1.0`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
