### PR TITLE
fix: use audio offset for id3 with audio-only

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1873,9 +1873,9 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    const timestampOffset = this.sourceUpdater_.videoTimestampOffset() === null ?
-      this.sourceUpdater_.audioTimestampOffset() :
-      this.sourceUpdater_.videoTimestampOffset();
+    const timestampOffset = segmentInfo.trackInfo.hasVideo ?
+      this.sourceUpdater_.videoTimestampOffset() :
+      this.sourceUpdater_.audioTimestampOffset();
 
     // There's potentially an issue where we could double add metadata if there's a muxed
     // audio/video source with a metadata track, and an alt audio with a metadata track.

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -2491,6 +2491,9 @@ QUnit.module('SegmentLoader', function(hooks) {
           // Simulate a caption event happening that will call handleCaptions_
           const dispatchType = 0x10;
 
+          // Ensure video and audio offset are different, to know which offset is used
+          loader.sourceUpdater_.videoTimestampOffset(loader.sourceUpdater_.audioTimestampOffset() - 10);
+
           loader.handleId3_(loader.pendingSegment_, metadata, dispatchType);
         });
 
@@ -2508,6 +2511,8 @@ QUnit.module('SegmentLoader', function(hooks) {
           const cue = addCueSpy.getCall(0).args[0];
 
           assert.strictEqual(cue.value.data, 'This is a priv tag', 'included the text');
+
+          assert.strictEqual(cue.startTime, metadata[0].cueTime + loader.sourceUpdater_.audioTimestampOffset(), 'cue.startTime offset from audioTimestampOffset');
           done();
         });
 


### PR DESCRIPTION
## Description
id3 cues are not added correctly to audio-only streams, as the test for an audio-only stream is broken. `videoTimestampOffset()` will never be `null` as it defaults to `0`, so the audio offset is not used.

## Specific Changes proposed
Uses the `videoTimestampOffset()` when `segmentInfo.trackInfo.hasVideo` is `false` rather than when `videoTimestampOffset()` is null

Fixes #130 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Example created (below)
- [ ] Reviewed by Two Core Contributors

## Example
- Open the [deploy preview](https://deploy-preview-1386--videojs-http-streaming.netlify.app/) and https://videojs-http-streaming.netlify.app to compare.
- In each console, add
  ```
  const printCueData = (cues) => {
    Array.from(cues).forEach((cue) => {
      if ("value" in cue && cue?.value?.data) {
        const value = new TextDecoder()
          .decode(cue.value.data)
          .replace("\x03", "")
          .replace("\x00", "");
        console.log({
          value,
          start: cue.startTime,
          end: cue.endTime,
        });
      }
    });
  };
  
  const onAddTrack = ({ track }) => {
    if (
      !(track?.kind === "metadata" && track.label === "Timed Metadata")
    ) {
      return;
    }
  
    const onCueChange = () => {
      if (!track.activeCues) {
        return;
      }
  
      const cues = printCueData(track.activeCues);
    };
  
    track.mode = "hidden";
    track.addEventListener("cuechange", onCueChange);
  };
  
  player.textTracks().addEventListener("addtrack", onAddTrack);
  ```
- In each load https://cue-points-test.vercel.app/audio/master.m3u8 and play
- Observe cues logged to the console in deploy preview (like `{value: '{"webcastId":"635fc...`)


Thanks to @berrutti for the test streams from [#130](https://github.com/videojs/http-streaming/issues/130#issuecomment-1301796493)