### PR TITLE
feat(xhr): add request and response hook API

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,9 +644,9 @@ callback function as a parameter as well as `offRequest` and `offResponse`
 functions which will remove a callback function from the `onRequest` or 
 `onResponse` set if it exists. 
 
-The `onRequest(callback)` function takes a `callback` function that will pass the xhr `request` 
-Object to that callback. These callbacks are called in the order registered and act as pre-request 
-hooks for modifying the xhr `request` Object prior to making a request.
+The `onRequest(callback)` function takes a `callback` function that will pass the xhr `request`
+Object to that callback. These callbacks are called synchronously, in the order registered
+and act as pre-request hooks for modifying the xhr `request` Object prior to making a request.
 
 Example:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ Example
 const globalRequestHook = (request) => {
   const requestUrl = new URL(request.uri);
   requestUrl.searchParams.set('foo', 'bar');
-  request.uri = decodeURIComponent(requestUrl.href);
+  request.uri = requestUrl.href;
 };
 videojs.Vhs.onRequest(globalRequestHook);
 
@@ -709,7 +709,7 @@ videojs.Vhs.onRequest(globalRequestHook);
 const playerRequestHook = (request) => {
   const requestUrl = new URL(request.uri);
   requestUrl.searchParams.set('foo', 'bar');
-  request.uri = decodeURIComponent(requestUrl.href);
+  request.uri = requestUrl.href;
 };
 player.tech().vhs.onRequest(playerRequestHook);
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Video.js Compatibility: 7.x, 8.x
 - [Compatibility](#compatibility)
   - [Browsers which support MSE](#browsers-which-support-mse)
   - [Native only](#native-only)
-  - [Flash Support](#flash-support)
   - [DRM](#drm)
 - [Documentation](#documentation)
   - [Options](#options)
@@ -70,6 +69,10 @@ Video.js Compatibility: 7.x, 8.x
     - [vhs.selectPlaylist](#vhsselectplaylist)
     - [vhs.representations](#vhsrepresentations)
     - [vhs.xhr](#vhsxhr)
+    - [vhs.onRequest](#vhsonrequest)
+    - [vhs.onResponse](#vhsonresponse)
+    - [vhs.offRequest](#vhsoffrequest)
+    - [vhs.offResponse](#vhsoffresponse)
     - [vhs.stats](#vhsstats)
   - [Events](#events)
     - [loadedmetadata](#loadedmetadata)
@@ -677,9 +680,95 @@ player.ready(function() {
   });
 });
 ```
+Note: any registered `onRequest` hooks, are called _after_ the `beforeRequest` function, so xhr
+options modified by this function may be further modified by these hooks.
 
 For information on the type of options that you can modify see the
 documentation at [https://github.com/Raynos/xhr](https://github.com/Raynos/xhr).
+
+#### vhs.onRequest
+Type: `function`
+
+The `onRequest(callback)` function takes a `callback` function that will pass the xhr `request` 
+Object to that callback. These callbacks are called in the order registered and act as pre-request 
+hooks for modifying the xhr `request` Object prior to making a request. These hooks can be set at 
+the global or player level, where the player level hooks will override global.
+
+
+Example
+```javascript
+// Global
+const globalRequestHook = (request) => {
+  const requestUrl = new URL(request.uri);
+  requestUrl.searchParams.set('foo', 'bar');
+  request.uri = decodeURIComponent(requestUrl.href);
+};
+videojs.Vhs.onRequest(globalRequestHook);
+
+// Player
+const playerRequestHook = (request) => {
+  const requestUrl = new URL(request.uri);
+  requestUrl.searchParams.set('foo', 'bar');
+  request.uri = decodeURIComponent(requestUrl.href);
+};
+player.tech().vhs.onRequest(playerRequestHook);
+```
+
+#### vhs.onResponse
+Type: `function`
+
+The `onResponse(callback)` function takes a `callback` function that will pass the xhr
+`request`, `error`, and `response` Objects to that callback. These callbacks are called
+in the order registered and act as post-request hooks for gathering data from the
+xhr `request`, `error` and `response` Objects. These hooks can be set at the global 
+or player level, where the player level hooks will override global.
+
+Example
+```javascript
+// Global
+const globalResponseHook = (request, error, response) => {
+  const bar = response.headers.foo
+};
+videojs.Vhs.onResponse(globalResponseHook);
+
+// Player
+const playerResponseHook = (request, error, response) => {
+  const bar = response.headers.foo
+};
+player.tech().vhs.onResponse(playerResponseHook);
+```
+
+#### vhs.offRequest
+Type: `function`
+
+The `offRequest` function takes a `callback` function, and will remove that function from
+the collection of `onRequest` hooks if it exists. This can be called at the global or 
+player level.
+
+Example
+```javascript
+// Global
+videojs.Vhs.offRequest(globalRequestHook);
+
+// Player
+player.tech().vhs.offRequest(playerRequestHook);
+```
+
+#### vhs.offResponse
+Type: `function`
+
+The `offResponse` function takes a `callback` function, and will remove that function from
+the collection of `offResponse` hooks if it exists. This can be called at the global or 
+player level.
+
+Example
+```javascript
+// Global
+videojs.Vhs.offResponse(globalResponseHook);
+
+// Player
+player.tech().vhs.offResponse(playerResponseHook);
+```
 
 #### vhs.stats
 Type: `object`

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -434,10 +434,10 @@ const expandDataUri = (dataUri) => {
  * @param {function} callback hook function for an xhr request
  */
 const addOnRequestHook = (xhr, callback) => {
-  if (!xhr.onRequest) {
-    xhr.onRequest = new Set();
+  if (!xhr._requestCallbackSet) {
+    xhr._requestCallbackSet = new Set();
   }
-  xhr.onRequest.add(callback);
+  xhr._requestCallbackSet.add(callback);
 };
 
 /**
@@ -447,10 +447,10 @@ const addOnRequestHook = (xhr, callback) => {
  * @param {function} callback hook function for an xhr response
  */
 const addOnResponseHook = (xhr, callback) => {
-  if (!xhr.onResponse) {
-    xhr.onResponse = new Set();
+  if (!xhr._responseCallbackSet) {
+    xhr._responseCallbackSet = new Set();
   }
-  xhr.onResponse.add(callback);
+  xhr._responseCallbackSet.add(callback);
 };
 
 /**
@@ -460,12 +460,12 @@ const addOnResponseHook = (xhr, callback) => {
  * @param {function} callback hook function to remove
  */
 const removeOnRequestHook = (xhr, callback) => {
-  if (!xhr.onRequest) {
+  if (!xhr._requestCallbackSet) {
     return;
   }
-  xhr.onRequest.delete(callback);
-  if (!xhr.onRequest.size) {
-    delete xhr.onRequest;
+  xhr._requestCallbackSet.delete(callback);
+  if (!xhr._requestCallbackSet.size) {
+    delete xhr._requestCallbackSet;
   }
 };
 
@@ -476,12 +476,12 @@ const removeOnRequestHook = (xhr, callback) => {
  * @param {function} callback hook function to remove
  */
 const removeOnResponseHook = (xhr, callback) => {
-  if (!xhr.onResponse) {
+  if (!xhr._responseCallbackSet) {
     return;
   }
-  xhr.onResponse.delete(callback);
-  if (!xhr.onResponse.size) {
-    delete xhr.onResponse;
+  xhr._responseCallbackSet.delete(callback);
+  if (!xhr._responseCallbackSet.size) {
+    delete xhr._responseCallbackSet;
   }
 };
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -492,6 +492,38 @@ Vhs.isSupported = function() {
     'your player\'s techOrder.');
 };
 
+/**
+ * A global function for setting the beforeRequest hook
+ *
+ * @param {function} callback for request options modifiction
+ */
+Vhs.onRequest = function(callback) {
+  Vhs.xhr.beforeRequest = callback;
+};
+
+/**
+ * A global function for setting the onResponse hook
+ *
+ * @param {callback} callback for response data retrieval
+ */
+Vhs.onResponse = function(callback) {
+  Vhs.xhr.beforeResponse = callback;
+};
+
+/**
+ * Deletes the global beforeRequest function
+ */
+Vhs.offRequest = function() {
+  delete Vhs.xhr.beforeRequest;
+};
+
+/**
+ * Deletes the global beforeResponse function
+ */
+Vhs.offResponse = function() {
+  delete Vhs.xhr.beforeResponse;
+};
+
 const Component = videojs.getComponent('Component');
 
 /**
@@ -1196,6 +1228,22 @@ class VhsHandler extends Component {
       tech: this.options_.tech,
       callback
     });
+  }
+
+  onRequest(callback) {
+    this.xhr.beforeRequest = callback;
+  }
+
+  onResponse(callback) {
+    this.xhr.beforeResponse = callback;
+  }
+
+  offRequest() {
+    delete this.xhr.beforeRequest;
+  }
+
+  offResponse() {
+    delete this.xhr.beforeResponse;
   }
 }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -428,6 +428,64 @@ const expandDataUri = (dataUri) => {
 };
 
 /**
+ * Adds a request hook to an xhr object
+ *
+ * @param {Object} xhr object to add the onRequest hook to
+ * @param {function} callback hook function for an xhr request
+ */
+const addOnRequestHook = (xhr, callback) => {
+  if (!xhr.onRequest) {
+    xhr.onRequest = new Set();
+  }
+  xhr.onRequest.add(callback);
+};
+
+/**
+ * Adds a response hook to an xhr object
+ *
+ * @param {Object} xhr object to add the onResponse hook to
+ * @param {function} callback hook function for an xhr response
+ */
+const addOnResponseHook = (xhr, callback) => {
+  if (!xhr.onResponse) {
+    xhr.onResponse = new Set();
+  }
+  xhr.onResponse.add(callback);
+};
+
+/**
+ * Removes a request hook on an xhr object, deletes the onRequest set if empty.
+ *
+ * @param {Object} xhr object to remove the onRequest hook from
+ * @param {function} callback hook function to remove
+ */
+const removeOnRequestHook = (xhr, callback) => {
+  if (!xhr.onRequest) {
+    return;
+  }
+  xhr.onRequest.delete(callback);
+  if (!xhr.onRequest.size) {
+    delete xhr.onRequest;
+  }
+};
+
+/**
+ * Removes a response hook on an xhr object, deletes the onResponse set if empty.
+ *
+ * @param {Object} xhr object to remove the onResponse hook from
+ * @param {function} callback hook function to remove
+ */
+const removeOnResponseHook = (xhr, callback) => {
+  if (!xhr.onResponse) {
+    return;
+  }
+  xhr.onResponse.delete(callback);
+  if (!xhr.onResponse.size) {
+    delete xhr.onResponse;
+  }
+};
+
+/**
  * Whether the browser has built-in HLS support.
  */
 Vhs.supportsNativeHls = (function() {
@@ -493,35 +551,39 @@ Vhs.isSupported = function() {
 };
 
 /**
- * A global function for setting the beforeRequest hook
+ * A global function for setting an onRequest hook
  *
- * @param {function} callback for request options modifiction
+ * @param {function} callback for request modifiction
  */
 Vhs.onRequest = function(callback) {
-  Vhs.xhr.beforeRequest = callback;
+  addOnRequestHook(Vhs.xhr, callback);
 };
 
 /**
- * A global function for setting the onResponse hook
+ * A global function for setting an onResponse hook
  *
  * @param {callback} callback for response data retrieval
  */
 Vhs.onResponse = function(callback) {
-  Vhs.xhr.beforeResponse = callback;
+  addOnResponseHook(Vhs.xhr, callback);
 };
 
 /**
- * Deletes the global beforeRequest function
+ * Deletes a global onRequest callback if it exists
+ *
+ * @param {function} callback to delete from the global set
  */
-Vhs.offRequest = function() {
-  delete Vhs.xhr.beforeRequest;
+Vhs.offRequest = function(callback) {
+  removeOnRequestHook(Vhs.xhr, callback);
 };
 
 /**
- * Deletes the global beforeResponse function
+ * Deletes a global onResponse callback if it exists
+ *
+ * @param {function} callback to delete from the global set
  */
-Vhs.offResponse = function() {
-  delete Vhs.xhr.beforeResponse;
+Vhs.offResponse = function(callback) {
+  removeOnResponseHook(Vhs.xhr, callback);
 };
 
 const Component = videojs.getComponent('Component');
@@ -1230,20 +1292,40 @@ class VhsHandler extends Component {
     });
   }
 
+  /**
+   * A player function for setting an onRequest hook
+   *
+   * @param {function} callback for request modifiction
+   */
   onRequest(callback) {
-    this.xhr.beforeRequest = callback;
+    addOnRequestHook(this.xhr, callback);
   }
 
+  /**
+   * A player function for setting an onResponse hook
+   *
+   * @param {callback} callback for response data retrieval
+   */
   onResponse(callback) {
-    this.xhr.beforeResponse = callback;
+    addOnResponseHook(this.xhr, callback);
   }
 
-  offRequest() {
-    delete this.xhr.beforeRequest;
+  /**
+   * Deletes a player onRequest callback if it exists
+   *
+   * @param {function} callback to delete from the player set
+   */
+  offRequest(callback) {
+    removeOnRequestHook(this.xhr, callback);
   }
 
-  offResponse() {
-    delete this.xhr.beforeResponse;
+  /**
+   * Deletes a player onResponse callback if it exists
+   *
+   * @param {function} callback to delete from the player set
+   */
+  offResponse(callback) {
+    removeOnResponseHook(this.xhr, callback);
   }
 }
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -555,7 +555,7 @@ Vhs.isSupported = function() {
  *
  * @param {function} callback for request modifiction
  */
-Vhs.onRequest = function(callback) {
+Vhs.xhr.onRequest = function(callback) {
   addOnRequestHook(Vhs.xhr, callback);
 };
 
@@ -564,7 +564,7 @@ Vhs.onRequest = function(callback) {
  *
  * @param {callback} callback for response data retrieval
  */
-Vhs.onResponse = function(callback) {
+Vhs.xhr.onResponse = function(callback) {
   addOnResponseHook(Vhs.xhr, callback);
 };
 
@@ -573,7 +573,7 @@ Vhs.onResponse = function(callback) {
  *
  * @param {function} callback to delete from the global set
  */
-Vhs.offRequest = function(callback) {
+Vhs.xhr.offRequest = function(callback) {
   removeOnRequestHook(Vhs.xhr, callback);
 };
 
@@ -582,7 +582,7 @@ Vhs.offRequest = function(callback) {
  *
  * @param {function} callback to delete from the global set
  */
-Vhs.offResponse = function(callback) {
+Vhs.xhr.offResponse = function(callback) {
   removeOnResponseHook(Vhs.xhr, callback);
 };
 
@@ -1293,39 +1293,45 @@ class VhsHandler extends Component {
   }
 
   /**
-   * A player function for setting an onRequest hook
-   *
-   * @param {function} callback for request modifiction
+   * Adds the onRequest, onResponse, offRequest and offResponse functions
+   * to the VhsHandler xhr Object.
    */
-  onRequest(callback) {
-    addOnRequestHook(this.xhr, callback);
-  }
+  setupXhrHooks_() {
+    /**
+     * A player function for setting an onRequest hook
+     *
+     * @param {function} callback for request modifiction
+     */
+    this.xhr.onRequest = (callback) => {
+      addOnRequestHook(this.xhr, callback);
+    };
 
-  /**
-   * A player function for setting an onResponse hook
-   *
-   * @param {callback} callback for response data retrieval
-   */
-  onResponse(callback) {
-    addOnResponseHook(this.xhr, callback);
-  }
+    /**
+     * A player function for setting an onResponse hook
+     *
+     * @param {callback} callback for response data retrieval
+     */
+    this.xhr.onResponse = (callback) => {
+      addOnResponseHook(this.xhr, callback);
+    };
 
-  /**
-   * Deletes a player onRequest callback if it exists
-   *
-   * @param {function} callback to delete from the player set
-   */
-  offRequest(callback) {
-    removeOnRequestHook(this.xhr, callback);
-  }
+    /**
+     * Deletes a player onRequest callback if it exists
+     *
+     * @param {function} callback to delete from the player set
+     */
+    this.xhr.offRequest = (callback) => {
+      removeOnRequestHook(this.xhr, callback);
+    };
 
-  /**
-   * Deletes a player onResponse callback if it exists
-   *
-   * @param {function} callback to delete from the player set
-   */
-  offResponse(callback) {
-    removeOnResponseHook(this.xhr, callback);
+    /**
+     * Deletes a player onResponse callback if it exists
+     *
+     * @param {function} callback to delete from the player set
+     */
+    this.xhr.offResponse = (callback) => {
+      removeOnResponseHook(this.xhr, callback);
+    };
   }
 }
 
@@ -1349,6 +1355,7 @@ const VhsSourceHandler = {
 
     tech.vhs = new VhsHandler(source, tech, localOptions);
     tech.vhs.xhr = xhrFactory();
+    tech.vhs.setupXhrHooks_();
 
     tech.vhs.src(source.src, source.type);
     return tech.vhs;

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -83,9 +83,9 @@ const xhrFactory = function() {
     // Allow an optional user-specified function to modify the option
     // object before we construct the xhr request
     const beforeRequest = XhrFunction.beforeRequest || videojs.Vhs.xhr.beforeRequest;
-    // onRequest and onResponse hooks as a set, at either the player or global level.
-    const onRequest = XhrFunction.onRequest || videojs.Vhs.xhr.onRequest;
-    const onResponse = XhrFunction.onResponse || videojs.Vhs.xhr.onResponse;
+    // onRequest and onResponse hooks as a Set, at either the player or global level.
+    const onRequest = XhrFunction._requestCallbackSet || videojs.Vhs.xhr._requestCallbackSet;
+    const onResponse = XhrFunction._responseCallbackSet || videojs.Vhs.xhr._responseCallbackSet;
 
     if (beforeRequest && typeof beforeRequest === 'function') {
       const newOptions = beforeRequest(options);

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -84,8 +84,8 @@ const xhrFactory = function() {
     // object before we construct the xhr request
     const beforeRequest = XhrFunction.beforeRequest || videojs.Vhs.xhr.beforeRequest;
     // onRequest and onResponse hooks as a Set, at either the player or global level.
-    const onRequest = XhrFunction._requestCallbackSet || videojs.Vhs.xhr._requestCallbackSet;
-    const onResponse = XhrFunction._responseCallbackSet || videojs.Vhs.xhr._responseCallbackSet;
+    const _requestCallbackSet = XhrFunction._requestCallbackSet || videojs.Vhs.xhr._requestCallbackSet;
+    const _responseCallbackSet = XhrFunction._responseCallbackSet || videojs.Vhs.xhr._responseCallbackSet;
 
     if (beforeRequest && typeof beforeRequest === 'function') {
       const newOptions = beforeRequest(options);
@@ -101,7 +101,7 @@ const xhrFactory = function() {
 
     const request = xhrMethod(options, function(error, response) {
       // call all registered onResponse hooks
-      callAllHooks(onResponse, request, error, response);
+      callAllHooks(_responseCallbackSet, request, error, response);
       return callbackWrapper(request, error, response, callback);
     });
     const originalAbort = request.abort;
@@ -113,7 +113,7 @@ const xhrFactory = function() {
     request.uri = options.uri;
     request.requestTime = Date.now();
     // call all registered onRequest hooks
-    callAllHooks(onRequest, request);
+    callAllHooks(_requestCallbackSet, request);
 
     return request;
   };

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -82,9 +82,7 @@ const xhrFactory = function() {
     const xhrMethod = videojs.Vhs.xhr.original === true ? videojsXHR : videojs.Vhs.xhr;
 
     const request = xhrMethod(options, function(error, response) {
-      // call onResponse here.
-      // If we have a response hook, call it now.
-      // TODO: This will be a collection of callbacks, not just a single function.
+      // call all registered onResponse hooks in order
       if (onResponse) {
         onResponse.forEach((responseHook) => {
           responseHook(error, response);

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -52,6 +52,7 @@ const callbackWrapper = function(request, error, response, callback) {
     error = new Error('XHR Failed with a response of: ' +
                       (request && (reqResponse || request.responseText)));
   }
+
   callback(error, request);
 };
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4060,8 +4060,8 @@ QUnit.test('Allows setting onRequest hooks globally', function(assert) {
     onRequestHookCallCount++;
   };
 
-  videojs.Vhs.onRequest(globalRequestHook1);
-  videojs.Vhs.onRequest(globalRequestHook2);
+  videojs.Vhs.xhr.onRequest(globalRequestHook1);
+  videojs.Vhs.xhr.onRequest(globalRequestHook2);
 
   // main
   this.standardXHRResponse(this.requests.shift());
@@ -4069,8 +4069,8 @@ QUnit.test('Allows setting onRequest hooks globally', function(assert) {
   assert.equal(onRequestHookCallCount, 2, '2 onRequest hooks called');
   assert.equal(actualRequestUrl, 'http://localhost:9999/test/media2.m3u8?foo=bar', 'request url modified by onRequest hook');
   // remove global hooks for other tests
-  videojs.Vhs.offRequest(globalRequestHook1);
-  videojs.Vhs.offRequest(globalRequestHook2);
+  videojs.Vhs.xhr.offRequest(globalRequestHook1);
+  videojs.Vhs.xhr.offRequest(globalRequestHook2);
 });
 
 QUnit.test('Allows setting onRequest hooks on the player', function(assert) {
@@ -4097,8 +4097,11 @@ QUnit.test('Allows setting onRequest hooks on the player', function(assert) {
     onRequestHookCallCount++;
   };
 
-  this.player.tech_.vhs.onRequest(playerRequestHook1);
-  this.player.tech_.vhs.onRequest(playerRequestHook2);
+  // Setup player level xhr hooks.
+  this.player.tech_.vhs.setupXhrHooks_();
+
+  this.player.tech_.vhs.xhr.onRequest(playerRequestHook1);
+  this.player.tech_.vhs.xhr.onRequest(playerRequestHook2);
 
   // main
   this.standardXHRResponse(this.requests.shift());
@@ -4106,8 +4109,8 @@ QUnit.test('Allows setting onRequest hooks on the player', function(assert) {
   assert.equal(onRequestHookCallCount, 2, '2 onRequest hooks called');
   assert.equal(actualRequestUrl, 'http://localhost:9999/test/media2.m3u8?foo=bar', 'request url modified by onRequest hook');
   // remove player hooks for other tests
-  this.player.tech_.vhs.offRequest(playerRequestHook1);
-  this.player.tech_.vhs.offRequest(playerRequestHook2);
+  this.player.tech_.vhs.xhr.offRequest(playerRequestHook1);
+  this.player.tech_.vhs.xhr.offRequest(playerRequestHook2);
 });
 
 QUnit.test('Allows setting onRequest hooks globally and overriding with player hooks', function(assert) {
@@ -4136,8 +4139,8 @@ QUnit.test('Allows setting onRequest hooks globally and overriding with player h
     onRequestHookCallCountGlobal++;
   };
 
-  videojs.Vhs.onRequest(globalRequestHook1);
-  videojs.Vhs.onRequest(globalRequestHook2);
+  videojs.Vhs.xhr.onRequest(globalRequestHook1);
+  videojs.Vhs.xhr.onRequest(globalRequestHook2);
 
   const playerRequestHook1 = (request) => {
     const requestUrl = new URL(request.url);
@@ -4151,14 +4154,17 @@ QUnit.test('Allows setting onRequest hooks globally and overriding with player h
     onRequestHookCallCountPlayer++;
   };
 
-  this.player.tech_.vhs.onRequest(playerRequestHook1);
-  this.player.tech_.vhs.onRequest(playerRequestHook2);
+  // Setup player level xhr hooks.
+  this.player.tech_.vhs.setupXhrHooks_();
+
+  this.player.tech_.vhs.xhr.onRequest(playerRequestHook1);
+  this.player.tech_.vhs.xhr.onRequest(playerRequestHook2);
 
   // main
   this.standardXHRResponse(this.requests.shift());
   // remove player request hooks
-  this.player.tech_.vhs.offRequest(playerRequestHook1);
-  this.player.tech_.vhs.offRequest(playerRequestHook2);
+  this.player.tech_.vhs.xhr.offRequest(playerRequestHook1);
+  this.player.tech_.vhs.xhr.offRequest(playerRequestHook2);
 
   assert.equal(onRequestHookCallCountGlobal, 0, 'no onRequest global hooks called');
   assert.equal(actualRequestUrlGlobal, undefined, 'global request url undefined');
@@ -4171,8 +4177,8 @@ QUnit.test('Allows setting onRequest hooks globally and overriding with player h
   assert.equal(onRequestHookCallCountGlobal, 2, '2 onRequest global hooks called');
   assert.equal(actualRequestUrlGlobal, 'http://localhost:9999/test/media2-00001.ts?foo=bar', 'request url modified by global onRequest hook');
 
-  videojs.Vhs.offRequest(globalRequestHook1);
-  videojs.Vhs.offRequest(globalRequestHook2);
+  videojs.Vhs.xhr.offRequest(globalRequestHook1);
+  videojs.Vhs.xhr.offRequest(globalRequestHook2);
 });
 
 QUnit.test('Allows removing onRequest hooks globally with offRequest', function(assert) {
@@ -4199,8 +4205,8 @@ QUnit.test('Allows removing onRequest hooks globally with offRequest', function(
     onRequestHookCallCount++;
   };
 
-  videojs.Vhs.onRequest(globalRequestHook1);
-  videojs.Vhs.onRequest(globalRequestHook2);
+  videojs.Vhs.xhr.onRequest(globalRequestHook1);
+  videojs.Vhs.xhr.onRequest(globalRequestHook2);
 
   // main
   this.standardXHRResponse(this.requests.shift());
@@ -4208,7 +4214,7 @@ QUnit.test('Allows removing onRequest hooks globally with offRequest', function(
   assert.equal(onRequestHookCallCount, 2, '2 onRequest hooks called');
   assert.equal(actualRequestUrl, 'http://localhost:9999/test/media2.m3u8?foo=bar', 'request url modified by onRequest hook');
 
-  videojs.Vhs.offRequest(globalRequestHook1);
+  videojs.Vhs.xhr.offRequest(globalRequestHook1);
 
   // media
   this.standardXHRResponse(this.requests.shift());
@@ -4237,16 +4243,16 @@ QUnit.test('Allows setting onResponse hooks globally', function(assert) {
     done();
   };
 
-  videojs.Vhs.onResponse(globalResponseHook1);
-  videojs.Vhs.onResponse(globalResponseHook2);
+  videojs.Vhs.xhr.onResponse(globalResponseHook1);
+  videojs.Vhs.xhr.onResponse(globalResponseHook2);
 
   // main
   this.standardXHRResponse(this.requests.shift());
   // media
   this.standardXHRResponse(this.requests.shift());
 
-  videojs.Vhs.offResponse(globalResponseHook1);
-  videojs.Vhs.offResponse(globalResponseHook2);
+  videojs.Vhs.xhr.offResponse(globalResponseHook1);
+  videojs.Vhs.xhr.offResponse(globalResponseHook2);
 });
 
 QUnit.test('Allows setting onResponse hooks on the player', function(assert) {
@@ -4270,16 +4276,19 @@ QUnit.test('Allows setting onResponse hooks on the player', function(assert) {
     done();
   };
 
-  this.player.tech_.vhs.onResponse(globalResponseHook1);
-  this.player.tech_.vhs.onResponse(globalResponseHook2);
+  // Setup player level xhr hooks.
+  this.player.tech_.vhs.setupXhrHooks_();
+
+  this.player.tech_.vhs.xhr.onResponse(globalResponseHook1);
+  this.player.tech_.vhs.xhr.onResponse(globalResponseHook2);
 
   // main
   this.standardXHRResponse(this.requests.shift());
   // media
   this.standardXHRResponse(this.requests.shift());
 
-  this.player.tech_.vhs.offResponse(globalResponseHook1);
-  this.player.tech_.vhs.offResponse(globalResponseHook2);
+  this.player.tech_.vhs.xhr.offResponse(globalResponseHook1);
+  this.player.tech_.vhs.xhr.offResponse(globalResponseHook2);
 });
 
 QUnit.test('Allows setting onResponse hooks globally and overriding with player hooks', function(assert) {
@@ -4314,15 +4323,18 @@ QUnit.test('Allows setting onResponse hooks globally and overriding with player 
     assert.equal(response.url, 'http://localhost:9999/test/media2.m3u8', 'got expected response url');
   };
 
-  videojs.Vhs.onResponse(globalResponseHook1);
-  videojs.Vhs.onResponse(globalResponseHook2);
-  this.player.tech_.vhs.onResponse(playerResponseHook1);
-  this.player.tech_.vhs.onResponse(playerResponseHook2);
+  // Setup player level xhr hooks.
+  this.player.tech_.vhs.setupXhrHooks_();
+
+  videojs.Vhs.xhr.onResponse(globalResponseHook1);
+  videojs.Vhs.xhr.onResponse(globalResponseHook2);
+  this.player.tech_.vhs.xhr.onResponse(playerResponseHook1);
+  this.player.tech_.vhs.xhr.onResponse(playerResponseHook2);
   // main
   this.standardXHRResponse(this.requests.shift());
 
-  this.player.tech_.vhs.offResponse(playerResponseHook1);
-  this.player.tech_.vhs.offResponse(playerResponseHook2);
+  this.player.tech_.vhs.xhr.offResponse(playerResponseHook1);
+  this.player.tech_.vhs.xhr.offResponse(playerResponseHook2);
 
   // media
   this.standardXHRResponse(this.requests.shift());
@@ -4330,8 +4342,8 @@ QUnit.test('Allows setting onResponse hooks globally and overriding with player 
   // ts
   this.standardXHRResponse(this.requests.shift(), muxedSegment());
 
-  videojs.Vhs.offResponse(globalResponseHook1);
-  videojs.Vhs.offResponse(globalResponseHook2);
+  videojs.Vhs.xhr.offResponse(globalResponseHook1);
+  videojs.Vhs.xhr.offResponse(globalResponseHook2);
 });
 
 QUnit.test('Allows removing onResponse hooks globally with offResponse', function(assert) {
@@ -4355,18 +4367,18 @@ QUnit.test('Allows removing onResponse hooks globally with offResponse', functio
     done();
   };
 
-  videojs.Vhs.onResponse(globalResponseHook1);
-  videojs.Vhs.onResponse(globalResponseHook2);
+  videojs.Vhs.xhr.onResponse(globalResponseHook1);
+  videojs.Vhs.xhr.onResponse(globalResponseHook2);
 
   // remove hook1
-  videojs.Vhs.offResponse(globalResponseHook1);
+  videojs.Vhs.xhr.offResponse(globalResponseHook1);
 
   // main
   this.standardXHRResponse(this.requests.shift());
   // media
   this.standardXHRResponse(this.requests.shift());
 
-  videojs.Vhs.offResponse(globalResponseHook2);
+  videojs.Vhs.xhr.offResponse(globalResponseHook2);
 });
 
 QUnit.test(

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4036,6 +4036,138 @@ QUnit.test('Allows overriding the global beforeRequest function', function(asser
   delete videojs.Vhs.xhr.beforeRequest;
 });
 
+QUnit.test('Allows setting beforeRequest with onRequest on the player', function(assert) {
+  let beforeRequestCalled = false;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.onRequest(() => {
+    beforeRequestCalled = true;
+  });
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.ok(beforeRequestCalled, 'beforeRequest was called');
+});
+
+QUnit.test('Allows setting beforeRequest with onRequest globally', function(assert) {
+  let beforeRequestCalled = false;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  videojs.Vhs.onRequest(() => {
+    beforeRequestCalled = true;
+  });
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.ok(beforeRequestCalled, 'beforeRequest was called');
+});
+
+QUnit.test('Allows overriding the global beforeRequest function calling onRequest locally', function(assert) {
+  let beforeGlobalRequestCalled = 0;
+  let beforeLocalRequestCalled = 0;
+
+  videojs.Vhs.onRequest(() => {
+    beforeGlobalRequestCalled++;
+  });
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.onRequest(() => {
+    beforeLocalRequestCalled++;
+  });
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+  // ts
+  this.standardXHRResponse(this.requests.shift(), muxedSegment());
+
+  assert.equal(beforeLocalRequestCalled, 2, 'local onRequest callback was called twice ' +
+                                           'for the media playlist and media');
+  assert.equal(beforeGlobalRequestCalled, 1, 'global onRequest callback was called once ' +
+                                            'for the main playlist');
+});
+
+QUnit.test('Allows deleting beforeRequest with offRequest on the player', function(assert) {
+  let beforeRequestCalled = false;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.vhs.onRequest(() => {
+    beforeRequestCalled = true;
+  });
+
+  this.player.tech_.vhs.offRequest();
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.notOk(beforeRequestCalled, 'beforeRequest was called');
+});
+
+QUnit.test('Allows deleting beforeRequest with offRequest globally', function(assert) {
+  let beforeRequestCalled = false;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  videojs.Vhs.onRequest(() => {
+    beforeRequestCalled = true;
+  });
+
+  videojs.Vhs.offRequest();
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.notOk(beforeRequestCalled, 'beforeRequest was called');
+});
+// TODO: Finish tests! Test onResponse and offResponse and their priority.
+
 QUnit.test(
   'passes useCueTags vhs option to main playlist controller',
   function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4036,136 +4036,136 @@ QUnit.test('Allows overriding the global beforeRequest function', function(asser
   delete videojs.Vhs.xhr.beforeRequest;
 });
 
-QUnit.test('Allows setting beforeRequest with onRequest on the player', function(assert) {
-  let beforeRequestCalled = false;
+// QUnit.test('Allows setting beforeRequest with onRequest on the player', function(assert) {
+//   let beforeRequestCalled = false;
 
-  this.player.src({
-    src: 'main.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
+//   this.player.src({
+//     src: 'main.m3u8',
+//     type: 'application/vnd.apple.mpegurl'
+//   });
 
-  this.clock.tick(1);
+//   this.clock.tick(1);
 
-  openMediaSource(this.player, this.clock);
+//   openMediaSource(this.player, this.clock);
 
-  this.player.tech_.vhs.onRequest(() => {
-    beforeRequestCalled = true;
-  });
+//   this.player.tech_.vhs.onRequest(() => {
+//     beforeRequestCalled = true;
+//   });
 
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
+//   // main
+//   this.standardXHRResponse(this.requests.shift());
+//   // media
+//   this.standardXHRResponse(this.requests.shift());
 
-  assert.ok(beforeRequestCalled, 'beforeRequest was called');
-});
+//   assert.ok(beforeRequestCalled, 'beforeRequest was called');
+// });
 
-QUnit.test('Allows setting beforeRequest with onRequest globally', function(assert) {
-  let beforeRequestCalled = false;
+// QUnit.test('Allows setting beforeRequest with onRequest globally', function(assert) {
+//   let beforeRequestCalled = false;
 
-  this.player.src({
-    src: 'main.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
+//   this.player.src({
+//     src: 'main.m3u8',
+//     type: 'application/vnd.apple.mpegurl'
+//   });
 
-  this.clock.tick(1);
+//   this.clock.tick(1);
 
-  openMediaSource(this.player, this.clock);
-  videojs.Vhs.onRequest(() => {
-    beforeRequestCalled = true;
-  });
+//   openMediaSource(this.player, this.clock);
+//   videojs.Vhs.onRequest(() => {
+//     beforeRequestCalled = true;
+//   });
 
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
+//   // main
+//   this.standardXHRResponse(this.requests.shift());
+//   // media
+//   this.standardXHRResponse(this.requests.shift());
 
-  assert.ok(beforeRequestCalled, 'beforeRequest was called');
-});
+//   assert.ok(beforeRequestCalled, 'beforeRequest was called');
+// });
 
-QUnit.test('Allows overriding the global beforeRequest function calling onRequest locally', function(assert) {
-  let beforeGlobalRequestCalled = 0;
-  let beforeLocalRequestCalled = 0;
+// QUnit.test('Allows overriding the global beforeRequest function calling onRequest locally', function(assert) {
+//   let beforeGlobalRequestCalled = 0;
+//   let beforeLocalRequestCalled = 0;
 
-  videojs.Vhs.onRequest(() => {
-    beforeGlobalRequestCalled++;
-  });
+//   videojs.Vhs.onRequest(() => {
+//     beforeGlobalRequestCalled++;
+//   });
 
-  this.player.src({
-    src: 'main.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
+//   this.player.src({
+//     src: 'main.m3u8',
+//     type: 'application/vnd.apple.mpegurl'
+//   });
 
-  this.clock.tick(1);
+//   this.clock.tick(1);
 
-  openMediaSource(this.player, this.clock);
+//   openMediaSource(this.player, this.clock);
 
-  this.player.tech_.vhs.onRequest(() => {
-    beforeLocalRequestCalled++;
-  });
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
-  // ts
-  this.standardXHRResponse(this.requests.shift(), muxedSegment());
+//   this.player.tech_.vhs.onRequest(() => {
+//     beforeLocalRequestCalled++;
+//   });
+//   // main
+//   this.standardXHRResponse(this.requests.shift());
+//   // media
+//   this.standardXHRResponse(this.requests.shift());
+//   // ts
+//   this.standardXHRResponse(this.requests.shift(), muxedSegment());
 
-  assert.equal(beforeLocalRequestCalled, 2, 'local onRequest callback was called twice ' +
-                                           'for the media playlist and media');
-  assert.equal(beforeGlobalRequestCalled, 1, 'global onRequest callback was called once ' +
-                                            'for the main playlist');
-});
+//   assert.equal(beforeLocalRequestCalled, 2, 'local onRequest callback was called twice ' +
+//                                            'for the media playlist and media');
+//   assert.equal(beforeGlobalRequestCalled, 1, 'global onRequest callback was called once ' +
+//                                             'for the main playlist');
+// });
 
-QUnit.test('Allows deleting beforeRequest with offRequest on the player', function(assert) {
-  let beforeRequestCalled = false;
+// QUnit.test('Allows deleting beforeRequest with offRequest on the player', function(assert) {
+//   let beforeRequestCalled = false;
 
-  this.player.src({
-    src: 'main.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
+//   this.player.src({
+//     src: 'main.m3u8',
+//     type: 'application/vnd.apple.mpegurl'
+//   });
 
-  this.clock.tick(1);
+//   this.clock.tick(1);
 
-  openMediaSource(this.player, this.clock);
+//   openMediaSource(this.player, this.clock);
 
-  this.player.tech_.vhs.onRequest(() => {
-    beforeRequestCalled = true;
-  });
+//   this.player.tech_.vhs.onRequest(() => {
+//     beforeRequestCalled = true;
+//   });
 
-  this.player.tech_.vhs.offRequest();
+//   this.player.tech_.vhs.offRequest();
 
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
+//   // main
+//   this.standardXHRResponse(this.requests.shift());
+//   // media
+//   this.standardXHRResponse(this.requests.shift());
 
-  assert.notOk(beforeRequestCalled, 'beforeRequest was called');
-});
+//   assert.notOk(beforeRequestCalled, 'beforeRequest was called');
+// });
 
-QUnit.test('Allows deleting beforeRequest with offRequest globally', function(assert) {
-  let beforeRequestCalled = false;
+// QUnit.test('Allows deleting beforeRequest with offRequest globally', function(assert) {
+//   let beforeRequestCalled = false;
 
-  this.player.src({
-    src: 'main.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
+//   this.player.src({
+//     src: 'main.m3u8',
+//     type: 'application/vnd.apple.mpegurl'
+//   });
 
-  this.clock.tick(1);
+//   this.clock.tick(1);
 
-  openMediaSource(this.player, this.clock);
-  videojs.Vhs.onRequest(() => {
-    beforeRequestCalled = true;
-  });
+//   openMediaSource(this.player, this.clock);
+//   videojs.Vhs.onRequest(() => {
+//     beforeRequestCalled = true;
+//   });
 
-  videojs.Vhs.offRequest();
+//   videojs.Vhs.offRequest();
 
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
+//   // main
+//   this.standardXHRResponse(this.requests.shift());
+//   // media
+//   this.standardXHRResponse(this.requests.shift());
 
-  assert.notOk(beforeRequestCalled, 'beforeRequest was called');
-});
+//   assert.notOk(beforeRequestCalled, 'beforeRequest was called');
+// });
 // TODO: Finish tests! Test onResponse and offResponse and their priority.
 
 QUnit.test(

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4036,137 +4036,338 @@ QUnit.test('Allows overriding the global beforeRequest function', function(asser
   delete videojs.Vhs.xhr.beforeRequest;
 });
 
-// QUnit.test('Allows setting beforeRequest with onRequest on the player', function(assert) {
-//   let beforeRequestCalled = false;
+QUnit.test('Allows setting onRequest hooks globally', function(assert) {
+  let onRequestHookCallCount = 0;
+  let actualRequestUrl;
 
-//   this.player.src({
-//     src: 'main.m3u8',
-//     type: 'application/vnd.apple.mpegurl'
-//   });
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
 
-//   this.clock.tick(1);
+  this.clock.tick(1);
 
-//   openMediaSource(this.player, this.clock);
+  openMediaSource(this.player, this.clock);
+  const globalRequestHook1 = (request) => {
+    const requestUrl = new URL(request.url);
 
-//   this.player.tech_.vhs.onRequest(() => {
-//     beforeRequestCalled = true;
-//   });
+    requestUrl.searchParams.set('foo', 'bar');
+    request.url = decodeURIComponent(requestUrl.href);
+    actualRequestUrl = request.url;
+    onRequestHookCallCount++;
+  };
+  const globalRequestHook2 = () => {
+    onRequestHookCallCount++;
+  };
 
-//   // main
-//   this.standardXHRResponse(this.requests.shift());
-//   // media
-//   this.standardXHRResponse(this.requests.shift());
+  videojs.Vhs.onRequest(globalRequestHook1);
+  videojs.Vhs.onRequest(globalRequestHook2);
 
-//   assert.ok(beforeRequestCalled, 'beforeRequest was called');
-// });
+  // main
+  this.standardXHRResponse(this.requests.shift());
 
-// QUnit.test('Allows setting beforeRequest with onRequest globally', function(assert) {
-//   let beforeRequestCalled = false;
+  assert.equal(onRequestHookCallCount, 2, '2 onRequest hooks called');
+  assert.equal(actualRequestUrl, 'http://localhost:9999/test/media2.m3u8?foo=bar', 'request url modified by onRequest hook');
+  // remove global hooks for other tests
+  videojs.Vhs.offRequest(globalRequestHook1);
+  videojs.Vhs.offRequest(globalRequestHook2);
+});
 
-//   this.player.src({
-//     src: 'main.m3u8',
-//     type: 'application/vnd.apple.mpegurl'
-//   });
+QUnit.test('Allows setting onRequest hooks on the player', function(assert) {
+  let onRequestHookCallCount = 0;
+  let actualRequestUrl;
 
-//   this.clock.tick(1);
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
 
-//   openMediaSource(this.player, this.clock);
-//   videojs.Vhs.onRequest(() => {
-//     beforeRequestCalled = true;
-//   });
+  this.clock.tick(1);
 
-//   // main
-//   this.standardXHRResponse(this.requests.shift());
-//   // media
-//   this.standardXHRResponse(this.requests.shift());
+  openMediaSource(this.player, this.clock);
+  const playerRequestHook1 = (request) => {
+    const requestUrl = new URL(request.url);
 
-//   assert.ok(beforeRequestCalled, 'beforeRequest was called');
-// });
+    requestUrl.searchParams.set('foo', 'bar');
+    request.url = decodeURIComponent(requestUrl.href);
+    actualRequestUrl = request.url;
+    onRequestHookCallCount++;
+  };
+  const playerRequestHook2 = () => {
+    onRequestHookCallCount++;
+  };
 
-// QUnit.test('Allows overriding the global beforeRequest function calling onRequest locally', function(assert) {
-//   let beforeGlobalRequestCalled = 0;
-//   let beforeLocalRequestCalled = 0;
+  this.player.tech_.vhs.onRequest(playerRequestHook1);
+  this.player.tech_.vhs.onRequest(playerRequestHook2);
 
-//   videojs.Vhs.onRequest(() => {
-//     beforeGlobalRequestCalled++;
-//   });
+  // main
+  this.standardXHRResponse(this.requests.shift());
 
-//   this.player.src({
-//     src: 'main.m3u8',
-//     type: 'application/vnd.apple.mpegurl'
-//   });
+  assert.equal(onRequestHookCallCount, 2, '2 onRequest hooks called');
+  assert.equal(actualRequestUrl, 'http://localhost:9999/test/media2.m3u8?foo=bar', 'request url modified by onRequest hook');
+  // remove player hooks for other tests
+  this.player.tech_.vhs.offRequest(playerRequestHook1);
+  this.player.tech_.vhs.offRequest(playerRequestHook2);
+});
 
-//   this.clock.tick(1);
+QUnit.test('Allows setting onRequest hooks globally and overriding with player hooks', function(assert) {
+  let onRequestHookCallCountGlobal = 0;
+  let onRequestHookCallCountPlayer = 0;
+  let actualRequestUrlGlobal;
+  let actualRequestUrlPlayer;
 
-//   openMediaSource(this.player, this.clock);
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
 
-//   this.player.tech_.vhs.onRequest(() => {
-//     beforeLocalRequestCalled++;
-//   });
-//   // main
-//   this.standardXHRResponse(this.requests.shift());
-//   // media
-//   this.standardXHRResponse(this.requests.shift());
-//   // ts
-//   this.standardXHRResponse(this.requests.shift(), muxedSegment());
+  this.clock.tick(1);
 
-//   assert.equal(beforeLocalRequestCalled, 2, 'local onRequest callback was called twice ' +
-//                                            'for the media playlist and media');
-//   assert.equal(beforeGlobalRequestCalled, 1, 'global onRequest callback was called once ' +
-//                                             'for the main playlist');
-// });
+  openMediaSource(this.player, this.clock);
+  const globalRequestHook1 = (request) => {
+    const requestUrl = new URL(request.url);
 
-// QUnit.test('Allows deleting beforeRequest with offRequest on the player', function(assert) {
-//   let beforeRequestCalled = false;
+    requestUrl.searchParams.set('foo', 'bar');
+    request.url = decodeURIComponent(requestUrl.href);
+    actualRequestUrlGlobal = request.url;
+    onRequestHookCallCountGlobal++;
+  };
+  const globalRequestHook2 = () => {
+    onRequestHookCallCountGlobal++;
+  };
 
-//   this.player.src({
-//     src: 'main.m3u8',
-//     type: 'application/vnd.apple.mpegurl'
-//   });
+  videojs.Vhs.onRequest(globalRequestHook1);
+  videojs.Vhs.onRequest(globalRequestHook2);
 
-//   this.clock.tick(1);
+  const playerRequestHook1 = (request) => {
+    const requestUrl = new URL(request.url);
 
-//   openMediaSource(this.player, this.clock);
+    requestUrl.searchParams.set('bar', 'foo');
+    request.url = decodeURIComponent(requestUrl.href);
+    actualRequestUrlPlayer = request.url;
+    onRequestHookCallCountPlayer++;
+  };
+  const playerRequestHook2 = () => {
+    onRequestHookCallCountPlayer++;
+  };
 
-//   this.player.tech_.vhs.onRequest(() => {
-//     beforeRequestCalled = true;
-//   });
+  this.player.tech_.vhs.onRequest(playerRequestHook1);
+  this.player.tech_.vhs.onRequest(playerRequestHook2);
 
-//   this.player.tech_.vhs.offRequest();
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // remove player request hooks
+  this.player.tech_.vhs.offRequest(playerRequestHook1);
+  this.player.tech_.vhs.offRequest(playerRequestHook2);
 
-//   // main
-//   this.standardXHRResponse(this.requests.shift());
-//   // media
-//   this.standardXHRResponse(this.requests.shift());
+  assert.equal(onRequestHookCallCountGlobal, 0, 'no onRequest global hooks called');
+  assert.equal(actualRequestUrlGlobal, undefined, 'global request url undefined');
+  assert.equal(onRequestHookCallCountPlayer, 2, '2 onRequest player hooks called');
+  assert.equal(actualRequestUrlPlayer, 'http://localhost:9999/test/media2.m3u8?bar=foo', 'request url modified by player onRequest hook');
 
-//   assert.notOk(beforeRequestCalled, 'beforeRequest was called');
-// });
+  // media
+  this.standardXHRResponse(this.requests.shift());
 
-// QUnit.test('Allows deleting beforeRequest with offRequest globally', function(assert) {
-//   let beforeRequestCalled = false;
+  assert.equal(onRequestHookCallCountGlobal, 2, '2 onRequest global hooks called');
+  assert.equal(actualRequestUrlGlobal, 'http://localhost:9999/test/media2-00001.ts?foo=bar', 'request url modified by global onRequest hook');
 
-//   this.player.src({
-//     src: 'main.m3u8',
-//     type: 'application/vnd.apple.mpegurl'
-//   });
+  videojs.Vhs.offRequest(globalRequestHook1);
+  videojs.Vhs.offRequest(globalRequestHook2);
+});
 
-//   this.clock.tick(1);
+QUnit.test('Allows removing onRequest hooks globally with offRequest', function(assert) {
+  let onRequestHookCallCount = 0;
+  let actualRequestUrl;
 
-//   openMediaSource(this.player, this.clock);
-//   videojs.Vhs.onRequest(() => {
-//     beforeRequestCalled = true;
-//   });
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
 
-//   videojs.Vhs.offRequest();
+  this.clock.tick(1);
 
-//   // main
-//   this.standardXHRResponse(this.requests.shift());
-//   // media
-//   this.standardXHRResponse(this.requests.shift());
+  openMediaSource(this.player, this.clock);
+  const globalRequestHook1 = (request) => {
+    const requestUrl = new URL(request.url);
 
-//   assert.notOk(beforeRequestCalled, 'beforeRequest was called');
-// });
-// TODO: Finish tests! Test onResponse and offResponse and their priority.
+    requestUrl.searchParams.set('foo', 'bar');
+    request.url = decodeURIComponent(requestUrl.href);
+    actualRequestUrl = request.url;
+    onRequestHookCallCount++;
+  };
+  const globalRequestHook2 = () => {
+    onRequestHookCallCount++;
+  };
+
+  videojs.Vhs.onRequest(globalRequestHook1);
+  videojs.Vhs.onRequest(globalRequestHook2);
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.equal(onRequestHookCallCount, 2, '2 onRequest hooks called');
+  assert.equal(actualRequestUrl, 'http://localhost:9999/test/media2.m3u8?foo=bar', 'request url modified by onRequest hook');
+
+  videojs.Vhs.offRequest(globalRequestHook1);
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.equal(onRequestHookCallCount, 3, '3 onRequest hooks called');
+});
+
+QUnit.test('Allows setting onResponse hooks globally', function(assert) {
+  const done = assert.async();
+  let onResponseHookCallCount = 0;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  const globalResponseHook1 = (request, error, response) => {
+    onResponseHookCallCount++;
+  };
+  const globalResponseHook2 = (request, error, response) => {
+    assert.equal(onResponseHookCallCount, 1, '1 onResponse hook called');
+    assert.equal(response.url, 'http://localhost:9999/test/media2.m3u8', 'got expected response url');
+    done();
+  };
+
+  videojs.Vhs.onResponse(globalResponseHook1);
+  videojs.Vhs.onResponse(globalResponseHook2);
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  videojs.Vhs.offResponse(globalResponseHook1);
+  videojs.Vhs.offResponse(globalResponseHook2);
+});
+
+QUnit.test('Allows setting onResponse hooks on the player', function(assert) {
+  const done = assert.async();
+  let onResponseHookCallCount = 0;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  const globalResponseHook1 = (request, error, response) => {
+    onResponseHookCallCount++;
+  };
+  const globalResponseHook2 = (request, error, response) => {
+    assert.equal(onResponseHookCallCount, 1, '1 onResponse hook called');
+    assert.equal(response.url, 'http://localhost:9999/test/media2.m3u8', 'got expected response url');
+    done();
+  };
+
+  this.player.tech_.vhs.onResponse(globalResponseHook1);
+  this.player.tech_.vhs.onResponse(globalResponseHook2);
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  this.player.tech_.vhs.offResponse(globalResponseHook1);
+  this.player.tech_.vhs.offResponse(globalResponseHook2);
+});
+
+QUnit.test('Allows setting onResponse hooks globally and overriding with player hooks', function(assert) {
+  const done = assert.async();
+  let onResponseHookCallCountGlobal = 0;
+  let onResponseHookCallCountplayer = 0;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  const globalResponseHook1 = (request, error, response) => {
+    onResponseHookCallCountGlobal++;
+  };
+
+  const globalResponseHook2 = (request, error, response) => {
+    assert.equal(onResponseHookCallCountGlobal, 1, 'no global onResponse hook called');
+    assert.equal(response.url, 'http://localhost:9999/test/media2-00001.ts', 'got expected response url');
+    done();
+  };
+
+  const playerResponseHook1 = (request, error, response) => {
+    onResponseHookCallCountplayer++;
+  };
+  const playerResponseHook2 = (request, error, response) => {
+    assert.equal(onResponseHookCallCountGlobal, 0, 'no global onResponse hook called');
+    assert.equal(onResponseHookCallCountplayer, 1, '1 player onResponse hook called');
+    assert.equal(response.url, 'http://localhost:9999/test/media2.m3u8', 'got expected response url');
+  };
+
+  videojs.Vhs.onResponse(globalResponseHook1);
+  videojs.Vhs.onResponse(globalResponseHook2);
+  this.player.tech_.vhs.onResponse(playerResponseHook1);
+  this.player.tech_.vhs.onResponse(playerResponseHook2);
+  // main
+  this.standardXHRResponse(this.requests.shift());
+
+  this.player.tech_.vhs.offResponse(playerResponseHook1);
+  this.player.tech_.vhs.offResponse(playerResponseHook2);
+
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  // ts
+  this.standardXHRResponse(this.requests.shift(), muxedSegment());
+
+  videojs.Vhs.offResponse(globalResponseHook1);
+  videojs.Vhs.offResponse(globalResponseHook2);
+});
+
+QUnit.test('Allows removing onResponse hooks globally with offResponse', function(assert) {
+  const done = assert.async();
+  let onResponseHookCallCount = 0;
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  openMediaSource(this.player, this.clock);
+  const globalResponseHook1 = (request, error, response) => {
+    onResponseHookCallCount++;
+  };
+  const globalResponseHook2 = (request, error, response) => {
+    assert.equal(onResponseHookCallCount, 0, '0 onResponse hooks called');
+    assert.equal(response.url, 'http://localhost:9999/test/media2.m3u8', 'got expected response url');
+    done();
+  };
+
+  videojs.Vhs.onResponse(globalResponseHook1);
+  videojs.Vhs.onResponse(globalResponseHook2);
+
+  // remove hook1
+  videojs.Vhs.offResponse(globalResponseHook1);
+
+  // main
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  videojs.Vhs.offResponse(globalResponseHook2);
+});
 
 QUnit.test(
   'passes useCueTags vhs option to main playlist controller',

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -48,7 +48,7 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
   assert.equal(this.requests.shift().url, 'global', 'url changed with global override');
 });
 
-QUnit.test('xhr calls global and player onRequest hooks respectively', function(assert) {
+QUnit.test('calls global and player onRequest hooks respectively', function(assert) {
   const defaultOptions = {
     url: 'default'
   };
@@ -57,7 +57,7 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   let xhrRequest = this.requests.shift();
 
   // create the global onRequest set and 2 hooks
-  videojs.Vhs.xhr.onRequest = new Set();
+  videojs.Vhs.xhr._requestCallbackSet = new Set();
   const globalRequestHook1 = (request) => {
     request.url = 'global';
   };
@@ -68,8 +68,8 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   };
 
   // add them to the set
-  videojs.Vhs.xhr.onRequest.add(globalRequestHook1);
-  videojs.Vhs.xhr.onRequest.add(globalRequestHook2);
+  videojs.Vhs.xhr._requestCallbackSet.add(globalRequestHook1);
+  videojs.Vhs.xhr._requestCallbackSet.add(globalRequestHook2);
 
   this.xhr(defaultOptions);
   xhrRequest = this.requests.shift();
@@ -78,7 +78,7 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   assert.equal(xhrRequest.headers.foo, 'bar', 'headers changed with global onRequest hooks');
 
   // create the player onRequest set and 2 hooks
-  this.xhr.onRequest = new Set();
+  this.xhr._requestCallbackSet = new Set();
   const playerRequestHook1 = (request) => {
     request.url = 'player';
   };
@@ -89,8 +89,8 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   };
 
   // add them to the set
-  this.xhr.onRequest.add(playerRequestHook1);
-  this.xhr.onRequest.add(playerRequestHook2);
+  this.xhr._requestCallbackSet.add(playerRequestHook1);
+  this.xhr._requestCallbackSet.add(playerRequestHook2);
 
   this.xhr(defaultOptions);
   xhrRequest = this.requests.shift();
@@ -100,13 +100,13 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   assert.equal(xhrRequest.headers.bar, 'foo', 'headers changed with player onRequest hooks');
 
   // delete player level request hooks and check to ensure global are still used
-  delete this.xhr.onRequest;
+  delete this.xhr._requestCallbackSet;
   this.xhr(defaultOptions);
   xhrRequest = this.requests.shift();
   assert.equal(xhrRequest.url, 'global', 'url changed with player onRequest hooks');
   assert.equal(xhrRequest.headers.foo, 'bar', 'headers changed with player onRequest hooks');
 
-  delete videojs.Vhs.xhr.onRequest;
+  delete videojs.Vhs.xhr._requestCallbackSet;
   this.xhr(defaultOptions);
   xhrRequest = this.requests.shift();
   assert.notEqual(xhrRequest.headers.foo, 'bar', 'headers the same without onRequest hooks');
@@ -120,7 +120,7 @@ QUnit.test('xhr calls global and player onResponse hooks respectively', function
   let globalHookCallCount = 0;
 
   // Create global onResponse set and 2 hooks
-  videojs.Vhs.xhr.onResponse = new Set();
+  videojs.Vhs.xhr._responseCallbackSet = new Set();
   const globalOnResponseHook1 = (request, error, response) => {
     globalHookCallCount++;
   };
@@ -128,11 +128,11 @@ QUnit.test('xhr calls global and player onResponse hooks respectively', function
     globalHookCallCount++;
   };
 
-  videojs.Vhs.xhr.onResponse.add(globalOnResponseHook1);
-  videojs.Vhs.xhr.onResponse.add(globalOnResponseHook2);
+  videojs.Vhs.xhr._responseCallbackSet.add(globalOnResponseHook1);
+  videojs.Vhs.xhr._responseCallbackSet.add(globalOnResponseHook2);
 
   // Create player onResponse set and 2 hooks
-  this.xhr.onResponse = new Set();
+  this.xhr._responseCallbackSet = new Set();
   const playerOnResponseHook1 = (request, error, response) => {
     assert.equal(response.body, 'foo-bar', 'expected response body');
     assert.equal(response.method, 'GET', 'expected method');
@@ -144,8 +144,8 @@ QUnit.test('xhr calls global and player onResponse hooks respectively', function
     done();
   };
 
-  this.xhr.onResponse.add(playerOnResponseHook1);
-  this.xhr.onResponse.add(playerOnResponseHook2);
+  this.xhr._responseCallbackSet.add(playerOnResponseHook1);
+  this.xhr._responseCallbackSet.add(playerOnResponseHook2);
 
   this.xhr(defaultOptions, () => { });
   this.requests.shift().respond(200, { foo: 'bar' }, 'foo-bar');

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -46,6 +46,48 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
 
   this.xhr(defaultOptions);
   assert.equal(this.requests.shift().url, 'global', 'url changed with global override');
+
+  delete videojs.Vhs.xhr.beforeRequest;
+});
+
+QUnit.test('xhr calls beforeResponse', function(assert) {
+  const done = assert.async();
+  const defaultOptions = {
+    url: 'default'
+  };
+
+  // Set player beforeResponse
+  this.xhr.beforeResponse = (response) => {
+    assert.equal(response.body, 'foo-bar', 'expected response body');
+    assert.equal(response.method, 'GET', 'expected method');
+    assert.equal(response.headers.foo, 'bar', 'expected headers');
+    assert.equal(response.statusCode, 200, 'expected statusCode');
+    assert.equal(response.url, 'default', 'expected URL');
+  };
+
+  // Set global beforeResponse
+  videojs.Vhs.xhr.beforeResponse = (response) => {
+    assert.equal(response.body, 'bar-foo', 'expected response body');
+    assert.equal(response.method, 'GET', 'expected method');
+    assert.equal(response.headers.bar, 'foo', 'expected headers');
+    assert.equal(response.statusCode, 200, 'expected statusCode');
+    assert.equal(response.url, 'global', 'expected URL');
+    done();
+  };
+
+  this.xhr(defaultOptions, () => { });
+  this.requests.shift().respond(200, { foo: 'bar' }, 'foo-bar');
+
+  delete this.xhr.beforeResponse;
+
+  const globalOptions = {
+    url: 'global'
+  };
+
+  this.xhr(globalOptions, () => { });
+  this.requests.shift().respond(200, { bar: 'foo' }, 'bar-foo');
+
+  delete videojs.Vhs.xhr.beforeResponse;
 });
 
 QUnit.test('byterangeStr works as expected', function(assert) {

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -46,8 +46,6 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
 
   this.xhr(defaultOptions);
   assert.equal(this.requests.shift().url, 'global', 'url changed with global override');
-
-  delete videojs.Vhs.xhr.beforeRequest;
 });
 
 QUnit.test('xhr calls global and player onRequest hooks respectively', function(assert) {

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -50,35 +50,124 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
   delete videojs.Vhs.xhr.beforeRequest;
 });
 
-QUnit.test('xhr calls beforeResponse', function(assert) {
-  const done = assert.async();
+QUnit.test('xhr calls global and player onRequest hooks respectively', function(assert) {
   const defaultOptions = {
     url: 'default'
   };
 
-  // Set player beforeResponse
-  this.xhr.beforeResponse = (response) => {
+  this.xhr(defaultOptions);
+  let xhrRequest = this.requests.shift();
+
+  assert.equal(xhrRequest.url, 'default', 'url the same without onRequest hooks');
+  // create the global onRequest set and 2 hooks
+  videojs.Vhs.xhr.onRequest = new Set();
+  const globalRequestHook1 = (request) => {
+    request.url = 'global';
+  };
+  const globalRequestHook2 = (request) => {
+    request.headers = {
+      foo: 'bar'
+    };
+  };
+
+  // add them to the set
+  videojs.Vhs.xhr.onRequest.add(globalRequestHook1);
+  videojs.Vhs.xhr.onRequest.add(globalRequestHook2);
+
+  this.xhr(defaultOptions);
+  xhrRequest = this.requests.shift();
+
+  assert.equal(xhrRequest.url, 'global', 'url changed with global onRequest hooks');
+  assert.equal(xhrRequest.headers.foo, 'bar', 'headers changed with global onRequest hooks');
+
+  // create the player onRequest set and 2 hooks
+  this.xhr.onRequest = new Set();
+  const playerRequestHook1 = (request) => {
+    request.url = 'player';
+  };
+  const playerRequestHook2 = (request) => {
+    request.headers = {
+      bar: 'foo'
+    };
+  };
+
+  // add them to the set
+  this.xhr.onRequest.add(playerRequestHook1);
+  this.xhr.onRequest.add(playerRequestHook2);
+
+  this.xhr(defaultOptions);
+  xhrRequest = this.requests.shift();
+
+  // player level request hooks override global
+  assert.equal(xhrRequest.url, 'player', 'url changed with player onRequest hooks');
+  assert.equal(xhrRequest.headers.bar, 'foo', 'headers changed with player onRequest hooks');
+
+  // delete player level request hooks and check to ensure global are still used
+  delete this.xhr.onRequest;
+  this.xhr(defaultOptions);
+  xhrRequest = this.requests.shift();
+  assert.equal(xhrRequest.url, 'global', 'url changed with player onRequest hooks');
+  assert.equal(xhrRequest.headers.foo, 'bar', 'headers changed with player onRequest hooks');
+
+  // delete global request hooks and ensure we return to default
+  delete videojs.Vhs.xhr.onRequest;
+  this.xhr(defaultOptions);
+  xhrRequest = this.requests.shift();
+  assert.equal(xhrRequest.url, 'default', 'url the same without onRequest hooks');
+  assert.notEqual(xhrRequest.headers.foo, 'bar', 'headers the same without onRequest hooks');
+});
+
+QUnit.test('xhr calls global and player onResponse hooks respectively', function(assert) {
+  const done = assert.async();
+  const defaultOptions = {
+    url: 'default'
+  };
+  let globalHookCallCount = 0;
+
+  // Create global onResponse set and 2 hooks
+  videojs.Vhs.xhr.onResponse = new Set();
+  const globalOnResponseHook1 = (request, error, response) => {
+    globalHookCallCount++;
+  };
+  const globalOnResponseHook2 = (request, error, response) => {
+    globalHookCallCount++;
+  };
+
+  videojs.Vhs.xhr.onResponse.add(globalOnResponseHook1);
+  videojs.Vhs.xhr.onResponse.add(globalOnResponseHook2);
+
+  // Create player onResponse set and 2 hooks
+  this.xhr.onResponse = new Set();
+  const playerOnResponseHook1 = (request, error, response) => {
     assert.equal(response.body, 'foo-bar', 'expected response body');
     assert.equal(response.method, 'GET', 'expected method');
+  };
+  const playerOnResponseHook2 = (request, error, response) => {
     assert.equal(response.headers.foo, 'bar', 'expected headers');
     assert.equal(response.statusCode, 200, 'expected statusCode');
     assert.equal(response.url, 'default', 'expected URL');
+    assert.equal(globalHookCallCount, 0, 'global response hooks not called yet');
   };
 
-  // Set global beforeResponse
-  videojs.Vhs.xhr.beforeResponse = (response) => {
+  this.xhr.onResponse.add(playerOnResponseHook1);
+  this.xhr.onResponse.add(playerOnResponseHook2);
+
+  this.xhr(defaultOptions, () => { });
+  this.requests.shift().respond(200, { foo: 'bar' }, 'foo-bar');
+
+  const globalOnResponseHook3 = (request, error, response) => {
     assert.equal(response.body, 'bar-foo', 'expected response body');
     assert.equal(response.method, 'GET', 'expected method');
     assert.equal(response.headers.bar, 'foo', 'expected headers');
     assert.equal(response.statusCode, 200, 'expected statusCode');
     assert.equal(response.url, 'global', 'expected URL');
+    assert.equal(globalHookCallCount, 2, 'global response hooks called 2 times');
     done();
   };
 
-  this.xhr(defaultOptions, () => { });
-  this.requests.shift().respond(200, { foo: 'bar' }, 'foo-bar');
-
-  delete this.xhr.beforeResponse;
+  videojs.Vhs.xhr.onResponse.add(globalOnResponseHook3);
+  // delete player onResponse hooks
+  delete this.xhr.onResponse;
 
   const globalOptions = {
     url: 'global'
@@ -86,8 +175,6 @@ QUnit.test('xhr calls beforeResponse', function(assert) {
 
   this.xhr(globalOptions, () => { });
   this.requests.shift().respond(200, { bar: 'foo' }, 'bar-foo');
-
-  delete videojs.Vhs.xhr.beforeResponse;
 });
 
 QUnit.test('byterangeStr works as expected', function(assert) {

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -56,7 +56,6 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   this.xhr(defaultOptions);
   let xhrRequest = this.requests.shift();
 
-  assert.equal(xhrRequest.url, 'default', 'url the same without onRequest hooks');
   // create the global onRequest set and 2 hooks
   videojs.Vhs.xhr.onRequest = new Set();
   const globalRequestHook1 = (request) => {
@@ -107,11 +106,9 @@ QUnit.test('xhr calls global and player onRequest hooks respectively', function(
   assert.equal(xhrRequest.url, 'global', 'url changed with player onRequest hooks');
   assert.equal(xhrRequest.headers.foo, 'bar', 'headers changed with player onRequest hooks');
 
-  // delete global request hooks and ensure we return to default
   delete videojs.Vhs.xhr.onRequest;
   this.xhr(defaultOptions);
   xhrRequest = this.requests.shift();
-  assert.equal(xhrRequest.url, 'default', 'url the same without onRequest hooks');
   assert.notEqual(xhrRequest.headers.foo, 'bar', 'headers the same without onRequest hooks');
 });
 
@@ -143,8 +140,8 @@ QUnit.test('xhr calls global and player onResponse hooks respectively', function
   const playerOnResponseHook2 = (request, error, response) => {
     assert.equal(response.headers.foo, 'bar', 'expected headers');
     assert.equal(response.statusCode, 200, 'expected statusCode');
-    assert.equal(response.url, 'default', 'expected URL');
     assert.equal(globalHookCallCount, 0, 'global response hooks not called yet');
+    done();
   };
 
   this.xhr.onResponse.add(playerOnResponseHook1);
@@ -152,27 +149,6 @@ QUnit.test('xhr calls global and player onResponse hooks respectively', function
 
   this.xhr(defaultOptions, () => { });
   this.requests.shift().respond(200, { foo: 'bar' }, 'foo-bar');
-
-  const globalOnResponseHook3 = (request, error, response) => {
-    assert.equal(response.body, 'bar-foo', 'expected response body');
-    assert.equal(response.method, 'GET', 'expected method');
-    assert.equal(response.headers.bar, 'foo', 'expected headers');
-    assert.equal(response.statusCode, 200, 'expected statusCode');
-    assert.equal(response.url, 'global', 'expected URL');
-    assert.equal(globalHookCallCount, 2, 'global response hooks called 2 times');
-    done();
-  };
-
-  videojs.Vhs.xhr.onResponse.add(globalOnResponseHook3);
-  // delete player onResponse hooks
-  delete this.xhr.onResponse;
-
-  const globalOptions = {
-    url: 'global'
-  };
-
-  this.xhr(globalOptions, () => { });
-  this.requests.shift().respond(200, { bar: 'foo' }, 'bar-foo');
 });
 
 QUnit.test('byterangeStr works as expected', function(assert) {


### PR DESCRIPTION
## Description
This PR would add xhr request and response hooks via an `onRequest(callback)` and `onResponse(callback)` API. The user can add as many unique hook callbacks as they want, and they will be called in the order they were added before the request and after the response is received respectively. The user can un-register these callbacks via the `offRequest(callback)` and `offResponse(callback)` API. The callback functions can take the following parameters:
- `onRequest` callbacks will pass the xhr `request` Object to the callback.
- `onResponse` callbacks will pass the xhr `request, error, and response` Objects to the callback in that order.

In addition, the user can use both **global** `videojs.Vhs` _and_ **player** `player.tech().xhr` scoped API functions to add these hooks, where player hooks will _override_ any global hooks.

Note: `onRequest` hooks are called **_after_** the `beforeRequest` function, so be aware that these hooks may further modify request options passed through that function.

## Specific Changes proposed
Adding API functions to both `Vhs` and the `VhsHandler` for adding and removing unique xhr request and response hooks, passing those hooks to the xhr module, then calling them in the order they were added before an xhr request and in the response callback respectively.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
