### PR TITLE
fix: onRequest hooks called too late

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,8 +646,7 @@ functions which will remove a callback function from the `onRequest` or
 
 The `onRequest(callback)` function takes a `callback` function that will pass the xhr `options`
 Object to that callback. These callbacks are called synchronously, in the order registered 
-and act as pre-request hooks for modifying the xhr `options` Object prior to making a request. 
-https://github.com/videojs/xhr#options
+and act as pre-request hooks for modifying the xhr `options` Object prior to making a request.
 
 Example:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -701,25 +701,9 @@ Example:
 ```javascript
 player.tech().vhs.xhr.offResponse(playerResponseHook);
 ```
-Additionally a `beforeRequest` function can be defined, 
-that will be called with an object containing the options that will be used 
-to create the xhr request.
 
-Note: any registered `onRequest` hooks, are called _after_ the `beforeRequest` function, so xhr
-options modified by this function may be further modified by these hooks.
-
-Example:
-```javascript
-player.tech().vhs.xhr.beforeRequest = function(options) {
-  options.uri = options.uri.replace('example.com', 'foo.com');
-
-  return options;
-};
-```
-
-The global `videojs.Vhs` also exposes an `xhr` property. Adding
-`onRequest`, `onResponse` hooks and/or specifying a `beforeRequest` 
-function that will allow you to intercept the request options, xhr 
+The global `videojs.Vhs` also exposes an `xhr` property. Adding `onRequest` 
+and/or `onResponse` hooks will allow you to intercept the request options, xhr 
 Object, error and response data for *all* requests in every player on a page. 
 For consistency across browsers the video source should be set at runtime 
 once the video player is ready.
@@ -762,24 +746,6 @@ videojs.Vhs.xhr.offRequest(globalRequestHook);
 ```javascript
 // Remove a global onResponse callback.
 videojs.Vhs.xhr.offResponse(globalResponseHook);
-```
-
-```javascript
-videojs.Vhs.xhr.beforeRequest = function(options) {
-  /*
-   * Modifications to requests that will affect every player.
-   */
-
-  return options;
-};
-
-var player = videojs('video-player-id');
-player.ready(function() {
-  this.src({
-    src: 'https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8',
-    type: 'application/x-mpegURL',
-  });
-});
 ```
 
 For information on the type of options that you can modify see the

--- a/README.md
+++ b/README.md
@@ -644,18 +644,33 @@ callback function as a parameter as well as `offRequest` and `offResponse`
 functions which will remove a callback function from the `onRequest` or 
 `onResponse` set if it exists. 
 
-The `onRequest(callback)` function takes a `callback` function that will pass the xhr `request`
-Object to that callback. These callbacks are called synchronously, in the order registered
-and act as pre-request hooks for modifying the xhr `request` Object prior to making a request.
+The `onRequest(callback)` function takes a `callback` function that will pass the xhr `options`
+Object to that callback. These callbacks are called synchronously, in the order registered 
+and act as pre-request hooks for modifying the xhr `options` Object prior to making a request. 
+https://github.com/videojs/xhr#options
 
 Example:
 ```javascript
-const playerRequestHook = (request) => {
-  const requestUrl = new URL(request.uri);
+const playerRequestHook = (options) => {
+  const requestUrl = new URL(options.uri);
   requestUrl.searchParams.set('foo', 'bar');
-  request.uri = requestUrl.href;
+  options.uri = requestUrl.href;
 };
 player.tech().vhs.xhr.onRequest(playerRequestHook);
+```
+
+If access to the `xhr` Object is required prior to the `xhr.send` call, an `options.beforeSend` 
+callback can be set within an `onRequest` callback function that will pass the `xhr` Object 
+as a parameter and will be called immediately prior to `xhr.send`.
+
+Example:
+```javascript
+const playerXhrRequestHook = (options) => {
+  options.beforeSend = (xhr) => {
+    xhr.open('GET', 'https://new.uri');
+  };
+};
+player.tech().vhs.xhr.onRequest(playerXhrRequestHook);
 ```
 
 The `onResponse(callback)` function takes a `callback` function that will pass the xhr
@@ -704,20 +719,30 @@ player.tech().vhs.xhr.beforeRequest = function(options) {
 
 The global `videojs.Vhs` also exposes an `xhr` property. Adding
 `onRequest`, `onResponse` hooks and/or specifying a `beforeRequest` 
-function that will allow you to intercept the request Object, response 
-data and options for *all* requests in every player on a page. For 
-consistency across browsers the video source should be set at runtime 
+function that will allow you to intercept the request options, xhr 
+Object, error and response data for *all* requests in every player on a page. 
+For consistency across browsers the video source should be set at runtime 
 once the video player is ready.
 
 Example:
 ```javascript
 // Global request callback, will affect every player.
-const globalRequestHook = (request) => {
-  const requestUrl = new URL(request.uri);
+const globalRequestHook = (options) => {
+  const requestUrl = new URL(options.uri);
   requestUrl.searchParams.set('foo', 'bar');
-  request.uri = requestUrl.href;
+  options.uri = requestUrl.href;
 };
 videojs.Vhs.xhr.onRequest(globalRequestHook);
+```
+
+```javascript
+// Global request callback defining beforeSend function, will affect every player.
+const globalXhrRequestHook = (options) => {
+  options.beforeSend = (xhr) => {
+    xhr.open('GET', 'https://new.uri');
+  };
+};
+videojs.Vhs.xhr.onRequest(globalXhrRequestHook);
 ```
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Video.js Compatibility: 7.x, 8.x
     - [vhs.stats](#vhsstats)
   - [Events](#events)
     - [loadedmetadata](#loadedmetadata)
+    - [xhr-hooks-ready](#xhr-hooks-ready)
   - [VHS Usage Events](#vhs-usage-events)
     - [Presence Stats](#presence-stats)
     - [Use Stats](#use-stats)
@@ -819,6 +820,11 @@ are triggered on the player object.
 
 Fired after the first segment is downloaded for a playlist. This will not happen
 until playback if video.js's `metadata` setting is `none`
+
+#### xhr-hooks-ready
+
+Fired when the player `xhr` object is ready to set `onRequest` and `offRequest` hooks, as well
+as remove hooks with `offRequest` and `offResponse`.
 
 ### VHS Usage Events
 

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ videojs.Vhs.xhr.onRequest(globalRequestHook);
 // Global request callback defining beforeSend function, will affect every player.
 const globalXhrRequestHook = (options) => {
   options.beforeSend = (xhr) => {
-    xhr.open('GET', 'https://new.uri');
+    xhr.setRequestHeader('foo', 'bar');
   };
 };
 videojs.Vhs.xhr.onRequest(globalXhrRequestHook);

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Example:
 ```javascript
 const playerXhrRequestHook = (options) => {
   options.beforeSend = (xhr) => {
-    xhr.open('GET', 'https://new.uri');
+    xhr.setRequestHeader('foo', 'bar');
   };
 };
 player.tech().vhs.xhr.onRequest(playerXhrRequestHook);

--- a/README.md
+++ b/README.md
@@ -643,19 +643,9 @@ the function with your own implementation. Instead, `xhr` provides
 the ability to specify `onRequest` and `onResponse` hooks which each take a
 callback function as a parameter, as well as `offRequest` and `offResponse`
 functions which can remove a callback function from the `onRequest` or
-`onResponse` Set.
-
-Additionally, an `xhr-hooks-ready` event is fired from a player when 
-per-player hooks are ready to be added or removed. This will ensure player 
-specific hooks are set prior to any manifest or segment requests.
-
-Example:
-```javascript
-player.on('xhr-hooks-ready', () => {
-  const playerRequestHook = (options) => options;
-  player.tech().vhs.xhr.onRequest(playerRequestHook);
-});
-```
+`onResponse` Set. An `xhr-hooks-ready` event is fired from a player when per-player
+hooks are ready to be added or removed. This will ensure player specific hooks are
+set prior to any manifest or segment requests.
 
 The `onRequest(callback)` function takes a `callback` function that will pass an xhr `options`
 Object to that callback. These callbacks are called synchronously, in the order registered 
@@ -666,12 +656,14 @@ hook receives the returned `options` as a parameter.
 
 Example:
 ```javascript
-const playerRequestHook = (options) => {
-  return {
-    uri: 'https://new.options.uri'
+player.on('xhr-hooks-ready', () => {
+  const playerRequestHook = (options) => {
+    return {
+      uri: 'https://new.options.uri'
+    };
   };
-};
-player.tech().vhs.xhr.onRequest(playerRequestHook);
+  player.tech().vhs.xhr.onRequest(playerRequestHook);
+});
 ```
 
 If access to the `xhr` Object is required prior to the `xhr.send` call, an `options.beforeSend` 
@@ -680,13 +672,15 @@ as a parameter and will be called immediately prior to `xhr.send`.
 
 Example:
 ```javascript
-const playerXhrRequestHook = (options) => {
-  options.beforeSend = (xhr) => {
-    xhr.setRequestHeader('foo', 'bar');
+player.on('xhr-hooks-ready', () => {
+  const playerXhrRequestHook = (options) => {
+    options.beforeSend = (xhr) => {
+      xhr.setRequestHeader('foo', 'bar');
+    };
+    return options;
   };
-  return options;
-};
-player.tech().vhs.xhr.onRequest(playerXhrRequestHook);
+  player.tech().vhs.xhr.onRequest(playerXhrRequestHook);
+});
 ```
 
 The `onResponse(callback)` function takes a `callback` function that will pass the xhr
@@ -697,10 +691,12 @@ return value, the parameters are passed to each subsequent callback by reference
 
 Example:
 ```javascript
-const playerResponseHook = (request, error, response) => {
-  const bar = response.headers.foo
-};
-player.tech().vhs.xhr.onResponse(playerResponseHook);
+player.on('xhr-hooks-ready', () => {
+  const playerResponseHook = (request, error, response) => {
+    const bar = response.headers.foo;
+  };
+  player.tech().vhs.xhr.onResponse(playerResponseHook);
+});
 ```
 
 The `offRequest` function takes a `callback` function, and will remove that function from
@@ -708,7 +704,9 @@ the collection of `onRequest` hooks if it exists.
 
 Example:
 ```javascript
-player.tech().vhs.xhr.offRequest(playerRequestHook);
+player.on('xhr-hooks-ready', () => {
+  player.tech().vhs.xhr.offRequest(playerRequestHook);
+});
 ```
 
 The `offResponse` function takes a `callback` function, and will remove that function from
@@ -716,7 +714,9 @@ the collection of `offResponse` hooks if it exists.
 
 Example:
 ```javascript
-player.tech().vhs.xhr.offResponse(playerResponseHook);
+player.on('xhr-hooks-ready', () => {
+  player.tech().vhs.xhr.offResponse(playerResponseHook);
+});
 ```
 
 The global `videojs.Vhs` also exposes an `xhr` property. Adding `onRequest`

--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ until playback if video.js's `metadata` setting is `none`
 
 #### xhr-hooks-ready
 
-Fired when the player `xhr` object is ready to set `onRequest` and `offRequest` hooks, as well
+Fired when the player `xhr` object is ready to set `onRequest` and `onResponse` hooks, as well
 as remove hooks with `offRequest` and `offResponse`.
 
 ### VHS Usage Events

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1332,6 +1332,12 @@ class VhsHandler extends Component {
     this.xhr.offResponse = (callback) => {
       removeOnResponseHook(this.xhr, callback);
     };
+
+    /**
+     * Trigger an event on the player to notify the user that vhs is ready to set xhr hooks.
+     * This allows hooks to be set before the source is set to vhs when handleSource is called.
+     */
+    this.player_.trigger('xhr-hooks-ready');
   }
 }
 
@@ -1356,7 +1362,6 @@ const VhsSourceHandler = {
     tech.vhs = new VhsHandler(source, tech, localOptions);
     tech.vhs.xhr = xhrFactory();
     tech.vhs.setupXhrHooks_();
-
     tech.vhs.src(source.src, source.type);
     return tech.vhs;
   },

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1333,10 +1333,8 @@ class VhsHandler extends Component {
       removeOnResponseHook(this.xhr, callback);
     };
 
-    /**
-     * Trigger an event on the player to notify the user that vhs is ready to set xhr hooks.
-     * This allows hooks to be set before the source is set to vhs when handleSource is called.
-     */
+    // Trigger an event on the player to notify the user that vhs is ready to set xhr hooks.
+    // This allows hooks to be set before the source is set to vhs when handleSource is called.
     this.player_.trigger('xhr-hooks-ready');
   }
 }

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -99,6 +99,8 @@ const xhrFactory = function() {
     // TODO: switch back to videojs.Vhs.xhr.name === 'XhrFunction' when we drop IE11
     const xhrMethod = videojs.Vhs.xhr.original === true ? videojsXHR : videojs.Vhs.xhr;
 
+    // call all registered onRequest hooks
+    callAllHooks(_requestCallbackSet, options);
     const request = xhrMethod(options, function(error, response) {
       // call all registered onResponse hooks
       callAllHooks(_responseCallbackSet, request, error, response);
@@ -112,9 +114,6 @@ const xhrFactory = function() {
     };
     request.uri = options.uri;
     request.requestTime = Date.now();
-    // call all registered onRequest hooks
-    callAllHooks(_requestCallbackSet, request);
-
     return request;
   };
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4523,6 +4523,26 @@ QUnit.test('Allows xhr object access in player onRequest hooks', function(assert
   this.player.tech_.vhs.xhr.offRequest(playerXhrRequestHook2);
 });
 
+QUnit.test('xhr-hooks-ready event fires as expected', function(assert) {
+  const done = assert.async();
+
+  this.player.on('xhr-hooks-ready', (event) => {
+    assert.equal(event.type, 'xhr-hooks-ready', 'event type is xhr-hooks-ready');
+    assert.ok(this.player.tech(true).vhs.xhr.onRequest);
+    assert.ok(this.player.tech(true).vhs.xhr.onResponse);
+    assert.ok(this.player.tech(true).vhs.xhr.offRequest);
+    assert.ok(this.player.tech(true).vhs.xhr.offResponse);
+    done();
+  });
+
+  this.player.src({
+    src: 'main.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+});
+
 QUnit.test(
   'passes useCueTags vhs option to main playlist controller',
   function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4123,9 +4123,11 @@ QUnit.test('Allows setting onRequest hooks globally', function(assert) {
     requestUrl.searchParams.set('foo', 'bar');
     actualRequestUrl = options.uri = requestUrl.href;
     onRequestHookCallCount++;
+    return options;
   };
-  const globalRequestHook2 = () => {
+  const globalRequestHook2 = (options) => {
     onRequestHookCallCount++;
+    return options;
   };
 
   videojs.Vhs.xhr.onRequest(globalRequestHook1);
@@ -4159,9 +4161,11 @@ QUnit.test('Allows setting onRequest hooks on the player', function(assert) {
     requestUrl.searchParams.set('foo', 'bar');
     actualRequestUrl = options.uri = requestUrl.href;
     onRequestHookCallCount++;
+    return options;
   };
-  const playerRequestHook2 = () => {
+  const playerRequestHook2 = (options) => {
     onRequestHookCallCount++;
+    return options;
   };
 
   // Setup player level xhr hooks.
@@ -4200,9 +4204,11 @@ QUnit.test('Allows setting onRequest hooks globally and overriding with player h
     requestUrl.searchParams.set('foo', 'bar');
     actualRequestUrlGlobal = options.uri = requestUrl.href;
     onRequestHookCallCountGlobal++;
+    return options;
   };
-  const globalRequestHook2 = () => {
+  const globalRequestHook2 = (options) => {
     onRequestHookCallCountGlobal++;
+    return options;
   };
 
   videojs.Vhs.xhr.onRequest(globalRequestHook1);
@@ -4214,9 +4220,11 @@ QUnit.test('Allows setting onRequest hooks globally and overriding with player h
     requestUrl.searchParams.set('bar', 'foo');
     actualRequestUrlPlayer = options.uri = requestUrl.href;
     onRequestHookCallCountPlayer++;
+    return options;
   };
-  const playerRequestHook2 = () => {
+  const playerRequestHook2 = (options) => {
     onRequestHookCallCountPlayer++;
+    return options;
   };
 
   // Setup player level xhr hooks.
@@ -4264,9 +4272,11 @@ QUnit.test('Allows removing onRequest hooks globally with offRequest', function(
     requestUrl.searchParams.set('foo', 'bar');
     actualRequestUrl = options.uri = requestUrl.href;
     onRequestHookCallCount++;
+    return options;
   };
-  const globalRequestHook2 = () => {
+  const globalRequestHook2 = (options) => {
     onRequestHookCallCount++;
+    return options;
   };
 
   videojs.Vhs.xhr.onRequest(globalRequestHook1);
@@ -4462,6 +4472,7 @@ QUnit.test('Allows xhr object access in global onRequest hooks', function(assert
       xhr.open('GET', 'https://foo.bar');
     };
     onRequestHookCallCount++;
+    return options;
   };
   const globalXhrRequestHook2 = (options) => {
     options.beforeSend = (xhr) => {
@@ -4469,6 +4480,7 @@ QUnit.test('Allows xhr object access in global onRequest hooks', function(assert
       expectedUrl = xhr.url;
     };
     onRequestHookCallCount++;
+    return options;
   };
 
   videojs.Vhs.xhr.onRequest(globalXhrRequestHook1);
@@ -4501,6 +4513,7 @@ QUnit.test('Allows xhr object access in player onRequest hooks', function(assert
       xhr.open('GET', 'https://new.url');
     };
     onRequestHookCallCount++;
+    return options;
   };
   const playerXhrRequestHook2 = (options) => {
     options.beforeSend = (xhr) => {
@@ -4508,6 +4521,7 @@ QUnit.test('Allows xhr object access in player onRequest hooks', function(assert
       expectedUrl = xhr.url;
     };
     onRequestHookCallCount++;
+    return options;
   };
 
   // Setup player level xhr hooks.

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4005,6 +4005,7 @@ QUnit.test(
     this.standardXHRResponse(this.requests.shift());
 
     assert.ok(beforeRequestCalled, 'beforeRequest was called');
+    assert.equal(this.env.log.warn.calls, 2, 'warning logged for deprecation');
 
     // verify stats
     assert.equal(this.player.tech_.vhs.stats.bandwidth, 4194304, 'default');
@@ -4030,6 +4031,7 @@ QUnit.test('Allows specifying the beforeRequest function globally', function(ass
   this.standardXHRResponse(this.requests.shift());
 
   assert.ok(beforeRequestCalled, 'beforeRequest was called');
+  assert.equal(this.env.log.warn.calls, 2, 'warning logged for deprecation');
 
   delete videojs.Vhs.xhr.beforeRequest;
 
@@ -4098,6 +4100,7 @@ QUnit.test('Allows overriding the global beforeRequest function', function(asser
                                            'for the media playlist and media');
   assert.equal(beforeGlobalRequestCalled, 1, 'global beforeRequest was called once ' +
                                             'for the main playlist');
+  assert.equal(this.env.log.warn.calls, 3, 'warning logged for deprecation');
 
   delete videojs.Vhs.xhr.beforeRequest;
 });

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -53,6 +53,37 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
   delete videojs.Vhs.xhr.beforeRequest;
 });
 
+QUnit.test('beforeRequest can return a new options object', function(assert) {
+  const defaultOptions = {
+    url: 'default'
+  };
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'default', 'url the same without override');
+
+  videojs.Vhs.xhr.beforeRequest = () => {
+    return { uri: 'global-newOptions'};
+  };
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'global-newOptions', 'url changed with global override');
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged for deprecation');
+
+  this.xhr.beforeRequest = () => {
+    return { uri: 'player-newOptions'};
+  };
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'player-newOptions', 'url changed with player override');
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged for deprecation');
+
+  delete this.xhr.beforeRequest;
+  delete videojs.Vhs.xhr.beforeRequest;
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'default', 'url the same without override');
+});
+
 QUnit.test('calls global and player onRequest hooks respectively', function(assert) {
   const defaultOptions = {
     url: 'default'

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -94,13 +94,15 @@ QUnit.test('calls global and player onRequest hooks respectively', function(asse
 
   // create the global onRequest set and 2 hooks
   videojs.Vhs.xhr._requestCallbackSet = new Set();
-  const globalRequestHook1 = (request) => {
-    request.url = 'global';
+  const globalRequestHook1 = (options) => {
+    options.url = 'global';
+    return options;
   };
-  const globalRequestHook2 = (request) => {
-    request.headers = {
+  const globalRequestHook2 = (options) => {
+    options.headers = {
       foo: 'bar'
     };
+    return options;
   };
 
   // add them to the set
@@ -115,13 +117,15 @@ QUnit.test('calls global and player onRequest hooks respectively', function(asse
 
   // create the player onRequest set and 2 hooks
   this.xhr._requestCallbackSet = new Set();
-  const playerRequestHook1 = (request) => {
-    request.url = 'player';
+  const playerRequestHook1 = (options) => {
+    options.url = 'player';
+    return options;
   };
-  const playerRequestHook2 = (request) => {
-    request.headers = {
+  const playerRequestHook2 = (options) => {
+    options.headers = {
       bar: 'foo'
     };
+    return options;
   };
 
   // add them to the set

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -33,6 +33,7 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
 
   this.xhr(defaultOptions);
   assert.equal(this.requests.shift().url, 'player', 'url changed with player override');
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged for deprecation');
 
   videojs.Vhs.xhr.beforeRequest = (options) => {
     options.url = 'global';
@@ -41,11 +42,15 @@ QUnit.test('xhr respects beforeRequest', function(assert) {
 
   this.xhr(defaultOptions);
   assert.equal(this.requests.shift().url, 'player', 'prioritizes player override');
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged for deprecation');
 
   delete this.xhr.beforeRequest;
 
   this.xhr(defaultOptions);
   assert.equal(this.requests.shift().url, 'global', 'url changed with global override');
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged for deprecation');
+
+  delete videojs.Vhs.xhr.beforeRequest;
 });
 
 QUnit.test('calls global and player onRequest hooks respectively', function(assert) {


### PR DESCRIPTION
## Description
The xhr wrapper calls `open` and `send` when a request object is instantiated, this is causing `onRequest` hooks to modify the xhr object too late, as they were already sent when the object was returned to the VHS xhr module. Additionally, setting xhr hooks in time for the initial manifest request when `preload` is set to `auto` or `metadata` is not possible with existing events or `ready` callbacks.

## Specific Changes proposed

### Moving the request hooks callback and changing the callback parameter
By calling all the `onRequest` hooks **before** we create the `request` object and passing the callback the `options` object instead, we can modify the request before `open` is called in the xhr wrapper. This `options` object allows for modifying the url/headers/methods, as well as setting a `beforeSend` callback, which gives the `onRequest` callback direct access to the `xhr` object via a nested callback. `beforeSend` will be called immediately before `xhr.send` is called, which allows for full control of the xhr object prior to sending the request.

For example, setting a request header.
```js
const playerXhrRequestHook = (options) => {
  options.beforeSend = (xhr) => {
    xhr.setRequestHeader('foo', 'bar');
  };
};
player.tech().vhs.xhr.onRequest(playerXhrRequestHook);
```
See all supported options: https://github.com/videojs/xhr#options

### Adding an xhr-hooks-ready event
This fixes a `preload` option issue in VHS, where if metadata is preloaded setting `onRequest` hooks is not possible on `player.ready` because `player.tech().vhs` doesn't exist yet as it's created in `handleSources`. Also if the user tries to set `onRequest` hooks on the `loadstart` event, it's too late and the callback will not be set before the manifest is requested. Thus, a new event is needed to be fired immediately when the hooks are available, which allows the user to apply these hooks to all requests, including the main manifest.

### Deprecating xhr.beforeRequest
Since adding an `onRequest` hooks is functionally the same as setting a `xhr.beforeRequest` callback,  a deprecation warning will log when setting a `beforeRequest` function. `beforeRequest` will also now alias to an `onRequest` callback.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
