### PR TITLE
fix(llhls): watcher causes playback failure

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -497,9 +497,9 @@ export default class PlaybackWatcher {
 
     let allowedEnd = seekable.end(seekable.length - 1) + Ranges.SAFE_TIME_DELTA;
     const isLive = !playlist.endList;
-    const isLLHLS = this.tech_.vhs.options_.llhls;
+    const isLLHLS = typeof playlist.partTargetDuration === 'number';
 
-    if (isLive && isLLHLS || allowSeeksWithinUnsafeLiveWindow) {
+    if (isLive && (isLLHLS || allowSeeksWithinUnsafeLiveWindow)) {
       allowedEnd = seekable.end(seekable.length - 1) + (playlist.targetDuration * 3);
     }
 

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -497,8 +497,9 @@ export default class PlaybackWatcher {
 
     let allowedEnd = seekable.end(seekable.length - 1) + Ranges.SAFE_TIME_DELTA;
     const isLive = !playlist.endList;
+    const isLLHLS = this.tech_.vhs.options_.llhls;
 
-    if (isLive && allowSeeksWithinUnsafeLiveWindow) {
+    if (isLive && isLLHLS || allowSeeksWithinUnsafeLiveWindow) {
       allowedEnd = seekable.end(seekable.length - 1) + (playlist.targetDuration * 3);
     }
 


### PR DESCRIPTION
## Description
Low latency streams can get into a bad state on startup and fail if the seek position is adjusted with the playback watcher, specifically by `fixesBadSeeks`. There are checks in that function that determine if a seek position is outside the seekable window. This seekable range is a calculated interval duration from the playlist, where the **end** of the seekable window is the `duration - HOLD-BACK`. When the player first calculates the seekable range from the manifest, the interval duration returned is not precise. Sometimes this non-precise duration will be greater than the precise duration determined after the playlist is loaded. Since the player uses the first, non-precise duration calculation to determine the start position of a live asset, if the precise duration is updated to a lesser value before the player completes the seek to the start position this can cause the start position to fall outside of the "safe seek window". When combined with a manifest that utilizes #EXT-X-INDEPENDENT-SEGMENTS tags, this would cause the player to get stuck requesting the same partial segment in rapid succession, triggering [playlist exclusion logic](https://github.com/videojs/http-streaming/blob/f5578513749187467866bc1f49b729b609a16041/src/playback-watcher.js#L196) and eventual a fatal `MEDIA_ERR_DECODE`.

The PRs for [#EXT-X-INDEPENDENT-SEGMENTS](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.5.1) support are:
https://github.com/videojs/m3u8-parser/pull/165
and
https://github.com/videojs/http-streaming/pull/1399

## Specific Changes proposed
Adding an exclusion for LLHLS to allow for seeking beyond the "safe" seek window.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
