### PR TITLE
feat: add support for independentSegments

### DIFF
--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -115,7 +115,6 @@ not yet been implemented. VHS currently supports everything in the
 * [EXT-X-DATERANGE]
 * [EXT-X-SESSION-DATA]
 * [EXT-X-SESSION-KEY]
-* [EXT-X-INDEPENDENT-SEGMENTS]
 * Alternate video via [EXT-X-MEDIA] of type video
 * ASSOC-LANGUAGE in [EXT-X-MEDIA]
 * CHANNELS in [EXT-X-MEDIA]
@@ -278,7 +277,6 @@ simply take on their default values (in the case where they have valid defaults)
 [EXT-X-I-FRAMES-ONLY]: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.3.6
 [EXT-X-I-FRAME-STREAM-INF]: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.4.3
 [EXT-X-SESSION-KEY]: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.4.5
-[EXT-X-INDEPENDENT-SEGMENTS]: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.5.1
 [EXT-X-START]: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.5.2
 [EXT-X-MEDIA]: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.4.1
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1480,11 +1480,17 @@ export default class SegmentLoader extends videojs.EventTarget {
       nextPart = nextSegment.parts[0];
     }
 
+    // independentSegments applies to every segment in a playlist. If independentSegments appears in a main playlist,
+    // it applies to each segment in each media playlist.
+    // https://datatracker.ietf.org/doc/html/draft-pantos-http-live-streaming-23#section-4.3.5.1
+    const hasIndependentSegments = (this.vhs_.playlists && this.vhs_.playlists.main && this.vhs_.playlists.main.independentSegments) ||
+      this.playlist_.independentSegments;
+
     // if we have no buffered data then we need to make sure
     // that the next part we append is "independent" if possible.
     // So we check if the previous part is independent, and request
     // it if it is.
-    if (!bufferedTime && nextPart && !nextPart.independent) {
+    if (!bufferedTime && nextPart && !hasIndependentSegments && !nextPart.independent) {
 
       if (next.partIndex === 0) {
         const lastSegment = segments[next.mediaIndex - 1];

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1407,6 +1407,52 @@ export const LoaderCommonFactory = ({
       assert.equal(segmentInfo2.mediaIndex, 3, 'previous segment');
     });
 
+    QUnit.test('chooses the correct next segment if independentSegments is true on the playlist', function(assert) {
+      loader.buffered_ = () => createTimeRanges();
+      const playlist = playlistWithDuration(50, {llhls: true});
+
+      playlist.independentSegments = true;
+
+      loader.hasPlayed_ = () => true;
+      loader.syncPoint_ = null;
+
+      loader.playlist(playlist);
+      loader.load();
+
+      loader.currentTime_ = () => 46;
+      // make the previous part indepenent, ensure we don't go back to that part.
+      playlist.segments[4].parts[1].independent = true;
+      const segmentInfo = loader.chooseNextRequest_();
+
+      assert.equal(segmentInfo.partIndex, 2, 'chooses part 2');
+      assert.equal(segmentInfo.mediaIndex, 4, 'same segment');
+    });
+
+    QUnit.test('chooses the correct next segment if independentSegments is true on the main playlist', function(assert) {
+      loader.buffered_ = () => createTimeRanges();
+      const playlist = playlistWithDuration(50, {llhls: true});
+
+      loader.vhs_.playlists = {
+        main: {
+          independentSegments: true
+        }
+      };
+
+      loader.hasPlayed_ = () => true;
+      loader.syncPoint_ = null;
+
+      loader.playlist(playlist);
+      loader.load();
+
+      loader.currentTime_ = () => 46;
+      // make the previous part indepenent, ensure we don't go back to that part.
+      playlist.segments[4].parts[1].independent = true;
+      const segmentInfo = loader.chooseNextRequest_();
+
+      assert.equal(segmentInfo.partIndex, 2, 'chooses part 2');
+      assert.equal(segmentInfo.mediaIndex, 4, 'same segment');
+    });
+
     QUnit.test('processing segment reachable even after playlist update removes it', function(assert) {
       const handleAppendsDone_ = loader.handleAppendsDone_.bind(loader);
       let expectedURI = '0.ts';


### PR DESCRIPTION
## Description
Adds support for [#EXT-X-INDEPENDENT-SEGMENTS](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.5.1) tags. This feature depends on [this PR](https://github.com/videojs/m3u8-parser/pull/165) in the m3u8 parser.

## Specific Changes proposed
Allow VHS to respect `independentSegments` for m3u8 playlists. This will cause VHS to no longer look backward for the next `independent` segment if `independentSegments` is true in the main playlist _or_ the media playlist. If `independentSegments` is set in the main playlist, it will apply to every segment in every media playlist.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
