### PR TITLE
chore(package): update m3u8-parser v6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6277,9 +6277,9 @@
       }
     },
     "m3u8-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-6.0.0.tgz",
-      "integrity": "sha512-s3JfDtqhxTilZQf+P1m9dZc4ohL4O/aylP1VV6g9lhKuQNfAcVUzq7d2wgJ9nZR4ibjuXaP87QzGCV6vB0kV6g==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-6.2.0.tgz",
+      "integrity": "sha512-qlC00JTxYOxawcqg+RB8jbyNwL3foY/nCY61kyWP+RCuJE9APLeqB/nSlTjb4Mg0yRmyERgjswpdQxMvkeoDrg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@videojs/vhs-utils": "4.0.0",
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
-    "m3u8-parser": "^6.0.0",
+    "m3u8-parser": "^6.2.0",
     "mpd-parser": "^1.1.1",
     "mux.js": "6.3.0",
     "video.js": "^7 || ^8"


### PR DESCRIPTION
## Description
Update m3u8 parser to add support for daterange and independent segment tags.

## Specific Changes proposed
Update m3u8 parser in the package.json

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
