### PR TITLE
refactor: add dateTimeObject and dateTimeString to Cues for backwards compatibility

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -3180,6 +3180,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
       custom: segment.custom,
+      // Since we now have programDateTime available for every segment, dateTimeObject and dateTimeString
+      // are redundant
+      // TODO: Consider removing this in future major version
+      dateTimeObject: segment.programDateTime ? new Date(segment.programDateTime) : undefined,
+      dateTimeString: segment.programDateTime ? new Date(segment.programDateTime).toISOString() : undefined,
       programDateTime: segment.programDateTime,
       bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,
       resolution: segmentInfo.playlist.attributes.RESOLUTION,

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -74,7 +74,7 @@ export const findSegmentForProgramTime = (programTime, playlist) => {
 
   let segment = playlist.segments[0];
 
-  if (dateTimeObject < segment.programDateTime) {
+  if (dateTimeObject < new Date(segment.programDateTime)) {
     // Requested time is before stream start.
     return null;
   }
@@ -82,7 +82,7 @@ export const findSegmentForProgramTime = (programTime, playlist) => {
   for (let i = 0; i < playlist.segments.length - 1; i++) {
     segment = playlist.segments[i];
 
-    const nextSegmentStart = playlist.segments[i + 1].programDateTime;
+    const nextSegmentStart = new Date(playlist.segments[i + 1].programDateTime);
 
     if (dateTimeObject < nextSegmentStart) {
       break;
@@ -102,7 +102,7 @@ export const findSegmentForProgramTime = (programTime, playlist) => {
     return null;
   }
 
-  if (dateTimeObject > lastSegmentStart) {
+  if (dateTimeObject > new Date(lastSegmentStart)) {
     segment = lastSegment;
   }
 


### PR DESCRIPTION
Adds `dateTimeObject` and `dateTimeString` back to segment metadata cues for backwards compatibility 