### PR TITLE
fix(live): only reset playlist loader for LLHLS

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1051,7 +1051,8 @@ export default class SegmentLoader extends videojs.EventTarget {
         // We only want to reset the loader here for LLHLS playback, as resetLoader sets fetchAtBuffer_
         // to false, resulting in fetching segments at currentTime and causing repeated
         // same-segment requests on playlist change. This erroneously drives up the playback watcher
-        // stalled segment count, as re-requesting browser cached segments will not increase the buffer.
+        // stalled segment count, as re-requesting segments at the currentTime or browser cached segments
+        // will not change the buffer.
         // Reference for LLHLS fixes: https://github.com/videojs/http-streaming/pull/1201
         const isLLHLS = !newPlaylist.endList && typeof newPlaylist.partTargetDuration === 'number';
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -865,7 +865,49 @@ export const LoaderCommonFactory = ({
       });
     });
 
-    QUnit.test('live rendition switch uses resetLoader', function(assert) {
+    QUnit.test('live LLHLS rendition switch uses resetLoader', function(assert) {
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+
+        loader.playlist(playlistWithDuration(50, {
+          mediaSequence: 0,
+          endList: false
+        }));
+
+        loader.load();
+        loader.mediaIndex = 0;
+        let resyncCalled = false;
+        let resetCalled = false;
+        const origReset = loader.resetLoader;
+        const origResync = loader.resyncLoader;
+
+        loader.resetLoader = function() {
+          resetCalled = true;
+          return origReset.call(loader);
+        };
+
+        loader.resyncLoader = function() {
+          resyncCalled = true;
+          return origResync.call(loader);
+        };
+
+        const newPlaylist = playlistWithDuration(50, {
+          mediaSequence: 0,
+          endList: false
+        });
+
+        newPlaylist.uri = 'playlist2.m3u8';
+        newPlaylist.partTargetDuration = 1;
+
+        loader.playlist(newPlaylist);
+
+        assert.true(resetCalled, 'reset was called');
+        assert.true(resyncCalled, 'resync was called');
+
+        return Promise.resolve();
+      });
+    });
+
+    QUnit.test('live rendition switch uses resyncLoader', function(assert) {
       return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
 
         loader.playlist(playlistWithDuration(50, {
@@ -899,8 +941,8 @@ export const LoaderCommonFactory = ({
 
         loader.playlist(newPlaylist);
 
-        assert.true(resetCalled, 'reset was called');
         assert.true(resyncCalled, 'resync was called');
+        assert.false(resetCalled, 'reset was not called');
 
         return Promise.resolve();
       });


### PR DESCRIPTION
## Description
After a LOT of debugging with playlist changes against a linear DASH stream, I discovered we're calling `resetLoader` when setting a new playlist (during a rendition switch), which sets `fetchAtBuffer_` to false then calls `resyncLoader`. This sets the `mediaIndex` to null, which eventually on the next `chooseNextRequest_` call (which as implied, chooses the next segment to request) forces us into the else logic. Because `fetchAtBuffer_` is false, we begin requesting segments from the `currentTime` rather than the end of the buffer. This causes the playback watcher to assume a segment download has stalled, because when we request segments at the `currentTime` we're either requesting cached segments or overwriting segments that were already buffered, which results in the buffer not changing and an increment of the stalled segment counter.

## Specific Changes proposed
Since this logic was originally implemented as an fix for LLHLS playback (see: https://github.com/videojs/http-streaming/pull/1201) we can isolate it to LLHLS streams by checking for a `partTargetDuration`  on the playlist, which is required for LLHLS streams, see:  https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.3.7. 
This greatly reduces the re-requesting of already buffered and cached segment requests during live playback and in turn the stability of these streams as the buffer isn't being artificially starved during a rendition switch.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
