### PR TITLE
fix(live): cue end time not finite

### DIFF
--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -234,7 +234,8 @@ export const addMetadata = ({
   // Map each cue group's endTime to the next group's startTime
   sortedStartTimes.forEach((startTime, idx) => {
     const cueGroup = cuesGroupedByStartTime[startTime];
-    const nextTime = Number(sortedStartTimes[idx + 1]) || videoDuration;
+    const finiteDuration = isFinite(videoDuration) ? videoDuration : 0;
+    const nextTime = Number(sortedStartTimes[idx + 1]) || finiteDuration;
 
     // Map each cue's endTime the next group's startTime
     cueGroup.forEach((cue) => {


### PR DESCRIPTION
## Description
When creating metadata cues, the last cue uses the videoDuration as the end time, in live playback this is `Infinity` and throws an error.

## Specific Changes proposed
Add an `isFinite` check to the duration, if it's not finite we use 0 instead.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
