### PR TITLE
fix: restore dateTimeObject and dateTimeString usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6299,9 +6299,9 @@
       }
     },
     "m3u8-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.0.0.tgz",
-      "integrity": "sha512-DiJ9XBgCzEWBZBccRaiMXHY6hJvaS+Znm+yacnyhTvNVnXeFl57QqLHJnXLi7QzKxOZzHzHf5sBvLrY2U2IFsg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
+      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@videojs/vhs-utils": "4.0.0",
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
-    "m3u8-parser": "^7.0.0",
+    "m3u8-parser": "^7.1.0",
     "mpd-parser": "^1.1.1",
     "mux.js": "7.0.0",
     "video.js": "^7 || ^8"

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -421,7 +421,7 @@ export default class PlaylistLoader extends EventTarget {
     this.dateRangesStorage_.setPendingDateRanges(mediaPlaylist.dateRanges);
     const availableDateRanges = this.dateRangesStorage_.getDateRangesToProcess();
 
-    if (!availableDateRanges.length) {
+    if (!availableDateRanges.length || !this.addDateRangesToTextTrack_) {
       return;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -3182,11 +3182,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
       custom: segment.custom,
-      // Since we now have programDateTime available for every segment, dateTimeObject and dateTimeString
-      // are redundant
-      // TODO: Consider removing this in future major version
-      dateTimeObject: segment.programDateTime ? new Date(segment.programDateTime) : undefined,
-      dateTimeString: segment.programDateTime ? new Date(segment.programDateTime).toISOString() : undefined,
+      dateTimeObject: segment.dateTimeObject,
+      dateTimeString: segment.dateTimeString,
       programDateTime: segment.programDateTime,
       bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,
       resolution: segmentInfo.playlist.attributes.RESOLUTION,

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -53,11 +53,11 @@ export const syncPointStrategies = [
         const datetimeMapping =
           syncController.timelineToDatetimeMappings[segment.timeline];
 
-        if (!datetimeMapping || !segment.programDateTime) {
+        if (!datetimeMapping || !segment.dateTimeObject) {
           continue;
         }
 
-        const segmentTime = segment.programDateTime / 1000;
+        const segmentTime = segment.dateTimeObject.getTime() / 1000;
         let start = segmentTime + datetimeMapping;
 
         // take part duration into account.
@@ -408,9 +408,9 @@ export default class SyncController extends videojs.EventTarget {
 
     if (playlist.segments &&
         playlist.segments.length &&
-        playlist.segments[0].programDateTime) {
+        playlist.segments[0].dateTimeObject) {
       const firstSegment = playlist.segments[0];
-      const playlistTimestamp = firstSegment.programDateTime / 1000;
+      const playlistTimestamp = firstSegment.dateTimeObject.getTime() / 1000;
 
       this.timelineToDatetimeMappings[firstSegment.timeline] = -playlistTimestamp;
     }
@@ -449,10 +449,10 @@ export default class SyncController extends videojs.EventTarget {
       }
     }
 
-    const dateTime = segment.programDateTime;
+    const dateTime = segment.dateTimeObject;
 
     if (segment.discontinuity && shouldSaveTimelineMapping && dateTime) {
-      this.timelineToDatetimeMappings[segment.timeline] = -(dateTime / 1000);
+      this.timelineToDatetimeMappings[segment.timeline] = -(dateTime.getTime() / 1000);
     }
   }
 

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -26,7 +26,7 @@ const SEGMENT_END_FUDGE_PERCENT = 0.25;
  * @return {Date} program time
  */
 export const playerTimeToProgramTime = (playerTime, segment) => {
-  if (!segment.programDateTime) {
+  if (!segment.dateTimeObject) {
     // Can't convert without an "anchor point" for the program time (i.e., a time that can
     // be used to map the start of a segment with a real world time).
     return null;
@@ -39,7 +39,7 @@ export const playerTimeToProgramTime = (playerTime, segment) => {
   const startOfSegment = transmuxedStart + transmuxerPrependedSeconds;
   const offsetFromSegmentStart = playerTime - startOfSegment;
 
-  return new Date(segment.programDateTime + offsetFromSegmentStart * 1000);
+  return new Date(segment.dateTimeObject.getTime() + offsetFromSegmentStart * 1000);
 };
 
 export const originalSegmentVideoDuration = (videoTimingInfo) => {
@@ -74,7 +74,7 @@ export const findSegmentForProgramTime = (programTime, playlist) => {
 
   let segment = playlist.segments[0];
 
-  if (dateTimeObject < new Date(segment.programDateTime)) {
+  if (dateTimeObject < new Date(segment.dateTimeObject)) {
     // Requested time is before stream start.
     return null;
   }
@@ -82,7 +82,7 @@ export const findSegmentForProgramTime = (programTime, playlist) => {
   for (let i = 0; i < playlist.segments.length - 1; i++) {
     segment = playlist.segments[i];
 
-    const nextSegmentStart = new Date(playlist.segments[i + 1].programDateTime);
+    const nextSegmentStart = new Date(playlist.segments[i + 1].dateTimeObject);
 
     if (dateTimeObject < nextSegmentStart) {
       break;
@@ -90,12 +90,12 @@ export const findSegmentForProgramTime = (programTime, playlist) => {
   }
 
   const lastSegment = playlist.segments[playlist.segments.length - 1];
-  const lastSegmentStart = lastSegment.programDateTime;
+  const lastSegmentStart = lastSegment.dateTimeObject;
   const lastSegmentDuration = lastSegment.videoTimingInfo ?
     originalSegmentVideoDuration(lastSegment.videoTimingInfo) :
     lastSegment.duration + lastSegment.duration * SEGMENT_END_FUDGE_PERCENT;
   const lastSegmentEnd =
-    new Date(lastSegmentStart + lastSegmentDuration * 1000);
+    new Date(lastSegmentStart.getTime() + lastSegmentDuration * 1000);
 
   if (dateTimeObject > lastSegmentEnd) {
     // Beyond the end of the stream, or our best guess of the end of the stream.
@@ -230,7 +230,7 @@ export const verifyProgramDateTimeTags = (playlist) => {
   for (let i = 0; i < playlist.segments.length; i++) {
     const segment = playlist.segments[i];
 
-    if (!segment.programDateTime) {
+    if (!segment.dateTimeObject) {
       return false;
     }
   }
@@ -355,7 +355,7 @@ export const seekToProgramTime = ({
 
   const segment = matchedSegment.segment;
   const mediaOffset = getOffsetFromTimestamp(
-    segment.programDateTime,
+    segment.dateTimeObject,
     programTime
   );
 

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -1053,7 +1053,7 @@ QUnit.module('Playlist Loader', function(hooks) {
     const segment = loader.main.playlists[0].segments[0];
 
     assert.strictEqual(segment.custom.test, '#PARSER:parsed', 'parsed custom tag');
-    assert.ok(segment.programDateTime, 'converted and parsed custom time');
+    assert.ok(segment.dateTimeObject, 'converted and parsed custom time');
 
     delete this.fakeVhs.options_;
   });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -4560,26 +4560,26 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       const segmentDurationMs = targetDuration * 1000;
 
-      const playlist1Start = new Date('2021-01-01T00:00:00.000-05:00').getTime();
+      const playlist1Start = new Date('2021-01-01T00:00:00.000-05:00');
 
-      playlist1.segments[0].programDateTime = playlist1Start;
-      playlist1.segments[1].programDateTime = new Date(playlist1Start + segmentDurationMs).getTime();
+      playlist1.segments[0].dateTimeObject = playlist1Start;
+      playlist1.segments[1].dateTimeObject = new Date(playlist1Start.getTime() + segmentDurationMs);
       // jump of 0.5 seconds after disco (0.5 seconds of missing real world time, e.g.,
       // an encoder went down briefly), should have a PDT mapping difference of -3.5
       // seconds from first mapping
-      playlist1.segments[2].programDateTime = new Date(playlist1.segments[1].programDateTime + segmentDurationMs + 500).getTime();
-      playlist1.segments[3].programDateTime = new Date(playlist1.segments[2].programDateTime + segmentDurationMs).getTime();
+      playlist1.segments[2].dateTimeObject = new Date(playlist1.segments[1].dateTimeObject.getTime() + segmentDurationMs + 500);
+      playlist1.segments[3].dateTimeObject = new Date(playlist1.segments[2].dateTimeObject.getTime() + segmentDurationMs);
 
       // offset by 0.25 seconds from playlist1
       const playlist2Start = new Date('2021-01-01T00:00:00.250-05:00');
 
-      playlist2.segments[0].programDateTime = playlist2Start.getTime();
-      playlist2.segments[1].programDateTime = new Date(playlist2Start + segmentDurationMs).getTime();
+      playlist2.segments[0].dateTimeObject = playlist2Start;
+      playlist2.segments[1].dateTimeObject = new Date(playlist2Start.getTime() + segmentDurationMs);
       // jump of 0.5 seconds after disco (0.5 seconds of missing real world time, e.g.,
       // an encoder went down briefly), should have a PDT mapping difference of -3.5
       // seconds from first mapping
-      playlist2.segments[2].programDateTime = new Date(playlist2.segments[1].programDateTime + segmentDurationMs + 500).getTime();
-      playlist2.segments[3].programDateTime = new Date(playlist2.segments[2].programDateTime + segmentDurationMs).getTime();
+      playlist2.segments[2].dateTimeObject = new Date(playlist2.segments[1].dateTimeObject.getTime() + segmentDurationMs + 500);
+      playlist2.segments[3].dateTimeObject = new Date(playlist2.segments[2].dateTimeObject.getTime() + segmentDurationMs);
 
       const {
         mediaSource_: mediaSource,
@@ -4680,11 +4680,11 @@ QUnit.module('SegmentLoader', function(hooks) {
       const segment3Start = new Date(segment2Start.getTime() + segmentDurationMs + 500);
 
       [playlist1, playlist2].forEach((playlist) => {
-        playlist.programDateTime = segment0Start;
-        playlist.segments[0].programDateTime = segment0Start;
-        playlist.segments[1].programDateTime = segment1Start;
-        playlist.segments[2].programDateTime = segment2Start;
-        playlist.segments[3].programDateTime = segment3Start;
+        playlist.dateTimeObject = segment0Start;
+        playlist.segments[0].dateTimeObject = segment0Start;
+        playlist.segments[1].dateTimeObject = segment1Start;
+        playlist.segments[2].dateTimeObject = segment2Start;
+        playlist.segments[3].dateTimeObject = segment3Start;
       });
 
       const {

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -45,7 +45,7 @@ QUnit.test('returns correct sync point for ProgramDateTime strategy', function(a
 
   assert.equal(syncPoint, null, 'no syncpoint when no date time to display time mapping');
 
-  playlist.segments[0].programDateTime = datetime.getTime();
+  playlist.segments[0].dateTimeObject = datetime;
 
   this.syncController.setDateTimeMappingForStart(playlist);
 
@@ -55,7 +55,7 @@ QUnit.test('returns correct sync point for ProgramDateTime strategy', function(a
 
   assert.equal(syncPoint, null, 'no syncpoint when datetimeObject not set on playlist');
 
-  newPlaylist.segments[0].programDateTime = new Date(2012, 11, 12, 12, 12, 22).getTime();
+  newPlaylist.segments[0].dateTimeObject = new Date(2012, 11, 12, 12, 12, 22);
 
   syncPoint = strategy.run(this.syncController, newPlaylist, duration, timeline);
 
@@ -78,7 +78,7 @@ QUnit.test('ProgramDateTime strategy finds nearest segment for sync', function(a
   assert.equal(syncPoint, null, 'no syncpoint when no date time to display time mapping');
 
   playlist.segments.forEach((segment, index) => {
-    segment.programDateTime = new Date(2012, 11, 12, 12, 12, 12 + (index * 10)).getTime();
+    segment.dateTimeObject = new Date(2012, 11, 12, 12, 12, 12 + (index * 10));
   });
 
   this.syncController.setDateTimeMappingForStart(playlist);
@@ -90,7 +90,7 @@ QUnit.test('ProgramDateTime strategy finds nearest segment for sync', function(a
   assert.equal(syncPoint, null, 'no syncpoint when datetimeObject not set on playlist');
 
   newPlaylist.segments.forEach((segment, index) => {
-    segment.programDateTime = new Date(2012, 11, 12, 12, 12, 22 + (index * 10)).getTime();
+    segment.dateTimeObject = new Date(2012, 11, 12, 12, 12, 22 + (index * 10));
   });
 
   syncPoint = strategy.run(this.syncController, newPlaylist, duration, timeline, 170);
@@ -115,7 +115,7 @@ QUnit.test(
   function(assert) {
     const playlist = playlistWithDuration(40);
 
-    playlist.segments[1].programDateTime = new Date(2012, 11, 12, 12, 12, 12).getTime();
+    playlist.segments[1].dateTimeObject = new Date(2012, 11, 12, 12, 12, 12);
 
     this.syncController.setDateTimeMappingForStart(playlist);
 
@@ -125,7 +125,7 @@ QUnit.test(
       'did not set datetime mapping'
     );
 
-    playlist.segments[0].programDateTime = new Date(2012, 11, 12, 12, 12, 2).getTime();
+    playlist.segments[0].dateTimeObject = new Date(2012, 11, 12, 12, 12, 2);
 
     this.syncController.setDateTimeMappingForStart(playlist);
 
@@ -140,12 +140,12 @@ QUnit.test(
 QUnit.test('uses separate date time to display time mapping for each timeline', function(assert) {
   const playlist = playlistWithDuration(40, { discontinuityStarts: [1, 3] });
 
-  playlist.segments[0].programDateTime = new Date(2020, 1, 1, 1, 1, 1).getTime();
+  playlist.segments[0].dateTimeObject = new Date(2020, 1, 1, 1, 1, 1);
   // 20 seconds later (10 more than default)
-  playlist.segments[1].programDateTime = new Date(2020, 1, 1, 1, 1, 21).getTime();
-  playlist.segments[2].programDateTime = new Date(2020, 1, 1, 1, 1, 31).getTime();
+  playlist.segments[1].dateTimeObject = new Date(2020, 1, 1, 1, 1, 21);
+  playlist.segments[2].dateTimeObject = new Date(2020, 1, 1, 1, 1, 31);
   // 30 seconds later (20 more than default)
-  playlist.segments[3].programDateTime = new Date(2020, 1, 1, 1, 2, 1).getTime();
+  playlist.segments[3].dateTimeObject = new Date(2020, 1, 1, 1, 2, 1);
 
   // after this call, the initial playlist mapping will be provided
   this.syncController.setDateTimeMappingForStart(playlist);
@@ -165,7 +165,7 @@ QUnit.test('uses separate date time to display time mapping for each timeline', 
   assert.deepEqual(
     this.syncController.timelineToDatetimeMappings,
     {
-      0: -(playlist.segments[0].programDateTime / 1000)
+      0: -(playlist.segments[0].dateTimeObject.getTime() / 1000)
     },
     'has correct mapping for timeline 0'
   );
@@ -183,8 +183,8 @@ QUnit.test('uses separate date time to display time mapping for each timeline', 
   assert.deepEqual(
     this.syncController.timelineToDatetimeMappings,
     {
-      0: -(playlist.segments[0].programDateTime / 1000),
-      1: -(playlist.segments[1].programDateTime / 1000)
+      0: -(playlist.segments[0].dateTimeObject.getTime() / 1000),
+      1: -(playlist.segments[1].dateTimeObject.getTime() / 1000)
     },
     'has correct mapping for timelines 0 and 1'
   );
@@ -202,8 +202,8 @@ QUnit.test('uses separate date time to display time mapping for each timeline', 
   assert.deepEqual(
     this.syncController.timelineToDatetimeMappings,
     {
-      0: -(playlist.segments[0].programDateTime / 1000),
-      1: -(playlist.segments[1].programDateTime / 1000)
+      0: -(playlist.segments[0].dateTimeObject.getTime() / 1000),
+      1: -(playlist.segments[1].dateTimeObject.getTime() / 1000)
     },
     'does not add a new timeline mapping when no disco'
   );
@@ -221,9 +221,9 @@ QUnit.test('uses separate date time to display time mapping for each timeline', 
   assert.deepEqual(
     this.syncController.timelineToDatetimeMappings,
     {
-      0: -(playlist.segments[0].programDateTime / 1000),
-      1: -(playlist.segments[1].programDateTime / 1000),
-      2: -(playlist.segments[3].programDateTime / 1000)
+      0: -(playlist.segments[0].dateTimeObject.getTime() / 1000),
+      1: -(playlist.segments[1].dateTimeObject.getTime() / 1000),
+      2: -(playlist.segments[3].dateTimeObject.getTime() / 1000)
     },
     'has correct mappings for timelines 0, 1, and 2'
   );
@@ -241,7 +241,7 @@ QUnit.test('ProgramDateTime strategy finds nearest llhls sync point', function(a
   assert.equal(syncPoint, null, 'no syncpoint when no date time to display time mapping');
 
   playlist.segments.forEach((segment, index) => {
-    segment.programDateTime = new Date(2012, 11, 12, 12, 12, 12 + (index * 10)).getTime();
+    segment.dateTimeObject = new Date(2012, 11, 12, 12, 12, 12 + (index * 10));
   });
 
   this.syncController.setDateTimeMappingForStart(playlist);

--- a/test/util/time.test.js
+++ b/test/util/time.test.js
@@ -24,7 +24,7 @@ QUnit.test(
       segments: [{
         start: 0,
         end: 1,
-        programDateTime: new Date().getTime()
+        dateTimeObject: new Date()
       }]
     };
     const badPlaylist = {
@@ -32,7 +32,7 @@ QUnit.test(
         {
           start: 0,
           end: 1,
-          programDateTime: new Date().getTime()
+          dateTimeObject: new Date()
         },
         {
           start: 1,
@@ -41,7 +41,7 @@ QUnit.test(
         {
           start: 2,
           end: 3,
-          programDateTime: new Date().getTime()
+          dateTimeObject: new Date()
         }
       ]
     };
@@ -280,7 +280,7 @@ QUnit.test(
             transmuxedPresentationEnd: 1
           },
           duration: 1,
-          programDateTime: new Date('2018-11-10T19:39:57.158Z').getTime()
+          dateTimeObject: new Date('2018-11-10T19:39:57.158Z')
         }],
         targetDuration: 1
       }),
@@ -295,7 +295,7 @@ QUnit.test(
   function(assert) {
     const segment = {
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
     };
 
     assert.deepEqual(
@@ -317,11 +317,11 @@ QUnit.test(
   function(assert) {
     const segment1 = {
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
     };
     const segment2 = {
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:58.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:58.158Z')
     };
 
     assert.deepEqual(
@@ -348,7 +348,7 @@ QUnit.test(
         transmuxedPresentationEnd: 1
       },
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
     };
 
     assert.deepEqual(
@@ -375,7 +375,7 @@ QUnit.test('findSegmentForProgramTime returns accurate last segment', function(a
         transmuxedPresentationEnd: 1
       },
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
     }, {
       videoTimingInfo: {
         transmuxerPrependedSeconds: 0,
@@ -383,7 +383,7 @@ QUnit.test('findSegmentForProgramTime returns accurate last segment', function(a
         transmuxedPresentationEnd: 2
       },
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:58.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:58.158Z')
     }]
   };
 
@@ -410,7 +410,7 @@ QUnit.test(
           transmuxedPresentationEnd: 1
         },
         duration: 1,
-        programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+        dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
       }, {
         videoTimingInfo: {
           transmuxerPrependedSeconds: 0,
@@ -418,7 +418,7 @@ QUnit.test(
           transmuxedPresentationEnd: 2
         },
         duration: 1,
-        programDateTime: new Date('2018-11-10T19:38:58.158Z').getTime()
+        dateTimeObject: new Date('2018-11-10T19:38:58.158Z')
       }]
     };
 
@@ -440,17 +440,17 @@ QUnit.test('findSegmentForProgramTime returns estimated last segment', function(
         transmuxedPresentationEnd: 1
       },
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
     }, {
       duration: 1,
-      programDateTime: new Date('2018-11-10T19:38:58.158Z').getTime()
+      dateTimeObject: new Date('2018-11-10T19:38:58.158Z')
     }]
   };
 
   // 25% of last segment duration + last segment duration on top of last segment start
   // to test allowed fudge
   const programTime =
-    new Date(playlist.segments[1].programDateTime + 1.25 * 1000);
+    new Date(playlist.segments[1].dateTimeObject.getTime() + 1.25 * 1000);
 
   assert.deepEqual(
     findSegmentForProgramTime(programTime.toISOString(), playlist),
@@ -476,16 +476,16 @@ QUnit.test(
           transmuxedPresentationEnd: 1
         },
         duration: 1,
-        programDateTime: new Date('2018-11-10T19:38:57.158Z').getTime()
+        dateTimeObject: new Date('2018-11-10T19:38:57.158Z')
       }, {
         duration: 1,
-        programDateTime: new Date('2018-11-10T19:38:58.158Z').getTime()
+        dateTimeObject: new Date('2018-11-10T19:38:58.158Z')
       }]
     };
 
     // just over allowed fudge of 25%
     const programTime =
-    new Date(playlist.segments[1].programDateTime + 1.26 * 1000);
+    new Date(playlist.segments[1].dateTimeObject.getTime() + 1.26 * 1000);
 
     assert.equal(
       findSegmentForProgramTime(programTime.toISOString(), playlist),
@@ -549,11 +549,11 @@ QUnit.test(
 ' program date time',
   function(assert) {
   // UTC: Sun, 11 Nov 2018 00:00:00 GMT
-    const programDateTime = new Date(1541894400000).getTime();
+    const dateTimeObject = new Date(1541894400000);
 
     assert.deepEqual(
       playerTimeToProgramTime(7, {
-        programDateTime,
+        dateTimeObject,
         videoTimingInfo: {
           transmuxedPresentationEnd: 11,
           transmuxedPresentationStart: 4,
@@ -561,7 +561,7 @@ QUnit.test(
         }
       }).toISOString(),
       // 7 seconds into the stream, segment starts at 4 seconds
-      (new Date(programDateTime + 3 * 1000)).toISOString(),
+      (new Date(dateTimeObject.getTime() + 3 * 1000)).toISOString(),
       'returns stream time based on segment program date time'
     );
   }
@@ -569,11 +569,11 @@ QUnit.test(
 
 QUnit.test('playerTimeToProgramTime accounts for prepended content', function(assert) {
   // UTC: Sun, 11 Nov 2018 00:00:00 GMT
-  const programDateTime = new Date(1541894400000).getTime();
+  const dateTimeObject = new Date(1541894400000);
 
   assert.deepEqual(
     playerTimeToProgramTime(7, {
-      programDateTime,
+      dateTimeObject,
       videoTimingInfo: {
         transmuxedPresentationEnd: 11,
         transmuxedPresentationStart: 4,
@@ -582,7 +582,7 @@ QUnit.test('playerTimeToProgramTime accounts for prepended content', function(as
     }).toISOString(),
     // 7 seconds into the stream, segment starts at 4 seconds, but after accounting for
     // prepended content of 2 seconds, the original segment starts at 6 seconds
-    (new Date(programDateTime + 1 * 1000)).toISOString(),
+    (new Date(dateTimeObject.getTime() + 1 * 1000)).toISOString(),
     'returns stream time based on segment program date time'
   );
 });
@@ -609,7 +609,8 @@ QUnit.module('Time: getProgramTime', {
       segments: [{
         duration: 4,
         // UTC: Sun, 11 Nov 2018 00:00:00 GMT
-        programDateTime: new Date(1541894400000).getTime(),
+        dateTimeObject: new Date(1541894400000),
+        dateTimeString: '2018-11-11T00:00:00.000Z',
         start: 5,
         videoTimingInfo: {
           transmuxerPrependedSeconds: 0,
@@ -695,7 +696,7 @@ QUnit.test(
 
         // offset into start of stream by time passed in
         const expectedDateTime =
-        new Date(this.playlist.segments[0].programDateTime + 6 * 1000);
+        new Date(this.playlist.segments[0].dateTimeObject.getTime() + 6 * 1000);
 
         assert.equal(
           programTime.programDateTime,
@@ -718,12 +719,14 @@ QUnit.test(
         {
           duration: 1,
           // UTC: Sun, 11 Nov 2018 00:00:00 GMT
-          programDateTime: new Date(1541894400000).getTime()
+          dateTimeObject: new Date(1541894400000),
+          dateTimeString: '2018-11-11T00:00:00.000Z'
         },
         {
           duration: 2,
           // UTC: Sun, 11 Nov 2018 00:00:00 GMT
-          programDateTime: new Date(1541894400000).getTime()
+          dateTimeObject: new Date(1541894400000),
+          dateTimeString: '2018-11-11T00:00:00.000Z'
         }
       ]
     };
@@ -799,7 +802,7 @@ QUnit.test('returns programDateTime parsed from media segment tags', function(as
       assert.equal(err, null, 'no error');
       assert.equal(
         programTime.programDateTime,
-        new Date(playlist.segments[0].programDateTime).toISOString(),
+        playlist.segments[0].dateTimeString,
         'uses programDateTime found in media segments'
       );
       done();
@@ -990,7 +993,8 @@ QUnit.test('returns error if time does not exist in live stream', function(asser
     programTime: '2018-10-12T22:33:52.037+00:00',
     playlist: {
       segments: [{
-        programDateTime: new Date('2018-10-12T22:33:49.037+00:00').getTime(),
+        dateTimeString: '2018-10-12T22:33:49.037+00:00',
+        dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
         duration: 1,
         start: 0
       }],
@@ -1037,7 +1041,8 @@ QUnit.test('vod: seeks and returns player time seeked to if buffered', function(
     playlist: {
       segments: [
         {
-          programDateTime: new Date('2018-10-12T22:33:49.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:49.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
           duration: 1,
           start: 0,
           videoTimingInfo: {
@@ -1046,7 +1051,8 @@ QUnit.test('vod: seeks and returns player time seeked to if buffered', function(
             transmuxedPresentationEnd: 1
           }
         }, {
-          programDateTime: new Date('2018-10-12T22:33:50.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:50.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 1,
           start: 1,
           videoTimingInfo: {
@@ -1101,7 +1107,8 @@ QUnit.test('vod: does not account for prepended content duration', function(asse
     playlist: {
       segments: [
         {
-          programDateTime: new Date('2018-10-12T22:33:48.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:48.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:48.037+00:00'),
           duration: 2,
           start: 0,
           videoTimingInfo: {
@@ -1110,7 +1117,8 @@ QUnit.test('vod: does not account for prepended content duration', function(asse
             transmuxedPresentationEnd: 2
           }
         }, {
-          programDateTime: new Date('2018-10-12T22:33:50.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:50.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 2,
           start: 2,
           videoTimingInfo: {
@@ -1165,7 +1173,8 @@ QUnit.test('live: seeks and returns player time seeked to if buffered', function
     playlist: {
       segments: [
         {
-          programDateTime: new Date('2018-10-12T22:33:49.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:49.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
           duration: 1,
           start: 0,
           videoTimingInfo: {
@@ -1174,7 +1183,8 @@ QUnit.test('live: seeks and returns player time seeked to if buffered', function
             transmuxedPresentationEnd: 1
           }
         }, {
-          programDateTime: new Date('2018-10-12T22:33:50.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:50.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 1,
           start: 1,
           videoTimingInfo: {
@@ -1228,7 +1238,8 @@ QUnit.test('setting pauseAfterSeek to false seeks without pausing', function(ass
     playlist: {
       segments: [
         {
-          programDateTime: new Date('2018-10-12T22:33:49.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:49.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:49.037+00:00'),
           duration: 1,
           start: 0,
           videoTimingInfo: {
@@ -1237,7 +1248,8 @@ QUnit.test('setting pauseAfterSeek to false seeks without pausing', function(ass
             transmuxedPresentationEnd: 1
           }
         }, {
-          programDateTime: new Date('2018-10-12T22:33:50.037+00:00').getTime(),
+          dateTimeString: '2018-10-12T22:33:50.037+00:00',
+          dateTimeObject: new Date('2018-10-12T22:33:50.037+00:00'),
           duration: 1,
           start: 1,
           videoTimingInfo: {


### PR DESCRIPTION
This PR shouldn't be merged before 

- [x] the corresponding [m3u8-parser PR](https://github.com/videojs/m3u8-parser/pull/174) is merged and released
- [ ] m3u8-parser is updated to the latest version containing the above PR
- [ ] tests pass 

## Description
Restores dateTimeObject and dateTimeString segment properties that were previously removed and refactored in these two PRs

- https://github.com/videojs/http-streaming/pull/1407
- https://github.com/videojs/http-streaming/pull/1409
