### PR TITLE
fix: reduce playlist exclusion defaults

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -28,7 +28,7 @@ import logger from './util/logger';
 import {merge, createTimeRanges} from './util/vjs-compat';
 import { addMetadata, createMetadataTrackIfNotExists, addDateRangeMetadata } from './util/text-tracks';
 
-const ABORT_EARLY_EXCLUSION_SECONDS = 60 * 2;
+const ABORT_EARLY_EXCLUSION_SECONDS = 10;
 
 let Vhs;
 

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -697,7 +697,7 @@ class VhsHandler extends Component {
     this.options_.bufferBasedABR = this.options_.bufferBasedABR || false;
 
     if (typeof this.options_.playlistExclusionDuration !== 'number') {
-      this.options_.playlistExclusionDuration = 5 * 60;
+      this.options_.playlistExclusionDuration = 10;
     }
 
     if (typeof this.options_.bandwidth !== 'number') {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -697,7 +697,7 @@ class VhsHandler extends Component {
     this.options_.bufferBasedABR = this.options_.bufferBasedABR || false;
 
     if (typeof this.options_.playlistExclusionDuration !== 'number') {
-      this.options_.playlistExclusionDuration = 10;
+      this.options_.playlistExclusionDuration = 60;
     }
 
     if (typeof this.options_.bandwidth !== 'number') {


### PR DESCRIPTION
## Description
The default playlist exclusion duration seemed arbitrarily long, especially for live playback. Lets reduce the default and the `earlyAbortWhenNeeded_` exclusion to seconds instead of minutes to allow for more live resiliency.

## Specific Changes proposed
Reduce the default `playlistExclusionDuration` value from 5 minutes to 10 seconds. Also reduce the `ABORT_EARLY_EXCLUSION_SECONDS` from 2 minutes to 10 seconds.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
