### PR TITLE
fix: fastQualityChange refactor

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -949,7 +949,7 @@ export class PlaylistController extends videojs.EventTarget {
     // Set the replace segments flag to the buffered end, this forces fetchAtBuffer
     // on the main loader to remain, false after the resetLoader call, until we have
     // replaced all content buffered ahead of the currentTime.
-    this.mainSegmentLoader_.replaceSegmentsUntil_ = bufferedEnd;
+    this.mainSegmentLoader_.replaceSegmentsUntil = bufferedEnd;
     this.mainSegmentLoader_.resetLoaderProperties();
     this.mainSegmentLoader_.resetLoader();
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -933,7 +933,10 @@ export class PlaylistController extends videojs.EventTarget {
 
     this.switchMedia_(media, 'fast-quality');
 
-    // Reset main segment loader properties and next segment position information
+    // Reset main segment loader properties and next segment position information.
+    // Don't need to reset audio as it is reset when media changes.
+    // We resetLoaderProperties separately here as we want to fetch init segments if
+    // necessary and ensure we're not in an ended state when we switch playlists.
     this.mainSegmentLoader_.resetLoaderProperties();
     this.mainSegmentLoader_.resetLoader();
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -930,13 +930,26 @@ export class PlaylistController extends videojs.EventTarget {
       this.logger_('skipping fastQualityChange because new media is same as old');
       return;
     }
-
     this.switchMedia_(media, 'fast-quality');
-
     // Reset main segment loader properties and next segment position information.
     // Don't need to reset audio as it is reset when media changes.
     // We resetLoaderProperties separately here as we want to fetch init segments if
     // necessary and ensure we're not in an ended state when we switch playlists.
+    this.resetMainLoaderReplaceSegments();
+  }
+
+  /**
+   * Sets the replaceUntil flag on the main segment soader to the buffered end
+   * and resets the main segment loaders properties.
+   */
+  resetMainLoaderReplaceSegments() {
+    const buffered = this.tech_.buffered();
+    const bufferedEnd = buffered.end(buffered.length - 1);
+
+    // Set the replace segments flag to the buffered end, this forces fetchAtBuffer
+    // on the main loader to remain, false after the resetLoader call, until we have
+    // replaced all content buffered ahead of the currentTime.
+    this.mainSegmentLoader_.replaceSegmentsUntil_ = bufferedEnd;
     this.mainSegmentLoader_.resetLoaderProperties();
     this.mainSegmentLoader_.resetLoader();
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -919,9 +919,9 @@ export class PlaylistController extends videojs.EventTarget {
 
   /**
    * Re-tune playback quality level for the current player
-   * conditions. This method will perform destructive actions like removing
-   * already buffered content in order to readjust the currently active
-   * playlist quickly. This is good for manual quality changes
+   * conditions. This will reset the main segment loader
+   * and the next segment position to the currentTime.
+   * This is good for manual quality changes.
    *
    * @private
    */
@@ -933,17 +933,9 @@ export class PlaylistController extends videojs.EventTarget {
 
     this.switchMedia_(media, 'fast-quality');
 
-    // Delete all buffered data to allow an immediate quality switch, then seek to give
-    // the browser a kick to remove any cached frames from the previous rendtion (.04 seconds
-    // ahead was roughly the minimum that will accomplish this across a variety of content
-    // in IE and Edge, but seeking in place is sufficient on all other browsers)
-    // Edge/IE bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14600375/
-    // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=651904
-    this.mainSegmentLoader_.resetEverything(() => {
-      this.tech_.setCurrentTime(this.tech_.currentTime());
-    });
-
-    // don't need to reset audio as it is reset when media changes
+    // Reset main segment loader properties and next segment position information
+    this.mainSegmentLoader_.resetLoaderProperties();
+    this.mainSegmentLoader_.resetLoader();
   }
 
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -629,6 +629,8 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // ...for determining the fetch location
     this.fetchAtBuffer_ = false;
+    // For comparing with currentTime when overwriting segments on playlist changes. Use -1 as the inactive flag.
+    this.replaceSegmentsUntil_ = -1;
 
     this.logger_ = logger(`SegmentLoader[${this.loaderType_}]`);
 
@@ -3057,7 +3059,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.logger_(`Appended ${segmentInfoString(segmentInfo)}`);
 
     this.addSegmentMetadataCue_(segmentInfo);
-    this.fetchAtBuffer_ = true;
+    if (this.currentTime_() >= this.replaceSegmentsUntil_) {
+      this.replaceSegmentsUntil_ = -1;
+      this.fetchAtBuffer_ = true;
+    }
     if (this.currentTimeline_ !== segmentInfo.timeline) {
       this.timelineChangeController_.lastTimelineChange({
         type: this.loaderType_,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1157,18 +1157,25 @@ export default class SegmentLoader extends videojs.EventTarget {
   }
 
   /**
-   * Delete all the buffered data and reset the SegmentLoader
-   *
-   * @param {Function} [done] an optional callback to be executed when the remove
-   * operation is complete
+   * Resets the segment loader ended and init properties.
    */
-  resetEverything(done) {
+  resetLoaderProperties() {
     this.ended_ = false;
     this.activeInitSegmentId_ = null;
     this.appendInitSegment_ = {
       audio: true,
       video: true
     };
+  }
+
+  /**
+   * Delete all the buffered data and reset the SegmentLoader
+   *
+   * @param {Function} [done] an optional callback to be executed when the remove
+   * operation is complete
+   */
+  resetEverything(done) {
+    this.resetLoaderProperties();
     this.resetLoader();
 
     // remove from 0, the earliest point, to Infinity, to signify removal of everything.

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -3216,4 +3216,16 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.segmentMetadataTrack_.addCue(cue);
   }
+
+  /**
+   * Public setter for defining the private replaceSegmentsUntil_ property, which
+   * determines when we can return fetchAtBuffer to true if overwriting the buffer.
+   *
+   * @param {number} bufferedEnd the end of the buffered range to replace segments
+   * until currentTime reaches this time.
+   */
+  set replaceSegmentsUntil(bufferedEnd) {
+    this.logger_(`Replacing currently buffered segments until ${bufferedEnd}`);
+    this.replaceSegmentsUntil_ = bufferedEnd;
+  }
 }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -629,7 +629,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // ...for determining the fetch location
     this.fetchAtBuffer_ = false;
-    // For comparing with currentTime when overwriting segments on playlist changes. Use -1 as the inactive flag.
+    // For comparing with currentTime when overwriting segments on fastQualityChange_ changes. Use -1 as the inactive flag.
     this.replaceSegmentsUntil_ = -1;
 
     this.logger_ = logger(`SegmentLoader[${this.loaderType_}]`);

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1147,6 +1147,7 @@ class VhsHandler extends Component {
         );
 
         // Clear the buffer before switching playlists, since it may already contain unplayable segments
+        this.playlistController_.mainSegmentLoader_.resetEverything();
         this.playlistController_.fastQualityChange_();
       }
     });

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -701,18 +701,11 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
     originalResync.call(segmentLoader);
   };
 
-  const origResetEverything = segmentLoader.resetEverything;
-  const origRemove = segmentLoader.remove;
+  const origResetLoaderProperties = segmentLoader.resetLoaderProperties;
 
-  segmentLoader.resetEverything = () => {
+  segmentLoader.resetLoaderProperties = () => {
     resets++;
-    origResetEverything.call(segmentLoader);
-  };
-
-  segmentLoader.remove = (start, end) => {
-    assert.equal(end, Infinity, 'on a remove all, end should be Infinity');
-
-    origRemove.call(segmentLoader, start, end);
+    origResetLoaderProperties.call(segmentLoader);
   };
 
   segmentLoader.startingMediaInfo_ = { hasVideo: true };
@@ -748,9 +741,7 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
 
   assert.equal(resyncs, 1, 'resynced segment loader if media is changed');
 
-  assert.equal(resets, 1, 'resetEverything called if media is changed');
-
-  assert.deepEqual(removeFuncArgs, {start: 0, end: 60}, 'remove() called with correct arguments if media is changed');
+  assert.equal(resets, 1, 'resetLoaderProperties called if media is changed');
 });
 
 QUnit.test('loadVttJs should be passed to the vttSegmentLoader and resolved on vttjsloaded', function(assert) {
@@ -768,55 +759,6 @@ QUnit.test('loadVttJs should be passed to the vttSegmentLoader and rejected on v
 
   controller.subtitleSegmentLoader_.loadVttJs().catch(() => {
     assert.equal(stub.callCount, 1, 'tech addWebVttScript called once');
-  });
-});
-
-QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', function(assert) {
-  let seeks = 0;
-
-  this.playlistController.mediaSource.trigger('sourceopen');
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
-
-  const segmentLoader = this.playlistController.mainSegmentLoader_;
-
-  return requestAndAppendSegment({
-    request: this.requests.shift(),
-    segmentLoader,
-    clock: this.clock
-  }).then(() => {
-    // media is changed
-    this.playlistController.selectPlaylist = () => {
-      const playlists = this.playlistController.main().playlists;
-      const currentPlaylist = this.playlistController.media();
-
-      return playlists.find((playlist) => playlist !== currentPlaylist);
-    };
-
-    this.player.tech_.on('seeking', function() {
-      seeks++;
-    });
-
-    const timeBeforeSwitch = this.player.currentTime();
-
-    // mock buffered values so removes are processed
-    segmentLoader.sourceUpdater_.audioBuffer.buffered = createTimeRanges([[0, 10]]);
-    segmentLoader.sourceUpdater_.videoBuffer.buffered = createTimeRanges([[0, 10]]);
-
-    this.playlistController.fastQualityChange_();
-    // trigger updateend to indicate the end of the remove operation
-    segmentLoader.sourceUpdater_.audioBuffer.trigger('updateend');
-    segmentLoader.sourceUpdater_.videoBuffer.trigger('updateend');
-    this.clock.tick(1);
-
-    assert.equal(
-      this.player.currentTime(),
-      timeBeforeSwitch,
-      'current time remains the same on fast quality switch'
-    );
-    assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
   });
 });
 
@@ -4815,7 +4757,6 @@ QUnit.test('on error all segment and playlist loaders are paused and aborted', f
 
 QUnit.test('can pass or select a playlist for fastQualityChange', function(assert) {
   const calls = {
-    resetEverything: 0,
     resyncLoader: 0,
     media: 0,
     selectPlaylist: 0
@@ -4846,24 +4787,18 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
     calls.resyncLoader++;
   };
 
-  pc.mainSegmentLoader_.resetEverything = () => {
-    calls.resetEverything++;
-  };
-
   pc.fastQualityChange_(pc.main().playlists[1]);
   assert.deepEqual(calls, {
-    resetEverything: 1,
     media: 1,
     selectPlaylist: 0,
-    resyncLoader: 0
+    resyncLoader: 1
   }, 'calls expected function when passed a playlist');
 
   pc.fastQualityChange_();
   assert.deepEqual(calls, {
-    resetEverything: 2,
     media: 2,
     selectPlaylist: 1,
-    resyncLoader: 0
+    resyncLoader: 2
   }, 'calls expected function when not passed a playlist');
 });
 

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -687,6 +687,8 @@ QUnit.test('resets everything for a fast quality change', function(assert) {
   let resets = 0;
   let removeFuncArgs = {};
 
+  this.player.tech_.buffered = () => createTimeRanges(0, 1);
+
   this.playlistController.mediaSource.trigger('sourceopen');
   // main
   this.standardXHRResponse(this.requests.shift());
@@ -4763,6 +4765,8 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
   };
 
   const pc = this.playlistController;
+
+  this.player.tech_.buffered = () => createTimeRanges(0, 1);
 
   pc.mediaSource.trigger('sourceopen');
   // main


### PR DESCRIPTION
## Description
`fastQualityChange_` was causing unnecessary rebuffering and requesting cached segments. This was resulting in slow and very buggy playlist changes. This was because it was calling `resetEverything` on the mainSegmentLoader, then calling `setCurrentTime` which calls `resetEverything` again on ALL the segment loaders, which removes all content from the buffer and aborts all requests.

Edit: Had to add a property `replaceSegmentsUntil`, which represents the end of the buffer at the moment `fastQualityChange_` is called. This tells the segment loader to leave `fetchAtBuffer_` as false until we've successfully replaced all the buffered segments between `currentTime` and `bufferedEnd` at the moment `fastQualityChange_` is called.

## Specific Changes proposed
Remove the `resetEverything` and `setCurrentTime` call from `fastQualityChange_` and instead reset the next segment position to `currentTime` with a `resetLoader` call, keeping the current buffer and overwriting it.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
