### PR TITLE
fix: remove segment loader abort in setCurrentTime

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1393,14 +1393,11 @@ export class PlaylistController extends videojs.EventTarget {
     // cancel outstanding requests so we begin buffering at the new
     // location
     this.mainSegmentLoader_.resetEverything();
-    this.mainSegmentLoader_.abort();
     if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
       this.audioSegmentLoader_.resetEverything();
-      this.audioSegmentLoader_.abort();
     }
     if (this.mediaTypes_.SUBTITLES.activePlaylistLoader) {
       this.subtitleSegmentLoader_.resetEverything();
-      this.subtitleSegmentLoader_.abort();
     }
 
     // start segment loader loading in case they are paused

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -3710,28 +3710,23 @@ QUnit.test('subtitle segment loader resets on seeks', function(assert) {
   this.clock.tick(1);
 
   let resetCount = 0;
-  let abortCount = 0;
   let loadCount = 0;
 
   playlistController.subtitleSegmentLoader_.resetEverything = () => resetCount++;
-  playlistController.subtitleSegmentLoader_.abort = () => abortCount++;
   playlistController.subtitleSegmentLoader_.load = () => loadCount++;
 
   this.player.pause();
   playlistController.setCurrentTime(5);
 
   assert.equal(resetCount, 1, 'reset subtitle segment loader');
-  assert.equal(abortCount, 1, 'aborted subtitle segment loader');
   assert.equal(loadCount, 1, 'called load on subtitle segment loader');
 
   this.player.play();
   resetCount = 0;
-  abortCount = 0;
   loadCount = 0;
   playlistController.setCurrentTime(10);
 
   assert.equal(resetCount, 1, 'reset subtitle segment loader');
-  assert.equal(abortCount, 1, 'aborted subtitle segment loader');
   assert.equal(loadCount, 1, 'called load on subtitle segment loader');
 });
 


### PR DESCRIPTION
## Description
Removing the `abort` call from `setCurrentTime` makes seeking and certain playlist switching cases more resilient. This is because `setCurrentTime` was essentially calling abort on all the segment loaders twice. Once in the `setCurrentTime` function directly, then from `resetEverything` which eventually calls `resyncLoader` which also calls `abort` on the segment loader.

## Specific Changes proposed
Remove the `abort` calls on all segment loaders and fix the tests.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
