### PR TITLE
fix: demo page representation selector

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -6,7 +6,7 @@
   representationsEl.addEventListener('change', function() {
     var selectedIndex = representationsEl.selectedIndex;
 
-    if (!selectedIndex || selectedIndex < 1 || !window.vhs) {
+    if (selectedIndex < 0 || !window.vhs) {
       return;
     }
     var selectedOption = representationsEl.options[representationsEl.selectedIndex];


### PR DESCRIPTION
## Description
The VHS demo page representation selector was not allowing the user to select the first or `0` indexed representation in the list.

## Specific Changes proposed
Remove the `!selectedIndex` check and change the expected index to `< 0 ` for "no element selected". See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedIndex 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
