### PR TITLE
chore: update mpd-parser to v1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6903,9 +6903,9 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.2.1.tgz",
-      "integrity": "sha512-f1DPoocf4ERvBi9XnS1MWFaBURdJvv9uu7EgQEjrD1+U33NL7Azw030Au/GPOpA7YWTw97T9Bt/WgcEmM/B88g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.2.2.tgz",
+      "integrity": "sha512-QCfB1koOoZw6E5La1cx+W/Yd0EZlRhHMqMr4TAJez0eRTuPDzPM5FWoiOqjyo37W+ISPLzmfJACSbJFEBjbL4Q==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
     "m3u8-parser": "^7.1.0",
-    "mpd-parser": "^1.2.1",
+    "mpd-parser": "^1.2.2",
     "mux.js": "7.0.0",
     "video.js": "^7 || ^8"
   },


### PR DESCRIPTION
## Description
Update to the newest version of the mpd-parser to consume the work for content-steering

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
