### PR TITLE
Fix ddos created by requesting infinitely for the same chunks

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -319,7 +319,7 @@ export default class PlaybackWatcher {
       seekTo = seekableEnd;
     }
 
-    if (this.beforeSeekableWindow_(seekable, currentTime)) {
+    if (seekable.length && seekable.length > 1 && this.beforeSeekableWindow_(seekable, currentTime)) {
       const seekableStart = seekable.start(0);
 
       // sync to the beginning of the live window


### PR DESCRIPTION
## Description
As stated in the following discussion, videojs player requests in certain situations indefinitely for the same chunks which results in a ddos being fired at the server. This issue keeps getting ignored/closed automatically.

https://github.com/videojs/http-streaming/issues/1000#issuecomment-899934566

This situation happens when there is a network congestion or just really slow internet speeds. (Chrome dev tools, throttling slow 3G for example) the player starts buffering after a few seconds. When the network recovers to normal speed, the player keeps requesting the same chunk over and over. (Imagine you have a hundreds of visitors..)


## Specific Changes proposed
Check if there are seekable points.

## Requirements Checklist
- [ ] Bug fixed
- [ ] Reviewed by Two Core Contributors
