### PR TITLE
feat: content steering demo page tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#player-stats" type="button" role="tab" aria-selected="false">Player Stats</button>
     </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#content-steering" type="button" role="tab" aria-selected="false">Content Steering</button>
+    </li>
   </ul>
 
   <div class="tab-content container-fluid">
@@ -219,6 +222,22 @@
           </dl>
         </div>
         <ul id="segment-metadata" class="col-8"></ul>
+      </div>
+    </div>
+
+    <div class="tab-pane" id="content-steering" role="tabpanel">
+      <div class="row">
+        <div class="content-steering col-8">
+          <dl>
+            <dt>Current Pathway:</dt>
+            <dd class="current-pathway"></dd>
+            <dt>Available Pathways:</dt>
+            <dd class="available-pathways"></dd>
+            <dt>Steering Manifest:</dt>
+            <dd class="steering-manifest"></dd>
+          </dl>
+        </div>
+      </div>
       </div>
     </div>
   </div>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -432,6 +432,27 @@
     }, 100);
   };
 
+  var setupContentSteeringData = function(player) {
+    var currentPathwayEl = document.querySelector('.current-pathway');
+    var availablePathwaysEl = document.querySelector('.available-pathways');
+    var steeringManifestEl = document.querySelector('.steering-manifest');
+
+    player.one('loadedmetadata', function() {
+      var steeringController = player.tech_.vhs.playlistController_.contentSteeringController_;
+
+      if (!steeringController) {
+        return;
+      }
+      var onContentSteering = function() {
+        currentPathwayEl.textContent = steeringController.currentPathway;
+        availablePathwaysEl.textContent = Array.from(steeringController.availablePathways_).join(', ');
+        steeringManifestEl.textContent = JSON.stringify(steeringController.steeringManifest);
+      };
+
+      steeringController.on('content-steering', onContentSteering);
+    });
+  };
+
   [
     'debug',
     'autoplay',
@@ -595,6 +616,7 @@
 
         setupPlayerStats(player);
         setupSegmentMetadata(player);
+        setupContentSteeringData(player);
 
         // save player muted state interation
         player.on('volumechange', function() {


### PR DESCRIPTION
## Description
Adds content steering information to the demo page.

## Specific Changes proposed
Creating  a new tab in the demo page that displays the current state of the content steering controller and content steering manifest object within the controller.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
