### PR TITLE
feat: content steering switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#player-stats" type="button" role="tab" aria-selected="false">Player Stats</button>
     </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#content-steering" type="button" role="tab" aria-selected="false">Content Steering</button>
+    </li>
   </ul>
 
   <div class="tab-content container-fluid">
@@ -219,6 +222,22 @@
           </dl>
         </div>
         <ul id="segment-metadata" class="col-8"></ul>
+      </div>
+    </div>
+
+    <div class="tab-pane" id="content-steering" role="tabpanel">
+      <div class="row">
+        <div class="content-steering col-8">
+          <dl>
+            <dt>Current Pathway:</dt>
+            <dd class="current-pathway"></dd>
+            <dt>Available Pathways:</dt>
+            <dd class="available-pathways"></dd>
+            <dt>Steering Manifest:</dt>
+            <dd class="steering-manifest"></dd>
+          </dl>
+        </div>
+      </div>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -49,9 +49,6 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#player-stats" type="button" role="tab" aria-selected="false">Player Stats</button>
     </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#content-steering" type="button" role="tab" aria-selected="false">Content Steering</button>
-    </li>
   </ul>
 
   <div class="tab-content container-fluid">
@@ -222,22 +219,6 @@
           </dl>
         </div>
         <ul id="segment-metadata" class="col-8"></ul>
-      </div>
-    </div>
-
-    <div class="tab-pane" id="content-steering" role="tabpanel">
-      <div class="row">
-        <div class="content-steering col-8">
-          <dl>
-            <dt>Current Pathway:</dt>
-            <dd class="current-pathway"></dd>
-            <dt>Available Pathways:</dt>
-            <dd class="available-pathways"></dd>
-            <dt>Steering Manifest:</dt>
-            <dd class="steering-manifest"></dd>
-          </dl>
-        </div>
-      </div>
       </div>
     </div>
   </div>

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -126,7 +126,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
     }
 
     if (this.queryBeforeStart) {
-      this.requestSteeringManifest(this.queryBeforeStart);
+      this.requestSteeringManifest(this.steeringManifest.reloadUri);
     }
   }
 
@@ -134,15 +134,15 @@ export default class ContentSteeringController extends videojs.EventTarget {
    * Requests the content steering manifest and parse the response. This should only be called after
    * assignTagProperties was called with a content steering tag.
    *
-   * @param {boolean} withQueryBeforeStart If true, the request should be made with the initial serverUri.
+   * @param {string} initialUri The optional uri to make the request with.
+   *    If set, the request should be made with exactly what is passed in this variable.
    *    This scenario is specific to DASH when the queryBeforeStart parameter is true.
    *    This scenario should only happen once on initalization.
    */
-  requestSteeringManifest(withQueryBeforeStart = false) {
-    // add parameters to the steering uri
+  requestSteeringManifest(initialUri) {
     const reloadUri = this.steeringManifest.reloadUri;
 
-    if (!reloadUri) {
+    if (!initialUri && !reloadUri) {
       return;
     }
 
@@ -150,7 +150,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
     // ExtUrlQueryInfo tag support. See the DASH content steering spec section 8.1.
 
     // This request URI accounts for manifest URIs that have been excluded.
-    const uri = withQueryBeforeStart ? reloadUri : this.getRequestURI(reloadUri);
+    const uri = initialUri || this.getRequestURI(reloadUri);
 
     // If there are no valid manifest URIs, we should stop content steering.
     if (!uri) {

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -85,7 +85,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.ttlTimeout_ = null;
     this.request_ = null;
     this.requestError_ = null;
-    this.exlucdedSteeringManifestURLs = [];
+    this.excludedSteeringManifestURLs = [];
     this.mainSegmentLoader_ = segmentLoader;
     this.logger_ = logger('Content Steering');
   }
@@ -166,7 +166,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
           this.logger_(`manifest request 410 ${error}.`);
           this.logger_(`There will be no more content steering requests to ${uri} this session.`);
 
-          this.exlucdedSteeringManifestURLs.push(uri);
+          this.excludedSteeringManifestURLs.push(uri);
           return;
         }
         // If the client receives HTTP 429 Too Many Requests with a Retry-After
@@ -322,7 +322,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
       return null;
     }
 
-    const isExcluded = (uri) => this.exlucdedSteeringManifestURLs.includes(uri);
+    const isExcluded = (uri) => this.excludedSteeringManifestURLs.includes(uri);
 
     if (this.proxyServerUrl_) {
       const proxyURI = this.setProxyServerUrl_(reloadUri);
@@ -388,6 +388,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.manifestType_ = null;
     this.ttlTimeout_ = null;
     this.request_ = null;
+    this.requestError_ = null;
+    this.excludedSteeringManifestURLs = [];
     this.availablePathways_ = new Set();
     this.excludedPathways_ = new Set();
     this.steeringManifest = new SteeringManifest();

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -289,8 +289,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
         }
       }
 
-      // If no pathway matches, ignore the manifest and choose whatever is available.
-      return this.availablePathways_[0];
+      // If no pathway matches, ignore the manifest and choose the first available.
+      return [...this.availablePathways_][0];
     };
 
     const nextPathway = chooseNextPathway(this.steeringManifest.priority);

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -245,9 +245,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
 
     if (this.mainSegmentLoader_.throughput.rate) {
       const throughputKey = `_${this.manifestType_}_throughput`;
-      const rateInteger = Math.round(this.mainSegmentLoader_.throughput.rate);
 
-      urlObject.searchParams.set(throughputKey, rateInteger);
+      urlObject.searchParams.set(throughputKey, this.mainSegmentLoader_.bandwidth);
     }
     return urlObject.toString();
   }

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -409,4 +409,17 @@ export default class ContentSteeringController extends videojs.EventTarget {
       this.availablePathways_.add(pathway);
     }
   }
+
+  excludePathway(pathway) {
+    return this.availablePathways_.delete(pathway);
+  }
+
+  /**
+   * Utility function for getting the current pathway priority from the content steering manifest.
+   *
+   * @return the pathway priority
+   */
+  getPriority() {
+    return this.steeringManifest.priority;
+  }
 }

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -418,13 +418,4 @@ export default class ContentSteeringController extends videojs.EventTarget {
   excludePathway(pathway) {
     return this.availablePathways_.delete(pathway);
   }
-
-  /**
-   * Utility function for getting the current pathway priority from the content steering manifest.
-   *
-   * @return the pathway priority
-   */
-  getPriority() {
-    return this.steeringManifest.priority;
-  }
 }

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -120,13 +120,10 @@ export default class ContentSteeringController extends videojs.EventTarget {
       this.proxyServerUrl_ = steeringTag.proxyServerURL;
     }
 
-    // We want to trigger an update to the playlists no matter what in HLS,
-    // In DASH, we only want to update here if `queryBeforeStart` is true.
-    const shouldContinue = this.manifestType_ === 'HLS' || this.queryBeforeStart;
-
     // trigger a steering event if we have a pathway from the content steering tag.
     // this tells VHS which segment pathway to start with.
-    if (this.defaultPathway && shouldContinue) {
+    // If queryBeforeStart is true we need to wait for the steering manifest response.
+    if (this.defaultPathway && !this.queryBeforeStart) {
       this.trigger('content-steering');
     }
   }

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -115,10 +115,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
     // pathwayId is HLS defaultServiceLocation is DASH
     this.defaultPathway = steeringTag.pathwayId || steeringTag.defaultServiceLocation;
     // currently only DASH supports the following properties on <ContentSteering> tags.
-    if (this.manifestType_ === 'DASH') {
-      this.queryBeforeStart = steeringTag.queryBeforeStart || false;
-      this.proxyServerUrl_ = steeringTag.proxyServerURL;
-    }
+    this.queryBeforeStart = steeringTag.queryBeforeStart || false;
+    this.proxyServerUrl_ = steeringTag.proxyServerURL || null;
 
     // trigger a steering event if we have a pathway from the content steering tag.
     // this tells VHS which segment pathway to start with.
@@ -388,6 +386,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
    * aborts steering requests clears the ttl timeout and resets all properties.
    */
   dispose() {
+    this.off('content-steering');
     this.abort();
     this.clearTTLTimeout_();
     this.currentPathway = null;
@@ -413,6 +412,13 @@ export default class ContentSteeringController extends videojs.EventTarget {
     if (pathway) {
       this.availablePathways_.add(pathway);
     }
+  }
+
+  /**
+   * clears all pathways from the available pathways set
+   */
+  clearAvailablePathways() {
+    this.availablePathways_.clear();
   }
 
   excludePathway(pathway) {

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -83,7 +83,6 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.manifestType_ = null;
     this.ttlTimeout_ = null;
     this.request_ = null;
-    this.requestError_ = null;
     this.excludedSteeringManifestURLs = new Set();
     this.mainSegmentLoader_ = segmentLoader;
     this.logger_ = logger('Content Steering');
@@ -164,7 +163,6 @@ export default class ContentSteeringController extends videojs.EventTarget {
       uri
     }, (error, errorInfo) => {
       if (error) {
-        this.requestError_ = error;
         // If the client receives HTTP 410 Gone in response to a manifest request,
         // it MUST NOT issue another request for that URI for the remainder of the
         // playback session. It MAY continue to use the most-recently obtained set
@@ -195,7 +193,6 @@ export default class ContentSteeringController extends videojs.EventTarget {
         this.startTTLTimeout_();
         return;
       }
-      this.requestError_ = null;
       const steeringManifestJson = JSON.parse(this.request_.responseText);
 
       this.startTTLTimeout_();
@@ -397,7 +394,6 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.manifestType_ = null;
     this.ttlTimeout_ = null;
     this.request_ = null;
-    this.requestError_ = null;
     this.excludedSteeringManifestURLs = new Set();
     this.availablePathways_ = new Set();
     this.excludedPathways_ = new Set();

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -120,9 +120,13 @@ export default class ContentSteeringController extends videojs.EventTarget {
       this.proxyServerUrl_ = steeringTag.proxyServerURL;
     }
 
+    // We want to trigger an update to the playlists no matter what in HLS,
+    // In DASH, we only want to update here if `queryBeforeStart` is true.
+    const shouldContinue = this.manifestType_ === 'HLS' || this.queryBeforeStart;
+
     // trigger a steering event if we have a pathway from the content steering tag.
     // this tells VHS which segment pathway to start with.
-    if (this.defaultPathway && !this.queryBeforeStart) {
+    if (this.defaultPathway && shouldContinue) {
       this.trigger('content-steering');
     }
   }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -325,7 +325,10 @@ export default class DashPlaylistLoader extends EventTarget {
 
     // live playlist staleness timeout
     this.on('mediaupdatetimeout', () => {
-      this.refreshMedia_(this.media().id);
+      // We handle live content steering in the playlist controller
+      if (!this.media().attributes.serviceLocation) {
+        this.refreshMedia_(this.media().id);
+      }
     });
 
     this.state = 'HAVE_NOTHING';

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -292,14 +292,11 @@ export const onError = {
    */
   SUBTITLES: (type, settings) => () => {
     const {
-      segmentLoaders: { [type]: segmentLoader},
       mediaTypes: { [type]: mediaType }
     } = settings;
 
     videojs.log.warn('Problem encountered loading the subtitle track.' +
                      'Disabling subtitle track.');
-
-    stopLoaders(segmentLoader, mediaType);
 
     const track = mediaType.activeTrack();
 

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -250,12 +250,9 @@ export const onError = {
    */
   AUDIO: (type, settings) => () => {
     const {
-      segmentLoaders: { [type]: segmentLoader},
       mediaTypes: { [type]: mediaType },
       excludePlaylist
     } = settings;
-
-    stopLoaders(segmentLoader, mediaType);
 
     // switch back to default audio track
     const activeTrack = mediaType.activeTrack();

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2181,6 +2181,10 @@ export class PlaylistController extends videojs.EventTarget {
     }
   }
 
+  /**
+   * Changes the current playlists for audio, video and subtitles after a new pathway
+   * is chosen from content steering.
+   */
   changeSegmentPathway_() {
     const nextPlaylist = this.selectPlaylist();
 
@@ -2194,11 +2198,11 @@ export class PlaylistController extends videojs.EventTarget {
 
     this.delegateLoaders_('main', ['pause']);
 
-    this.switchMedia_(nextPlaylist, 'content-steering');
-
     // Switch audio and text track playlists if necessary in DASH
     if (this.contentSteeringController_.manifestType_ === 'DASH') {
       this.switchMediaForDASHContentSteering_();
     }
+
+    this.switchMedia_(nextPlaylist, 'content-steering');
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1258,7 +1258,7 @@ export class PlaylistController extends videojs.EventTarget {
       // If we're content steering, try other pathways.
       if (this.main().contentSteering) {
         const pathway = this.pathwayAttribute_(playlistToExclude);
-        // Ignore atleast 1 steering manifest refresh.
+        // Ignore at least 1 steering manifest refresh.
         const reIncludeDelay = this.contentSteeringController_.steeringManifest.ttl * 1000;
 
         this.contentSteeringController_.excludePathway(pathway);
@@ -2140,12 +2140,9 @@ export class PlaylistController extends videojs.EventTarget {
       });
     }
 
-    if (this.contentSteeringController_.queryBeforeStart) {
-      // If the DASH `queryBeforeStart` parameter is set, we want to ensure we
-      // make a request for the steering manifest before playback
-      this.contentSteeringController_.requestSteeringManifest();
-    } else {
-      // Otherwise, we want to start playback as soon as possible.
+    // Do this at startup only, after that the steering requests are managed by the Content Steering class.
+    // DASH queryBeforeStart scenarios will be handled by the Content Steering class.
+    if (!this.contentSteeringController_.queryBeforeStart) {
       this.tech_.one('canplay', () => {
         this.contentSteeringController_.requestSteeringManifest();
       });

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -306,8 +306,11 @@ export class PlaylistController extends videojs.EventTarget {
         })
       }), options);
 
-    // pass main segment loader for current throughput.
-    this.contentSteeringController_ = new ContentSteeringController(this.mainSegmentLoader_);
+    const getBandwidth = () => {
+      return this.mainSegmentLoader_.bandwidth;
+    };
+
+    this.contentSteeringController_ = new ContentSteeringController(this.vhs_.xhr, getBandwidth);
     this.setupSegmentLoaderListeners_();
 
     if (this.bufferBasedABR) {

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2187,6 +2187,21 @@ export class PlaylistController extends videojs.EventTarget {
       this.logger_(`excluding ${variant.id} for ${variant.lastExcludeReason_}`);
     });
 
+    if (this.contentSteeringController_.manifestType_ === 'DASH') {
+      Object.keys(this.mediaTypes_).forEach((key) => {
+        const type = this.mediaTypes_[key];
+
+        if (type.activePlaylistLoader) {
+          const currentPlaylist = type.activePlaylistLoader.media_;
+
+          // Check if the current media playlist matches the current CDN
+          if (currentPlaylist && currentPlaylist.attributes.serviceLocation !== currentPathway) {
+            didEnablePlaylists = true;
+          }
+        }
+      });
+    }
+
     if (didEnablePlaylists) {
       this.changeSegmentPathway_();
     }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -307,6 +307,7 @@ export class PlaylistController extends videojs.EventTarget {
       }), options);
 
     // pass main segment loader for current throughput.
+    this.contentSteeringController_ = new ContentSteeringController(this.mainSegmentLoader_);
     this.setupSegmentLoaderListeners_();
 
     if (this.bufferBasedABR) {
@@ -1685,6 +1686,7 @@ export class PlaylistController extends videojs.EventTarget {
     this.decrypter_.terminate();
     this.mainPlaylistLoader_.dispose();
     this.mainSegmentLoader_.dispose();
+    this.contentSteeringController_.dispose();
 
     if (this.loadOnPlay_) {
       this.tech_.off('play', this.loadOnPlay_);
@@ -2118,8 +2120,6 @@ export class PlaylistController extends videojs.EventTarget {
 
       this.contentSteeringController_.assignTagProperties(main.uri, main.contentSteering);
     };
-
-    this.contentSteeringController_ = new ContentSteeringController(this.mainSegmentLoader_);
 
     updateSteeringValues(initialMain);
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2134,7 +2134,7 @@ export class PlaylistController extends videojs.EventTarget {
         // clear past values
         this.contentSteeringController_.abort();
         this.contentSteeringController_.clearTTLTimeout_();
-        this.contentSteeringController_.availablePathways_.clear();
+        this.contentSteeringController_.clearAvailablePathways();
 
         updateSteeringValues(this.main());
       });

--- a/test/content-steering-controller.test.js
+++ b/test/content-steering-controller.test.js
@@ -496,3 +496,17 @@ QUnit.test('chooses first pathway when none are in the priority list', function(
   // test-1 is the default pathway added in beforeEach
   assert.equal(expected, 'test-1', 'use first pathway when none exist on the priority list');
 });
+
+QUnit.test('disposes the controller when there are no available pathways', function(assert) {
+  const steeringTag = {
+    serverUri: '/content/steering'
+  };
+
+  this.contentSteeringController.excludePathway('test-1');
+  const disposeSpy = sinon.spy(this.contentSteeringController, 'dispose');
+
+  this.assignAndRequest(steeringTag);
+  this.requests[0].respond(200, { 'Content-Type': 'application/json' }, '{ "VERSION": 1, "PATHWAY-PRIORITY": ["cdn-z"] }');
+
+  assert.ok(disposeSpy.called, 'diposes the content steering controller');
+});

--- a/test/content-steering-controller.test.js
+++ b/test/content-steering-controller.test.js
@@ -8,17 +8,8 @@ QUnit.module('ContentSteering', {
   beforeEach(assert) {
     this.env = useFakeEnvironment(assert);
     this.requests = this.env.requests;
-    this.fakeVhs = {
-      xhr: xhrFactory()
-    };
-    this.mockSegmentLoader = {
-      vhs_: this.fakeVhs,
-      throughput: {
-        rate: 0
-      }
-    };
     this.baseURL = 'https://foo.bar';
-    this.contentSteeringController = new ContentSteeringController(this.mockSegmentLoader);
+    this.contentSteeringController = new ContentSteeringController(xhrFactory(), () => undefined);
     this.contentSteeringController.addAvailablePathway('test-1');
     // handles a common testing flow of assigning tag properties and requesting the steering manifest immediately.
     this.assignAndRequest = (steeringTag) => {
@@ -97,8 +88,10 @@ QUnit.test('Can add HLS pathway and throughput to steering manifest requests', f
   };
   const expectedThroughputUrl = steeringTag.serverUri + '/?_HLS_pathway=cdn-a&_HLS_throughput=99999';
 
+  this.contentSteeringController.getBandwidth_ = () => {
+    return 99999;
+  };
   this.contentSteeringController.assignTagProperties(this.baseURL, steeringTag);
-  this.mockSegmentLoader.throughput.rate = 99999;
   assert.equal(this.contentSteeringController.setSteeringParams_(steeringTag.serverUri), expectedThroughputUrl, 'pathway and throughput parameters set as expected');
 });
 
@@ -169,8 +162,10 @@ QUnit.test('Can add DASH pathway and throughput to steering manifest requests', 
   };
   const expectedThroughputUrl = steeringTag.serverURL + '&_DASH_pathway=cdn-c&_DASH_throughput=9999';
 
+  this.contentSteeringController.getBandwidth_ = () => {
+    return 9999;
+  };
   this.contentSteeringController.assignTagProperties(this.baseURL, steeringTag);
-  this.mockSegmentLoader.throughput.rate = 9999;
   assert.equal(this.contentSteeringController.setSteeringParams_(steeringTag.serverURL), expectedThroughputUrl, 'pathway and throughput parameters set as expected');
 });
 
@@ -192,7 +187,9 @@ QUnit.test('Can handle DASH proxyServerURL', function(assert) {
   };
   const expectedProxyUrl = 'https://proxy.url/?url=https%3A%2F%2Fcontent.steering.dash%2F%3Fprevious%3Dparams&_DASH_pathway=dash-cdn&_DASH_throughput=99';
 
-  this.mockSegmentLoader.throughput.rate = 99;
+  this.contentSteeringController.getBandwidth_ = () => {
+    return 99;
+  };
   this.assignAndRequest(steeringTag);
   assert.equal(this.requests[0].uri, expectedProxyUrl, 'returns expected proxy server URL');
 });

--- a/test/content-steering-controller.test.js
+++ b/test/content-steering-controller.test.js
@@ -378,7 +378,7 @@ QUnit.test('Exclude request URI on a 410 error', function(assert) {
   this.assignAndRequest(steeringTag);
   this.requests[0].respond(410);
 
-  const excludedUri = this.contentSteeringController.excludedSteeringManifestURLs[0];
+  const excludedUri = [...this.contentSteeringController.excludedSteeringManifestURLs][0];
 
   assert.equal(excludedUri, resolvedUri, 'exludes uri from future requests');
 });
@@ -427,7 +427,7 @@ QUnit.test('getRequestURI returns resolved reloadUri when proxyUri is excluded',
 
   this.contentSteeringController.proxyServerUrl_ = 'https://proxy.url';
   // exlude the resolved url
-  this.contentSteeringController.excludedSteeringManifestURLs[0] = 'https://proxy.url/?url=https%3A%2F%2Fbaseurl.com%2F';
+  this.contentSteeringController.excludedSteeringManifestURLs.add('https://proxy.url/?url=https%3A%2F%2Fbaseurl.com%2F');
 
   const actual = this.contentSteeringController.getRequestURI(reloadUri);
   const expected = 'https://baseurl.com/';
@@ -440,8 +440,8 @@ QUnit.test('getRequestURI returns null when both reloadUri or proxyUri are exclu
 
   this.contentSteeringController.proxyServerUrl_ = 'https://proxy.url';
   // exlude the resolved urls
-  this.contentSteeringController.excludedSteeringManifestURLs[0] = 'https://proxy.url/?url=https%3A%2F%2Fbaseurl.com%2F';
-  this.contentSteeringController.excludedSteeringManifestURLs[1] = 'https://baseurl.com/';
+  this.contentSteeringController.excludedSteeringManifestURLs.add('https://proxy.url/?url=https%3A%2F%2Fbaseurl.com%2F');
+  this.contentSteeringController.excludedSteeringManifestURLs.add('https://baseurl.com/');
 
   const actual = this.contentSteeringController.getRequestURI(reloadUri);
 

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -6432,7 +6432,7 @@ QUnit.test('initContentSteeringController_ for DASH with queryBeforeStart', func
   assert.deepEqual(steering.steeringManifest.reloadUri, mainPlaylist.contentSteering.serverURL);
 });
 
-QUnit.test.only('initContentSteeringController_ for DASH without queryBeforeStart', function(assert) {
+QUnit.test('initContentSteeringController_ for DASH without queryBeforeStart', function(assert) {
   const options = {
     src: 'test',
     tech: this.player.tech_,

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -6479,7 +6479,7 @@ QUnit.test('initContentSteeringController_ for DASH without queryBeforeStart', f
   assert.notOk(requestSteeringManifestSpy.called);
 
   // Now the playlist should make the request to the content steering server
-  // This event mean the media should already be loaded.
+  // This event means the media should already be loaded.
   this.player.tech_.trigger('canplay');
 
   // requestManifest is called, which means a request to the steering server is made.
@@ -6492,4 +6492,68 @@ QUnit.test('initContentSteeringController_ for DASH without queryBeforeStart', f
   assert.deepEqual(pathways[1], 'cdn-b');
   assert.deepEqual(steering.manifestType_, 'DASH');
   assert.deepEqual(steering.steeringManifest.reloadUri, mainPlaylist.contentSteering.serverURL);
+});
+
+QUnit.test('Test Live DASH update with content steering', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'dash'
+  };
+
+  const pc = new PlaylistController(options);
+
+  // Stub the steering request functionality and the resetting of media.
+  sinon.stub(pc.contentSteeringController_, 'requestSteeringManifest');
+  sinon.stub(pc.mainPlaylistLoader_, 'refreshMedia_');
+
+  const mainPlaylist = {
+    contentSteering: {
+      defaultServiceLocation: 'cdn-a',
+      serverURL: 'https://www.server.test'
+    },
+    playlists: [
+      {
+        attributes: {
+          NAME: 'video_1920x1080_4531kbps',
+          serviceLocation: 'cdn-a'
+        },
+        endList: true,
+        id: '0-placeholder-uri-0',
+        resolvedUri: 'https://fastly.content-steering.com/bbb/placeholder-uri-0',
+        uri: 'placeholder-uri-0'
+      },
+      {
+        attributes: {
+          NAME: 'video_1280x720_2445kbps',
+          serviceLocation: 'cdn-b'
+        },
+        endList: true,
+        id: '1-placeholder-uri-1',
+        resolvedUri: 'https://fastly.content-steering.com/bbb/placeholder-uri-1',
+        uri: 'placeholder-uri-1'
+      }
+    ]
+  };
+
+  // Second manifest after live update just changes the queryBeforeStartParam
+  const mainPlaylistAfter = Object.assign({}, mainPlaylist);
+
+  pc.main = () => mainPlaylist;
+  pc.mainPlaylistLoader_.media = () => mainPlaylist.playlists[0];
+
+  pc.initContentSteeringController_();
+
+  // The initial manifest did not have queryBeforeStart set
+  assert.deepEqual(pc.contentSteeringController_.queryBeforeStart, false);
+
+  // mimics refreshMedia_, resetting main with the new manifest
+  mainPlaylistAfter.contentSteering.queryBeforeStart = true;
+  pc.main = () => mainPlaylistAfter;
+
+  // mimic a live DASH manifest update
+  pc.mainPlaylistLoader_.trigger('mediaupdatetimeout');
+
+  // The content steering controller was updated with the new information.
+  assert.deepEqual(pc.contentSteeringController_.queryBeforeStart, true);
 });


### PR DESCRIPTION
## Description
The changes include the logic for switching pathways regarding content steering. All specifications for both DASH and HLS can be found in the resources below. The function of these changes are to ensure that we are communicating with the content steering server, handling the responses, switching playlists based on this data, and ensuring that we follow the requirements of the spec when deciding when/where to switch.

## Specific Changes proposed
- Logic to determine which pathway/serviceLocation should be selected based on priority.
- Logic to switch media in cases where we want to switch playlists.
- Logic to exclude playlists when necessary according to the spec.
- Logic to set timers to retry certain content steering requests.
- Tests to cover specification

## Example Manifests to Test Locally
DASH: https://fastly.content-steering.com/bbb/playlist_steering_fastly_https_cdn-a_cdn-c_cdn-b.mpd
HLS: https://fastly.content-steering.com/bbb_hls/master_steering_fastly_https.m3u8

## Specs
https://dashif.org/docs/DASH-IF-CTS-00XX-Content-Steering-Community-Review.pdf
https://developer.apple.com/streaming/HLSContentSteeringSpecification.pdf

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
