### PR TITLE
fix: wrap onwarn values in an object as expected by the playlist-loader

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -93,7 +93,7 @@ export const parseManifest = ({
     }
 
     if (onwarn) {
-      onwarn(`manifest has no targetDuration defaulting to ${targetDuration}`);
+      onwarn({ message: `manifest has no targetDuration defaulting to ${targetDuration}` });
     }
     manifest.targetDuration = targetDuration;
   }
@@ -104,7 +104,7 @@ export const parseManifest = ({
     const partTargetDuration = parts.reduce((acc, p) => Math.max(acc, p.duration), 0);
 
     if (onwarn) {
-      onwarn(`manifest has no partTargetDuration defaulting to ${partTargetDuration}`);
+      onwarn({ message: `manifest has no partTargetDuration defaulting to ${partTargetDuration}` });
       log.error('LL-HLS manifest has parts but lacks required #EXT-X-PART-INF:PART-TARGET value. See https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-09#section-4.4.3.7. Playback is not guaranteed.');
     }
     manifest.partTargetDuration = partTargetDuration;


### PR DESCRIPTION
## Description
Hey, apologies for not first opening an issue, but it's a very small fix.
When debugging an issue in one of my projects I noticed the debug log: `VIDEOJS: DEBUG: VHS: PlaylistLoader > m3u8-parser warn for [URL]: undefined`.

This is caused by PlaylistLoader#parseManifest_ expecting onwarn to be called with an object that has a message parameter. In manifest.js#parseManifest the onwarn method is sometimes called with a string. It's also called with a message object inside the m3u8 parser.

## Specific Changes proposed
We could either change onwarn to always return a string, or return a message object from inside manifest.js#parseManifest.
In this fix I went with the latter as to not break any usage of parseManifest.

Please let me know if anything is unclear, I'll be happy to append the PR.

## Requirements Checklist
- [ ] Bug fixed
- [ ] Reviewed by Two Core Contributors
