### PR TITLE
fix: content steering bug fixes and tests

### DIFF
--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -430,9 +430,9 @@ export default class ContentSteeringController extends videojs.EventTarget {
    */
   didDASHTagChange(baseURL, newTag) {
     return !newTag && this.steeringManifest.reloadUri ||
-      resolveUrl(baseURL, newTag.serverURL) !== this.steeringManifest.reloadUri ||
+      newTag && (resolveUrl(baseURL, newTag.serverURL) !== this.steeringManifest.reloadUri ||
       newTag.defaultServiceLocation !== this.defaultPathway ||
       newTag.queryBeforeStart !== this.queryBeforeStart ||
-      newTag.proxyServerURL !== this.proxyServerUrl_;
+      newTag.proxyServerURL !== this.proxyServerUrl_);
   }
 }

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -133,10 +133,9 @@ export default class ContentSteeringController extends videojs.EventTarget {
    *
    * @param {string} initialUri The optional uri to make the request with.
    *    If set, the request should be made with exactly what is passed in this variable.
-   *    This scenario is specific to DASH when the queryBeforeStart parameter is true.
    *    This scenario should only happen once on initalization.
    */
-  requestSteeringManifest() {
+  requestSteeringManifest(initial) {
     const reloadUri = this.steeringManifest.reloadUri;
 
     if (!reloadUri) {
@@ -147,7 +146,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
     // ExtUrlQueryInfo tag support. See the DASH content steering spec section 8.1.
 
     // This request URI accounts for manifest URIs that have been excluded.
-    const uri = this.getRequestURI(reloadUri);
+    const uri = initial ? reloadUri : this.getRequestURI(reloadUri);
 
     // If there are no valid manifest URIs, we should stop content steering.
     if (!uri) {
@@ -381,6 +380,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
    * aborts steering requests clears the ttl timeout and resets all properties.
    */
   dispose() {
+    this.off('content-steering');
+    this.off('error');
     this.abort();
     this.clearTTLTimeout_();
     this.currentPathway = null;
@@ -434,5 +435,9 @@ export default class ContentSteeringController extends videojs.EventTarget {
       newTag.defaultServiceLocation !== this.defaultPathway ||
       newTag.queryBeforeStart !== this.queryBeforeStart ||
       newTag.proxyServerURL !== this.proxyServerUrl_);
+  }
+
+  getAvailablePathways() {
+    return this.availablePathways_;
   }
 }

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -75,7 +75,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
 
     this.currentPathway = null;
     this.defaultPathway = null;
-    this.queryBeforeStart = null;
+    this.queryBeforeStart = false;
     this.availablePathways_ = new Set();
     this.excludedPathways_ = new Set();
     this.steeringManifest = new SteeringManifest();
@@ -92,7 +92,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
   /**
    * Assigns the content steering tag properties to the steering controller
    *
-   * @param {string} baseUrl the baseURL from the manifest for resolving the steering manifest url
+   * @param {string} baseUrl the baseURL from the main manifest for resolving the steering manifest url
    * @param {Object} steeringTag the content steering tag from the main manifest
    */
   assignTagProperties(baseUrl, steeringTag) {
@@ -110,23 +110,20 @@ export default class ContentSteeringController extends videojs.EventTarget {
       this.decodeDataUriManifest_(steeringUri.substring(steeringUri.indexOf(',') + 1));
       return;
     }
-    // With DASH queryBeforeStart, we want to use the steeringUri as soon as possible for the request.
-    this.steeringManifest.reloadUri = this.queryBeforeStart ? steeringUri : resolveUrl(baseUrl, steeringUri);
+
+    // reloadUri is the resolution of the main manifest URL and steering URL.
+    this.steeringManifest.reloadUri = resolveUrl(baseUrl, steeringUri);
     // pathwayId is HLS defaultServiceLocation is DASH
     this.defaultPathway = steeringTag.pathwayId || steeringTag.defaultServiceLocation;
     // currently only DASH supports the following properties on <ContentSteering> tags.
-    this.queryBeforeStart = steeringTag.queryBeforeStart || false;
-    this.proxyServerUrl_ = steeringTag.proxyServerURL || null;
+    this.queryBeforeStart = steeringTag.queryBeforeStart;
+    this.proxyServerUrl_ = steeringTag.proxyServerURL;
 
     // trigger a steering event if we have a pathway from the content steering tag.
     // this tells VHS which segment pathway to start with.
     // If queryBeforeStart is true we need to wait for the steering manifest response.
     if (this.defaultPathway && !this.queryBeforeStart) {
       this.trigger('content-steering');
-    }
-
-    if (this.queryBeforeStart) {
-      this.requestSteeringManifest(this.steeringManifest.reloadUri);
     }
   }
 
@@ -139,10 +136,10 @@ export default class ContentSteeringController extends videojs.EventTarget {
    *    This scenario is specific to DASH when the queryBeforeStart parameter is true.
    *    This scenario should only happen once on initalization.
    */
-  requestSteeringManifest(initialUri) {
+  requestSteeringManifest() {
     const reloadUri = this.steeringManifest.reloadUri;
 
-    if (!initialUri && !reloadUri) {
+    if (!reloadUri) {
       return;
     }
 
@@ -150,7 +147,7 @@ export default class ContentSteeringController extends videojs.EventTarget {
     // ExtUrlQueryInfo tag support. See the DASH content steering spec section 8.1.
 
     // This request URI accounts for manifest URIs that have been excluded.
-    const uri = initialUri || this.getRequestURI(reloadUri);
+    const uri = this.getRequestURI(reloadUri);
 
     // If there are no valid manifest URIs, we should stop content steering.
     if (!uri) {
@@ -196,8 +193,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
       }
       const steeringManifestJson = JSON.parse(this.request_.responseText);
 
-      this.startTTLTimeout_();
       this.assignSteeringProperties_(steeringManifestJson);
+      this.startTTLTimeout_();
     });
   }
 
@@ -384,8 +381,6 @@ export default class ContentSteeringController extends videojs.EventTarget {
    * aborts steering requests clears the ttl timeout and resets all properties.
    */
   dispose() {
-    this.off('content-steering');
-    this.off('error');
     this.abort();
     this.clearTTLTimeout_();
     this.currentPathway = null;
@@ -413,13 +408,31 @@ export default class ContentSteeringController extends videojs.EventTarget {
   }
 
   /**
-   * clears all pathways from the available pathways set
+   * Clears all pathways from the available pathways set
    */
   clearAvailablePathways() {
     this.availablePathways_.clear();
   }
 
+  /**
+   * Removes a pathway from the available pathways set.
+   */
   excludePathway(pathway) {
     return this.availablePathways_.delete(pathway);
+  }
+
+  /**
+   * Checks the refreshed DASH manifest content steering tag for changes.
+   *
+   * @param {string} baseURL new steering tag on DASH manifest refresh
+   * @param {Object} newTag the new tag to check for changes
+   * @return a true or false whether the new tag has different values
+   */
+  didDASHTagChange(baseURL, newTag) {
+    return !newTag && this.steeringManifest.reloadUri ||
+      resolveUrl(baseURL, newTag.serverURL) !== this.steeringManifest.reloadUri ||
+      newTag.defaultServiceLocation !== this.defaultPathway ||
+      newTag.queryBeforeStart !== this.queryBeforeStart ||
+      newTag.proxyServerURL !== this.proxyServerUrl_;
   }
 }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -325,10 +325,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
     // live playlist staleness timeout
     this.on('mediaupdatetimeout', () => {
-      // We handle live content steering in the playlist controller
-      if (!this.media().attributes.serviceLocation) {
-        this.refreshMedia_(this.media().id);
-      }
+      this.refreshMedia_(this.media().id);
     });
 
     this.state = 'HAVE_NOTHING';

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -608,6 +608,8 @@ export class PlaylistController extends videojs.EventTarget {
       let updatedPlaylist = this.mainPlaylistLoader_.media();
 
       if (!updatedPlaylist) {
+        // Add content steering listeners on first load and init.
+        this.attachContentSteeringListeners_();
         this.initContentSteeringController_();
         // exclude any variants that are not supported by the browser before selecting
         // an initial media as the playlist selectors do not consider browser support
@@ -2104,51 +2106,62 @@ export class PlaylistController extends videojs.EventTarget {
     });
   }
 
+  /**
+   * Utility for getting the pathway or service location from an HLS or DASH playlist.
+   *
+   * @param {Object} playlist for getting pathway from.
+   * @return the pathway attribute of a playlist
+   */
   pathwayAttribute_(playlist) {
     return playlist.attributes['PATHWAY-ID'] || playlist.attributes.serviceLocation;
   }
+
   /**
-   * Initialize content steering listeners and apply the tag properties.
+   * Initialize available pathways and apply the tag properties.
    */
   initContentSteeringController_() {
-    const initialMain = this.main();
+    const main = this.main();
 
-    if (!initialMain.contentSteering) {
+    if (!main.contentSteering) {
       return;
     }
-
-    const updateSteeringValues = (main) => {
-      for (const playlist of main.playlists) {
-        this.contentSteeringController_.addAvailablePathway(this.pathwayAttribute_(playlist));
-      }
-
-      this.contentSteeringController_.assignTagProperties(main.uri, main.contentSteering);
-    };
-
-    updateSteeringValues(initialMain);
-
-    this.contentSteeringController_.on('content-steering', this.excludeThenChangePathway_.bind(this));
-
-    // We need to ensure we update the content steering values when a new
-    // manifest is loaded in live DASH with content steering.
-    if (this.sourceType_ === 'dash') {
-      this.mainPlaylistLoader_.on('mediaupdatetimeout', () => {
-        this.mainPlaylistLoader_.refreshMedia_(this.mainPlaylistLoader_.media().id);
-
-        // clear past values
-        this.contentSteeringController_.abort();
-        this.contentSteeringController_.clearTTLTimeout_();
-        this.contentSteeringController_.clearAvailablePathways();
-
-        updateSteeringValues(this.main());
-      });
+    for (const playlist of main.playlists) {
+      this.contentSteeringController_.addAvailablePathway(this.pathwayAttribute_(playlist));
     }
+    this.contentSteeringController_.assignTagProperties(main.uri, main.contentSteering);
+    // request the steering manifest immediately if queryBeforeStart is set.
+    if (this.contentSteeringController_.queryBeforeStart) {
+      this.contentSteeringController_.requestSteeringManifest();
+      return;
+    }
+    // otherwise start content steering after playback starts
+    this.tech_.one('canplay', () => {
+      this.contentSteeringController_.requestSteeringManifest();
+    });
+  }
 
-    // Do this at startup only, after that the steering requests are managed by the Content Steering class.
-    // DASH queryBeforeStart scenarios will be handled by the Content Steering class.
-    if (!this.contentSteeringController_.queryBeforeStart) {
-      this.tech_.one('canplay', () => {
-        this.contentSteeringController_.requestSteeringManifest();
+  /**
+   * Reset the content steering controller and re-init.
+   */
+  resetContentSteeringController_() {
+    this.contentSteeringController_.clearAvailablePathways();
+    this.contentSteeringController_.dispose();
+    this.initContentSteeringController_();
+  }
+
+  /**
+   * Attaches the listeners for content steering.
+   */
+  attachContentSteeringListeners_() {
+    this.contentSteeringController_.on('content-steering', this.excludeThenChangePathway_.bind(this));
+    if (this.sourceType_ === 'dash') {
+      this.mainPlaylistLoader_.on('loadedplaylist', () => {
+        const main = this.main();
+        const didDashTagChange = this.contentSteeringController_.didDASHTagChange(main.uri, main.contentSteering);
+
+        if (didDashTagChange) {
+          this.resetContentSteeringController_();
+        }
       });
     }
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2173,9 +2173,10 @@ export class PlaylistController extends videojs.EventTarget {
                 return true;
               }
             }
-            if (!newPathways.length && availablePathways.size) {
-              return true;
-            }
+          }
+          // If we have no new serviceLocations and previously had availablePathways
+          if (!newPathways.length && availablePathways.size) {
+            return true;
           }
           return false;
         };

--- a/test/content-steering-controller.test.js
+++ b/test/content-steering-controller.test.js
@@ -194,6 +194,33 @@ QUnit.test('Can handle DASH proxyServerURL', function(assert) {
   assert.equal(this.requests[0].uri, expectedProxyUrl, 'returns expected proxy server URL');
 });
 
+QUnit.test('didDASHTagChange can check if a DASH content steering tag has changed', function(assert) {
+  const oldSteeringTag = {
+    serverURL: 'https://content.steering.dash/?old=params',
+    proxyServerURL: 'https://old.proxy.url',
+    defaultServiceLocation: 'old-dash-cdn'
+  };
+  const newSteeringTag = {
+    serverURL: 'https://content.steering.dash/?new=params',
+    proxyServerURL: 'https://new.proxy.url',
+    defaultServiceLocation: 'new-dash-cdn',
+    queryBeforeStart: true
+  };
+  const ommittedAttributes = {
+    serverURL: 'https://content.steering.dash/?old=params'
+  };
+
+  this.contentSteeringController.assignTagProperties(this.baseURL, oldSteeringTag);
+  assert.false(this.contentSteeringController.didDASHTagChange(this.baseURL, oldSteeringTag));
+  assert.true(this.contentSteeringController.didDASHTagChange(this.baseURL, newSteeringTag));
+  assert.true(this.contentSteeringController.didDASHTagChange(this.baseURL, ommittedAttributes));
+  this.contentSteeringController.dispose();
+  this.contentSteeringController.assignTagProperties(this.baseURL, ommittedAttributes);
+  assert.false(this.contentSteeringController.didDASHTagChange(this.baseURL, ommittedAttributes));
+  assert.true(this.contentSteeringController.didDASHTagChange(this.baseURL, newSteeringTag));
+  assert.true(this.contentSteeringController.didDASHTagChange(this.baseURL, oldSteeringTag));
+});
+
 // Common steering manifest tests
 QUnit.test('Can handle content steering manifest with VERSION', function(assert) {
   const steeringTag = {
@@ -269,7 +296,7 @@ QUnit.test('Can handle DASH content steering manifest with SERVICE-LOCATION-PRIO
 
 QUnit.test('Can handle DASH content steering manifest with PATHWAY-PRIORITY and tag with pathwayId', function(assert) {
   const steeringTag = {
-    serverUri: 'https://content.steering.hls',
+    serverUri: 'https://content.steering.dash',
     pathwayId: 'dash3'
   };
 

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -2821,62 +2821,6 @@ QUnit.test('pause does not remove minimum update period timeout when not main', 
   );
 });
 
-QUnit.test('Content Steering with Live DASH should NOT update media', function(assert) {
-  const mainLoader = new DashPlaylistLoader('dash-live.mpd', this.fakeVhs);
-
-  const refreshMediaSpy = sinon.stub(mainLoader, 'refreshMedia_');
-
-  mainLoader.load();
-  this.standardXHRResponse(this.requests.shift());
-  this.clock.tick(1);
-
-  const media = mainLoader.main.playlists[0];
-
-  mainLoader.media = () => media;
-
-  // This means content steering is active on the media.
-  media.attributes.serviceLocation = 'cdn-a';
-
-  mainLoader.media(media);
-
-  // This means there was a DASH live update.
-  mainLoader.trigger('mediaupdatetimeout');
-
-  // If refreshMedia_ is only called once, it means it was called on initialization,
-  // and is expected to be called later by the playlist controller.
-  assert.equal(
-    refreshMediaSpy.callCount,
-    1
-  );
-});
-
-QUnit.test('Live DASH without content steering should update media', function(assert) {
-  const mainLoader = new DashPlaylistLoader('dash-live.mpd', this.fakeVhs);
-
-  const refreshMediaSpy = sinon.stub(mainLoader, 'refreshMedia_');
-
-  mainLoader.load();
-  this.standardXHRResponse(this.requests.shift());
-  this.clock.tick(1);
-
-  const media = mainLoader.main.playlists[0];
-
-  mainLoader.media = () => media;
-
-  mainLoader.media(media);
-
-  // This means there was a DASH live update.
-  mainLoader.trigger('mediaupdatetimeout');
-
-  // If refreshMedia_ is called twice, it means it is was called on initialization,
-  // and later when there is a live update. This should all be handled by the
-  // playlist controller.
-  assert.equal(
-    refreshMediaSpy.callCount,
-    2
-  );
-});
-
 QUnit.test('updateMain: merges in top level timelineStarts', function(assert) {
   const prev = {
     timelineStarts: [0, 1],

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -6628,6 +6628,7 @@ QUnit.test('switch media on priority change for content steering', function(asse
 
   const switchMediaStub = sinon.stub(pc, 'switchMedia_');
 
+  pc.attachContentSteeringListeners_();
   pc.initContentSteeringController_();
 
   // Initially, cdn-a should be selected and there should be no media switch
@@ -6734,6 +6735,7 @@ QUnit.test('media group playlists should switch on steering change', function(as
   sinon.stub(pc, 'switchMedia_');
   const mediaSpy = sinon.spy(pc.mediaTypes_.AUDIO.activePlaylistLoader, 'media');
 
+  pc.attachContentSteeringListeners_();
   pc.initContentSteeringController_();
 
   const steeringManifestJson = {
@@ -6761,6 +6763,7 @@ QUnit.test('playlists should not change when there is no currentPathway', functi
   // Set up playlists
   pc.main = () => this.csMainPlaylist;
 
+  pc.attachContentSteeringListeners_();
   pc.initContentSteeringController_();
 
   // mimic there being no current pathway


### PR DESCRIPTION
## Description
This PR addresses a few content steering bugs and ads some additional testing around live DASH.

## Specific Changes proposed
Refactoring the content steering initialization to attach listeners separately, change some `queryBeforeStart` behavior and an issue with the initial `ttl` value.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
