### PR TITLE
feat: Content Steering HLS Pathway Cloning

### DIFF
--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -16,7 +16,7 @@ import videojs from 'video.js';
 class SteeringManifest {
   constructor() {
     this.priority_ = [];
-    this.pathwayClones_ = [];
+    this.pathwayClones_ = new Map();
   }
 
   set version(number) {
@@ -48,7 +48,7 @@ class SteeringManifest {
   set pathwayClones(array) {
     // pathwayClones must be non-empty.
     if (array && array.length) {
-      this.pathwayClones_ = array;
+      this.pathwayClones_ = new Map(array.map((clone) => [clone.ID, clone]));
     }
   }
 
@@ -95,8 +95,8 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.manifestType_ = null;
     this.ttlTimeout_ = null;
     this.request_ = null;
-    this.currentPathwayClones = [];
-    this.nextPathwayClones = [];
+    this.currentPathwayClones = new Map();
+    this.nextPathwayClones = new Map();
     this.excludedSteeringManifestURLs = new Set();
     this.logger_ = logger('Content Steering');
     this.xhr_ = xhr;

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -83,6 +83,43 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.manifestType_ = null;
     this.ttlTimeout_ = null;
     this.request_ = null;
+    this.pathwayClones = [
+      {
+        ['BASE-ID']: 'cdn-a',
+        ID: 'cdn-d',
+        ['URI-REPLACEMENT']: {
+          HOST: 'www.test.com',
+          PARAMS: {
+            test: 123
+          },
+          ['PER-VARIANT-URIS']: {},
+          ['PER-RENDITION-URIS']: {}
+        }
+      },
+      {
+        ['BASE-ID']: 'cdn-b',
+        ID: 'cdn-e',
+        ['URI-REPLACEMENT']: {
+          HOST: 'www.test2.com',
+          PARAMS: {
+
+          },
+          ['PER-VARIANT-URIS']: {},
+          ['PER-RENDITION-URIS']: {}
+        }
+      },
+      {
+        ['BASE-ID']: 'cdn-z',
+        ID: 'cdn-d',
+        ['URI-REPLACEMENT']: {
+          HOST: 'www.test.com',
+          PARAMS: {
+            ['PER-VARIANT-URIS']: {},
+            ['PER-RENDITION-URIS']: {}
+          }
+        }
+      }
+    ];
     this.excludedSteeringManifestURLs = new Set();
     this.logger_ = logger('Content Steering');
     this.xhr_ = xhr;
@@ -270,6 +307,9 @@ export default class ContentSteeringController extends videojs.EventTarget {
     // HLS = PATHWAY-PRIORITY required. DASH = SERVICE-LOCATION-PRIORITY optional
     this.steeringManifest.priority = steeringJson['PATHWAY-PRIORITY'] || steeringJson['SERVICE-LOCATION-PRIORITY'];
     // TODO: HLS handle PATHWAY-CLONES. See section 7.2 https://datatracker.ietf.org/doc/draft-pantos-hls-rfc8216bis/
+
+    // TODO: Get real pathway clones from content steering server.
+    // this.pathwayClones = steeringJson['PATHWAY-CLONES'];
 
     // 1. apply first pathway from the array.
     // 2. if first pathway doesn't exist in manifest, try next pathway.

--- a/src/content-steering-controller.js
+++ b/src/content-steering-controller.js
@@ -77,49 +77,51 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.defaultPathway = null;
     this.queryBeforeStart = null;
     this.availablePathways_ = new Set();
-    this.excludedPathways_ = new Set();
     this.steeringManifest = new SteeringManifest();
     this.proxyServerUrl_ = null;
     this.manifestType_ = null;
     this.ttlTimeout_ = null;
     this.request_ = null;
-    this.pathwayClones = [
-      {
-        ['BASE-ID']: 'cdn-a',
-        ID: 'cdn-d',
-        ['URI-REPLACEMENT']: {
-          HOST: 'www.test.com',
-          PARAMS: {
-            test: 123
-          },
-          ['PER-VARIANT-URIS']: {},
-          ['PER-RENDITION-URIS']: {}
-        }
-      },
-      {
-        ['BASE-ID']: 'cdn-b',
-        ID: 'cdn-e',
-        ['URI-REPLACEMENT']: {
-          HOST: 'www.test2.com',
-          PARAMS: {
+    this.currentPathwayClones = [];
+    this.nextPathwayClones = [];
+    // TODO: Delete this once tests are written.
+    // this.nextPathwayClones = [
+    //   {
+    //     ['BASE-ID']: 'cdn-a',
+    //     ID: 'cdn-d',
+    //     ['URI-REPLACEMENT']: {
+    //       HOST: 'www.test.com',
+    //       PARAMS: {
+    //         test: 123
+    //       },
+    //       ['PER-VARIANT-URIS']: {},
+    //       ['PER-RENDITION-URIS']: {}
+    //     }
+    //   },
+    //   {
+    //     ['BASE-ID']: 'cdn-b',
+    //     ID: 'cdn-e',
+    //     ['URI-REPLACEMENT']: {
+    //       HOST: 'www.test2.com',
+    //       PARAMS: {
 
-          },
-          ['PER-VARIANT-URIS']: {},
-          ['PER-RENDITION-URIS']: {}
-        }
-      },
-      {
-        ['BASE-ID']: 'cdn-z',
-        ID: 'cdn-d',
-        ['URI-REPLACEMENT']: {
-          HOST: 'www.test.com',
-          PARAMS: {
-            ['PER-VARIANT-URIS']: {},
-            ['PER-RENDITION-URIS']: {}
-          }
-        }
-      }
-    ];
+    //       },
+    //       ['PER-VARIANT-URIS']: {},
+    //       ['PER-RENDITION-URIS']: {}
+    //     }
+    //   },
+    //   {
+    //     ['BASE-ID']: 'cdn-z',
+    //     ID: 'cdn-x',
+    //     ['URI-REPLACEMENT']: {
+    //       HOST: 'www.test.com',
+    //       PARAMS: {
+    //         ['PER-VARIANT-URIS']: {},
+    //         ['PER-RENDITION-URIS']: {}
+    //       }
+    //     }
+    //   }
+    // ];
     this.excludedSteeringManifestURLs = new Set();
     this.logger_ = logger('Content Steering');
     this.xhr_ = xhr;
@@ -306,10 +308,10 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.steeringManifest.reloadUri = steeringJson['RELOAD-URI'];
     // HLS = PATHWAY-PRIORITY required. DASH = SERVICE-LOCATION-PRIORITY optional
     this.steeringManifest.priority = steeringJson['PATHWAY-PRIORITY'] || steeringJson['SERVICE-LOCATION-PRIORITY'];
-    // TODO: HLS handle PATHWAY-CLONES. See section 7.2 https://datatracker.ietf.org/doc/draft-pantos-hls-rfc8216bis/
 
-    // TODO: Get real pathway clones from content steering server.
-    // this.pathwayClones = steeringJson['PATHWAY-CLONES'];
+    // Pathway clones to be created/updated in HLS.
+    // See section 7.2 https://datatracker.ietf.org/doc/draft-pantos-hls-rfc8216bis/
+    this.nextPathwayClones = steeringJson['PATHWAY-CLONES'];
 
     // 1. apply first pathway from the array.
     // 2. if first pathway doesn't exist in manifest, try next pathway.
@@ -437,7 +439,6 @@ export default class ContentSteeringController extends videojs.EventTarget {
     this.request_ = null;
     this.excludedSteeringManifestURLs = new Set();
     this.availablePathways_ = new Set();
-    this.excludedPathways_ = new Set();
     this.steeringManifest = new SteeringManifest();
   }
 

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -11,7 +11,7 @@ export const createPlaylistID = (index, uri) => {
 };
 
 // default function for creating a group id
-const groupID = (type, group, label) => {
+export const groupID = (type, group, label) => {
   return `placeholder-uri-${type}-${group}-${label}`;
 };
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2163,13 +2163,7 @@ export class PlaylistController extends videojs.EventTarget {
       return;
     }
 
-    const pastClones = this.contentSteeringController_.currentPathwayClones;
-    const nextClones = this.contentSteeringController_.nextPathwayClones;
-    const hasClones = (pastClones && pastClones.size) || (nextClones && nextClones.size);
-
-    if (hasClones) {
-      this.handlePathwayClones_();
-    }
+    this.handlePathwayClones_();
 
     const main = this.main();
     const playlists = main.playlists;
@@ -2235,6 +2229,12 @@ export class PlaylistController extends videojs.EventTarget {
     const playlists = main.playlists;
     const currentPathwayClones = this.contentSteeringController_.currentPathwayClones;
     const nextPathwayClones = this.contentSteeringController_.nextPathwayClones;
+
+    const hasClones = (currentPathwayClones && currentPathwayClones.size) || (nextPathwayClones && nextPathwayClones.size);
+
+    if (!hasClones) {
+      return;
+    }
 
     for (const [id, clone] of currentPathwayClones.entries()) {
       const newClone = nextPathwayClones.get(id);

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2225,6 +2225,7 @@ export class PlaylistController extends videojs.EventTarget {
    * the pathway clones for HLS Content Steering.
    *
    * See https://datatracker.ietf.org/doc/draft-pantos-hls-rfc8216bis/
+   *
    * NOTE: Pathway cloning does not currently support the `PER_VARIANT_URIS` and
    * `PER_RENDITION_URIS` as we do not handle `STABLE-VARIANT-ID` or
    * `STABLE-RENDITION-ID` values.

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2252,7 +2252,7 @@ export class PlaylistController extends videojs.EventTarget {
         });
 
         playlistsToClone.forEach((p) => {
-          this.mainPlaylistLoader_.clonePathway(clone, p);
+          this.mainPlaylistLoader_.addClonePathway(clone, p);
         });
 
         this.contentSteeringController_.addAvailablePathway(clone.ID);
@@ -2266,7 +2266,7 @@ export class PlaylistController extends videojs.EventTarget {
       // Update a preexisting cloned pathway.
       // True is set for the update flag.
       this.mainPlaylistLoader_.updateOrDeleteClone(clone, true);
-
+      this.contentSteeringController_.addAvailablePathway(clone.ID);
     });
 
     // Deep copy contents of next to current pathways.

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2225,6 +2225,9 @@ export class PlaylistController extends videojs.EventTarget {
    * the pathway clones for HLS Content Steering.
    *
    * See https://datatracker.ietf.org/doc/draft-pantos-hls-rfc8216bis/
+   * NOTE: Pathway cloning does not currently support the `PER_VARIANT_URIS` and
+   * `PER_RENDITION_URIS` as we do not handle `STABLE-VARIANT-ID` or
+   * `STABLE-RENDITION-ID` values.
    */
   handlePathwayClones_() {
     const main = this.main();

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -932,11 +932,12 @@ export default class PlaylistLoader extends EventTarget {
   }
 
   /**
-   * Updates or deletes a prexisting pathway clone.
+   * Updates or deletes a preexisting pathway clone.
    * Ensures that all playlists related to the old pathway clone are
    * either updated or deleted.
    *
-   * @param {Object} clone The pathway clone object for the newly updated pathway clone.
+   * @param {Object} clone On update, the pathway clone object for the newly updated pathway clone.
+   *        On delete, the old pathway clone object to be deleted.
    * @param {boolean} isUpdate True if the pathway is to be updated,
    *        false if it is meant to be deleted.
    */
@@ -1032,7 +1033,7 @@ export default class PlaylistLoader extends EventTarget {
    * @param {Object} clone The pathway clone object.
    * @param {Object} basePlaylist The original playlist to clone from.
    */
-  clonePathway(clone, basePlaylist = {}) {
+  addClonePathway(clone, basePlaylist = {}) {
     const main = this.main;
     const index = main.playlists.length;
     const uri = this.createCloneURI_(basePlaylist.resolvedUri, clone);
@@ -1048,8 +1049,6 @@ export default class PlaylistLoader extends EventTarget {
     main.playlists[uri] = playlist;
 
     this.createClonedMediaGroups_(clone);
-
-    return this.main;
   }
 
   /**

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -6745,7 +6745,8 @@ QUnit.test('Pathway cloning - add a new pathway when the clone has not existed',
     ['RELOAD-URI']: 'https://fastly-server.content-steering.com/dash.dcsm',
     ['PATHWAY-PRIORITY']: [
       'cdn-b',
-      'cdn-a'
+      'cdn-a',
+      'cdn-z'
     ],
     ['PATHWAY-CLONES']: [clone]
   };
@@ -6757,8 +6758,12 @@ QUnit.test('Pathway cloning - add a new pathway when the clone has not existed',
   assert.equal(addCloneStub.getCall(0).args[0], clone);
   assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
 
+  const cloneMap = new Map();
+
+  cloneMap.set(clone.ID, clone);
+
   // Ensure we set the current pathway clones from next.
-  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [clone]);
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones.get('cdn-z'), cloneMap.get('cdn-z'));
 });
 
 QUnit.test('Pathway cloning - update the pathway when the BASE-ID does not match', function(assert) {
@@ -6802,7 +6807,8 @@ QUnit.test('Pathway cloning - update the pathway when the BASE-ID does not match
     }
   };
 
-  pc.contentSteeringController_.currentPathwayClones = [pastClone];
+  pc.contentSteeringController_.currentPathwayClones = new Map();
+  pc.contentSteeringController_.currentPathwayClones.set(pastClone.ID, pastClone);
 
   const steeringManifestJson = {
     VERSION: 1,
@@ -6823,8 +6829,12 @@ QUnit.test('Pathway cloning - update the pathway when the BASE-ID does not match
   assert.equal(updateCloneStub.getCall(0).args[1], true);
   assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
 
+  const nextClonesMap = new Map();
+
+  nextClonesMap.set(nextClone.ID, nextClone);
+
   // Ensure we set the current pathway clones from next.
-  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [nextClone]);
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, nextClonesMap);
 });
 
 QUnit.test('Pathway cloning - update the pathway when there is a new param', function(assert) {
@@ -6869,7 +6879,8 @@ QUnit.test('Pathway cloning - update the pathway when there is a new param', fun
     }
   };
 
-  pc.contentSteeringController_.currentPathwayClones = [pastClone];
+  pc.contentSteeringController_.currentPathwayClones = new Map();
+  pc.contentSteeringController_.currentPathwayClones.set(pastClone.ID, pastClone);
 
   const steeringManifestJson = {
     VERSION: 1,
@@ -6891,8 +6902,12 @@ QUnit.test('Pathway cloning - update the pathway when there is a new param', fun
   assert.equal(updateCloneStub.getCall(0).args[1], true);
   assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
 
+  const nextClonesMap = new Map();
+
+  nextClonesMap.set(nextClone.ID, nextClone);
+
   // Ensure we set the current pathway clones from next.
-  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [nextClone]);
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, nextClonesMap);
 });
 
 QUnit.test('Pathway cloning - update the pathway when a param is missing', function(assert) {
@@ -6934,7 +6949,8 @@ QUnit.test('Pathway cloning - update the pathway when a param is missing', funct
     }
   };
 
-  pc.contentSteeringController_.currentPathwayClones = [pastClone];
+  pc.contentSteeringController_.currentPathwayClones = new Map();
+  pc.contentSteeringController_.currentPathwayClones.set(pastClone.ID, pastClone);
 
   const steeringManifestJson = {
     VERSION: 1,
@@ -6956,8 +6972,12 @@ QUnit.test('Pathway cloning - update the pathway when a param is missing', funct
   assert.equal(updateCloneStub.getCall(0).args[1], true);
   assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
 
+  const nextClonesMap = new Map();
+
+  nextClonesMap.set(nextClone.ID, nextClone);
+
   // Ensure we set the current pathway clones from next.
-  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [nextClone]);
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, nextClonesMap);
 });
 
 QUnit.test('Pathway cloning - delete the pathway when it is no longer in the steering response', function(assert) {
@@ -6990,7 +7010,8 @@ QUnit.test('Pathway cloning - delete the pathway when it is no longer in the ste
     }
   };
 
-  pc.contentSteeringController_.currentPathwayClones = [pastClone];
+  pc.contentSteeringController_.currentPathwayClones = new Map();
+  pc.contentSteeringController_.currentPathwayClones.set(pastClone.ID, pastClone);
 
   const steeringManifestJson = {
     VERSION: 1,
@@ -7014,7 +7035,7 @@ QUnit.test('Pathway cloning - delete the pathway when it is no longer in the ste
   // The value is no longer in the available pathways.
   assert.equal(!pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
 
-  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, []);
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, new Map());
 });
 
 QUnit.test('Pathway cloning - do nothing when next and past clones are the same', function(assert) {
@@ -7048,7 +7069,8 @@ QUnit.test('Pathway cloning - do nothing when next and past clones are the same'
     }
   };
 
-  pc.contentSteeringController_.currentPathwayClones = [clone];
+  pc.contentSteeringController_.currentPathwayClones = new Map();
+  pc.contentSteeringController_.currentPathwayClones.set(clone.ID, clone);
 
   const steeringManifestJson = {
     VERSION: 1,
@@ -7062,7 +7084,7 @@ QUnit.test('Pathway cloning - do nothing when next and past clones are the same'
     ['PATHWAY-CLONES']: [clone]
   };
 
-  // By adding this we are saying that the pathway was previosuly available.
+  // By adding this we are saying that the pathway was previously available.
   pc.contentSteeringController_.addAvailablePathway('cdn-z');
 
   // This triggers `handlePathwayClones()`.
@@ -7075,5 +7097,9 @@ QUnit.test('Pathway cloning - do nothing when next and past clones are the same'
   // The value is still in the available pathways.
   assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
 
-  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [clone]);
+  const clonesMap = new Map();
+
+  clonesMap.set(clone.ID, clone);
+
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, clonesMap);
 });

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -6708,3 +6708,239 @@ QUnit.test('playlists should not change when there is no currentPathway', functi
   // media is never switched
   assert.notOk(switchMediaSpy.called);
 });
+
+QUnit.test('Pathway cloning - add a new pathway when the clone has not existed', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'hls'
+  };
+
+  const pc = new PlaylistController(options);
+
+  this.csMainPlaylist.playlists.forEach(p => {
+    p.attributes['PATHWAY-ID'] = p.attributes.serviceLocation;
+    p.attributes.serviceLocation = undefined;
+  });
+
+  pc.main = () => this.csMainPlaylist;
+  pc.initContentSteeringController_();
+
+  const addCloneStub = sinon.stub(pc.mainPlaylistLoader_, 'addClonePathway');
+
+  const clone = {
+    ID: 'cdn-z',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-z.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  const steeringManifestJson = {
+    VERSION: 1,
+    TTL: 10,
+    ['RELOAD-URI']: 'https://fastly-server.content-steering.com/dash.dcsm',
+    ['PATHWAY-PRIORITY']: [
+      'cdn-b',
+      'cdn-a'
+    ],
+    ['PATHWAY-CLONES']: [clone]
+  };
+
+  // This triggers `handlePathwayClones_()`
+  pc.contentSteeringController_.assignSteeringProperties_(steeringManifestJson);
+
+  // Assert that we add a clone and it is added to the available pathways If not already.
+  assert.equal(addCloneStub.getCall(0).args[0], clone);
+  assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
+
+  // Ensure we set the current pathway clones from next.
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [clone]);
+});
+
+QUnit.test('Pathway cloning - update the pathway when the current and next clones do not match', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'hls'
+  };
+
+  const pc = new PlaylistController(options);
+
+  this.csMainPlaylist.playlists.forEach(p => {
+    p.attributes['PATHWAY-ID'] = p.attributes.serviceLocation;
+    p.attributes.serviceLocation = undefined;
+  });
+
+  pc.main = () => this.csMainPlaylist;
+  pc.initContentSteeringController_();
+
+  const updateCloneStub = sinon.stub(pc.mainPlaylistLoader_, 'updateOrDeleteClone');
+
+  const pastClone = {
+    ID: 'cdn-z',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-z.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  const nextClone = {
+    ID: 'cdn-z',
+    ['BASE-ID']: 'cdn-b',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-b.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  pc.contentSteeringController_.currentPathwayClones = [pastClone];
+
+  const steeringManifestJson = {
+    VERSION: 1,
+    TTL: 10,
+    ['RELOAD-URI']: 'https://fastly-server.content-steering.com/dash.dcsm',
+    ['PATHWAY-PRIORITY']: [
+      'cdn-b',
+      'cdn-a'
+    ],
+    ['PATHWAY-CLONES']: [nextClone]
+  };
+
+  // This triggers `handlePathwayClones()`.
+  pc.contentSteeringController_.assignSteeringProperties_(steeringManifestJson);
+
+  // Assert that we update the clone and it is still in the available pathways.
+  assert.equal(updateCloneStub.getCall(0).args[0], nextClone);
+  assert.equal(updateCloneStub.getCall(0).args[1], true);
+  assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
+
+  // Ensure we set the current pathway clones from next.
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [nextClone]);
+});
+
+QUnit.test('Pathway cloning - delete the pathway when it is no longer in the steering response', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'hls'
+  };
+
+  const pc = new PlaylistController(options);
+
+  this.csMainPlaylist.playlists.forEach(p => {
+    p.attributes['PATHWAY-ID'] = p.attributes.serviceLocation;
+    p.attributes.serviceLocation = undefined;
+  });
+
+  pc.main = () => this.csMainPlaylist;
+  pc.initContentSteeringController_();
+
+  const updateCloneStub = sinon.stub(pc.mainPlaylistLoader_, 'updateOrDeleteClone');
+
+  const pastClone = {
+    ID: 'cdn-z',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-z.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  pc.contentSteeringController_.currentPathwayClones = [pastClone];
+
+  const steeringManifestJson = {
+    VERSION: 1,
+    TTL: 10,
+    ['RELOAD-URI']: 'https://fastly-server.content-steering.com/dash.dcsm',
+    ['PATHWAY-PRIORITY']: [
+      'cdn-b',
+      'cdn-a'
+    ],
+    // empty response
+    ['PATHWAY-CLONES']: []
+  };
+
+  // This triggers `handlePathwayClones()`.
+  pc.contentSteeringController_.assignSteeringProperties_(steeringManifestJson);
+
+  // Assert that we update the clone and it is still in the available pathways.
+  assert.equal(updateCloneStub.getCall(0).args[0], pastClone);
+  // undefined means we are deleting.
+  assert.equal(updateCloneStub.getCall(0).args[1], undefined);
+  // The value is no longer in the available pathways.
+  assert.equal(!pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
+
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, []);
+});
+
+QUnit.test('Pathway cloning - do nothing when next and past clones are the same', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'hls'
+  };
+
+  const pc = new PlaylistController(options);
+
+  this.csMainPlaylist.playlists.forEach(p => {
+    p.attributes['PATHWAY-ID'] = p.attributes.serviceLocation;
+    p.attributes.serviceLocation = undefined;
+  });
+
+  pc.main = () => this.csMainPlaylist;
+  pc.initContentSteeringController_();
+
+  const addCloneStub = sinon.stub(pc.mainPlaylistLoader_, 'addClonePathway');
+  const updateCloneStub = sinon.stub(pc.mainPlaylistLoader_, 'updateOrDeleteClone');
+
+  const clone = {
+    ID: 'cdn-z',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-z.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  pc.contentSteeringController_.currentPathwayClones = [clone];
+
+  const steeringManifestJson = {
+    VERSION: 1,
+    TTL: 10,
+    ['RELOAD-URI']: 'https://fastly-server.content-steering.com/dash.dcsm',
+    ['PATHWAY-PRIORITY']: [
+      'cdn-b',
+      'cdn-a',
+      'cdn-z'
+    ],
+    ['PATHWAY-CLONES']: [clone]
+  };
+
+  // By adding this we are saying that the pathway was previosuly available.
+  pc.contentSteeringController_.addAvailablePathway('cdn-z');
+
+  // This triggers `handlePathwayClones()`.
+  pc.contentSteeringController_.assignSteeringProperties_(steeringManifestJson);
+
+  // Assert that we do not add, update, or delete any pathway clones.
+  assert.equal(addCloneStub.callCount, 0);
+  assert.equal(updateCloneStub.callCount, 0);
+
+  // The value is still in the available pathways.
+  assert.equal(pc.contentSteeringController_.availablePathways_.has('cdn-z'), true);
+
+  assert.deepEqual(pc.contentSteeringController_.currentPathwayClones, [clone]);
+});

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -2887,3 +2887,233 @@ QUnit.module('Playlist Loader', function(hooks) {
     assert.strictEqual(addDateRangesToTextTrackSpy.callCount, 1);
   });
 });
+
+QUnit.module('Pathway Cloning', {
+  before() {
+    this.fakeVhs = {
+      xhr: xhrFactory()
+    };
+    this.loader = new PlaylistLoader('http://example.com/media.m3u8', this.fakeVhs);
+
+    this.loader.load();
+
+    // Setup video playlists and media groups/playlists
+
+    const videoUri = '//test.com/playlist.m3u8';
+    const videoId = `0-${videoUri}`;
+    const videoPlaylist = {
+      attributes: {
+        ['PATHWAY-ID']: 'cdn-a',
+        AUDIO: 'cdn-a',
+        BANDWIDTH: 9,
+        CODECS: 'avc1.640028,mp4a.40.2'
+      },
+      id: videoId,
+      uri: videoUri,
+      resolvedUri: 'https://test.com/playlist.m3u8',
+      segments: []
+    };
+
+    const audioUri = 'https://test.com/audio_128kbps/playlist.m3u8';
+    const audioId = '0-placeholder-uri-AUDIO-cdn-a-English';
+    const audioPlaylist = {
+      attributes: {},
+      autoselect: true,
+      default: false,
+      id: audioId,
+      language: 'en',
+      uri: audioUri,
+      resolvedUri: audioUri
+    };
+
+    this.loader.main = {
+      mediaGroups: {
+        AUDIO: {
+          'cdn-a': {
+            English: {
+              autoselect: true,
+              default: false,
+              language: 'en',
+              resolvedUri: audioUri,
+              uri: audioUri,
+              playlists: [audioPlaylist]
+            }
+          }
+        }
+      },
+      playlists: [videoPlaylist]
+    };
+
+    // link all playlists by ID and URI
+    this.loader.main.playlists[videoId] = videoPlaylist;
+    this.loader.main.playlists[videoUri] = videoPlaylist;
+    this.loader.main.playlists[audioId] = audioPlaylist;
+    this.loader.main.playlists[audioUri] = audioPlaylist;
+  },
+  after() {
+    this.loader.dispose();
+  }
+});
+
+QUnit.test('add a new pathway clone', function(assert) {
+  // The cloned pathway already exists due to the previous test.
+
+  const clone = {
+    ID: 'cdn-b',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-b.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  const videoUri = 'https://www.cdn-b.com/playlist.m3u8?test=123';
+  const videoId = `cdn-b-${videoUri}`;
+  const expectedVideoPlaylist = {
+    attributes: {
+      AUDIO: 'cdn-b',
+      BANDWIDTH: 9,
+      CODECS: 'avc1.640028,mp4a.40.2',
+      ['PATHWAY-ID']: 'cdn-b'
+    },
+    id: videoId,
+    resolvedUri: videoUri,
+    segments: [],
+    uri: videoUri
+  };
+
+  const audioUri = 'https://www.cdn-b.com/audio_128kbps/playlist.m3u8?test=123';
+  const audioId = 'cdn-b-placeholder-uri-AUDIO-cdn-b-English';
+  const expectedAudioPlaylist = {
+    attributes: {},
+    autoselect: true,
+    default: false,
+    id: audioId,
+    language: 'en',
+    resolvedUri: audioUri,
+    uri: audioUri
+  };
+
+  const expectedMediaGroup = {
+    English: {
+      autoselect: true,
+      default: false,
+      language: 'en',
+      playlists: [expectedAudioPlaylist],
+      resolvedUri: audioUri,
+      uri: audioUri
+    }
+  };
+
+  this.loader.addClonePathway(clone, this.loader.main.playlists[0]);
+
+  assert.deepEqual(this.loader.main.playlists[1], expectedVideoPlaylist);
+  assert.deepEqual(this.loader.main.playlists[videoUri], expectedVideoPlaylist);
+  assert.deepEqual(this.loader.main.playlists[videoId], expectedVideoPlaylist);
+
+  assert.deepEqual(this.loader.main.playlists[audioId], expectedAudioPlaylist);
+  assert.deepEqual(this.loader.main.playlists[audioUri], expectedAudioPlaylist);
+  assert.deepEqual(this.loader.main.mediaGroups.AUDIO['cdn-b'], expectedMediaGroup);
+});
+
+QUnit.test('update the pathway clone', function(assert) {
+  // The cloned pathway already exists due to the previous test.
+
+  // The old clone to be deleted.
+  const clone = {
+    ID: 'cdn-b',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.newurl.com',
+      PARAMS: {
+        test: 'updatedValue'
+      }
+    }
+  };
+
+  // These values have been updated.
+  const videoUri = 'https://www.newurl.com/playlist.m3u8?test=updatedValue';
+  const videoId = `cdn-b-${videoUri}`;
+  const expectedVideoPlaylist = {
+    attributes: {
+      AUDIO: 'cdn-b',
+      BANDWIDTH: 9,
+      CODECS: 'avc1.640028,mp4a.40.2',
+      ['PATHWAY-ID']: 'cdn-b'
+    },
+    id: videoId,
+    resolvedUri: videoUri,
+    segments: [],
+    uri: videoUri
+  };
+
+  // These values have been updated.
+  const audioUri = 'https://www.newurl.com/audio_128kbps/playlist.m3u8?test=updatedValue';
+  const audioId = 'cdn-b-placeholder-uri-AUDIO-cdn-b-English';
+  const expectedAudioPlaylist = {
+    attributes: {},
+    autoselect: true,
+    default: false,
+    id: audioId,
+    language: 'en',
+    resolvedUri: audioUri,
+    uri: audioUri
+  };
+
+  const expectedMediaGroup = {
+    English: {
+      autoselect: true,
+      default: false,
+      language: 'en',
+      playlists: [expectedAudioPlaylist],
+      resolvedUri: audioUri,
+      uri: audioUri
+    }
+  };
+
+  // set the flag to true to ensure we update.
+  this.loader.updateOrDeleteClone(clone, true);
+
+  assert.deepEqual(this.loader.main.playlists[1], expectedVideoPlaylist);
+  assert.deepEqual(this.loader.main.playlists[videoUri], expectedVideoPlaylist);
+  assert.deepEqual(this.loader.main.playlists[videoId], expectedVideoPlaylist);
+
+  assert.deepEqual(this.loader.main.playlists[audioId], expectedAudioPlaylist);
+  assert.deepEqual(this.loader.main.playlists[audioUri], expectedAudioPlaylist);
+  assert.deepEqual(this.loader.main.mediaGroups.AUDIO['cdn-b'], expectedMediaGroup);
+});
+
+QUnit.test('delete the pathway clone', function(assert) {
+  // The old clone to be deleted.
+  const clone = {
+    ID: 'cdn-b',
+    ['BASE-ID']: 'cdn-a',
+    ['URI-REPLACEMENT']: {
+      HOST: 'www.cdn-b.com',
+      PARAMS: {
+        test: 123
+      }
+    }
+  };
+
+  // the playlist exists before the deletion.
+  assert.deepEqual(this.loader.main.playlists[1].attributes['PATHWAY-ID'], 'cdn-b');
+
+  const videoUri = 'https://www.cdn-b.com/playlist.m3u8?test=123';
+  const videoId = `cdn-b-${videoUri}`;
+  const audioUri = 'https://www.cdn-b.com/audio_128kbps/playlist.m3u8?test=123';
+  const audioId = 'cdn-b-placeholder-uri-AUDIO-cdn-b-English';
+
+  // set the flag to false to ensure we delete.
+  this.loader.updateOrDeleteClone(clone, false);
+
+  assert.deepEqual(this.loader.main.playlists[1], undefined);
+  assert.deepEqual(this.loader.main.playlists[videoUri], undefined);
+  assert.deepEqual(this.loader.main.playlists[videoId], undefined);
+
+  assert.deepEqual(this.loader.main.playlists[audioId], undefined);
+  assert.deepEqual(this.loader.main.playlists[audioUri], undefined);
+  assert.deepEqual(this.loader.main.mediaGroups.AUDIO['cdn-b'], undefined);
+});

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -2938,7 +2938,9 @@ QUnit.module('Pathway Cloning', {
               uri: audioUri,
               playlists: [audioPlaylist]
             }
-          }
+          },
+          // Ensures we hit the code where we skip this.
+          'cdn-other': {}
         }
       },
       playlists: [videoPlaylist]


### PR DESCRIPTION
## Description
Implementation for HLS Pathway cloning for content steering. See the spec here: https://datatracker.ietf.org/doc/draft-pantos-hls-rfc8216bis/

Whenever we get a response from the content server with a `PATHWAY-CLONES` array, we need to add, update, or delete playlists and media based on the data we receive. A pathway clone object tells us information about a new pathway that should be created/updated based off of another pathway.

## Specific Changes proposed
- Store the pathway cloning data retrieved from the server reponse in the content steering controlelr.
- Add a new pathway with playlist and media data when the pathway clone did not exist previously.
- Update playlist and media data from a previously existing pathway clone when we get new data from the pathway clone object.
- Delete playlist and media data from a pathway clone that is no longer in the content steering server response.
- Unit tests for this functionality.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
