### PR TITLE
Clamp seekable end

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -391,11 +391,17 @@ export const playlistEnd = function(playlist, expired, useSafeLiveEnd, liveEdgeP
 export const seekable = function(playlist, expired, liveEdgePadding) {
   const useSafeLiveEnd = true;
   const seekableStart = expired || 0;
-  const seekableEnd = playlistEnd(playlist, expired, useSafeLiveEnd, liveEdgePadding);
+  let seekableEnd = playlistEnd(playlist, expired, useSafeLiveEnd, liveEdgePadding);
 
   if (seekableEnd === null) {
     return createTimeRanges();
   }
+
+  // Clamp seekable end since it can not be less than the seekable start
+  if (seekableEnd < seekableStart) {
+    seekableEnd = seekableStart;
+  }
+
   return createTimeRanges(seekableStart, seekableEnd);
 };
 

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -616,6 +616,45 @@ QUnit.module('Playlist', function() {
       playlist = {
         targetDuration: 10,
         mediaSequence: 100,
+        syncInfo: {
+          time: 50,
+          mediaSequence: 95
+        },
+        segments: [
+          {
+            duration: 9.01,
+            uri: '0.ts'
+          },
+          {
+            duration: 9.01,
+            uri: '1.ts'
+          },
+          {
+            duration: 9.01,
+            uri: '2.ts'
+          },
+        ]
+      };
+
+      seekable = Playlist.seekable(playlist, 100);
+      playlistEnd = Playlist.playlistEnd(playlist, 100);
+
+      assert.ok(seekable.length, 'seekable range calculated');
+      assert.equal(
+        seekable.start(0),
+        100,
+        'estimated start time based on expired sync point'
+      );
+      assert.equal(
+        seekable.end(0),
+        100,
+        'seekable end is clamped to start time'
+      );
+      assert.equal(playlistEnd, 127.03, 'playlist end at the last segment end');
+
+      playlist = {
+        targetDuration: 10,
+        mediaSequence: 100,
         segments: [
           {
             duration: 10,

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -632,7 +632,7 @@ QUnit.module('Playlist', function() {
           {
             duration: 9.01,
             uri: '2.ts'
-          },
+          }
         ]
       };
 


### PR DESCRIPTION
## Description

We have default `liveEdgePadding` as 3 * targetDuration. 
Assume we have a stream with a maximum of three segments. 
Each segment's actual duration is less than a `targetDuration`. 
In this scenario, we may have a `seekable.end` less than a `seekable.start`. 
This may lead to unexpected behavior.


## Specific Changes proposed
Clamp `seekable.end` to make sure that it is more or equal to `seekable start`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
