### PR TITLE
fix: fmp4 captions regression

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -500,7 +500,7 @@ const handleSegmentBytes = ({
 
             // Run through the CaptionParser in case there are captions.
             // Initialize CaptionParser if it hasn't been yet
-            if (!tracks.video || !data.byteLength || !segment.transmuxer) {
+            if (!tracks.video || !emsgData.byteLength || !segment.transmuxer) {
               finishLoading(undefined, id3Frames);
               return;
             }


### PR DESCRIPTION
## Description
Fixes an issue where caption data wasn't being passed out to the transmuxer callback for parsing.

## Specific Changes proposed
Use the correctly scoped data object.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
