### PR TITLE
fix regression: prevent wrapping in resetMainLoaderReplaceSegments

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -981,7 +981,7 @@ export class PlaylistController extends videojs.EventTarget {
    */
   resetMainLoaderReplaceSegments() {
     const buffered = this.tech_.buffered();
-    const bufferedEnd = buffered.end(buffered.length - 1);
+    const bufferedEnd = buffered.length ? buffered.end(buffered.length - 1) : 0;
 
     // Set the replace segments flag to the buffered end, this forces fetchAtBuffer
     // on the main loader to remain, false after the resetLoader call, until we have


### PR DESCRIPTION
This fixes a regression introduced in 4590bdd05aa2dd59bb2b60ce86daf453a093fba0

If the quality is changed during initialization, this function is called. Since `buffered.length` is zero and `buffered` is a [TimeRanges](https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges), `length` (an `unsigned long`) wraps around and becomes `4294967295`

```
PsVideo.ts:462 DOMException: Failed to execute 'end' on 'TimeRanges': The index provided (4294967295) is greater than the maximum bound (0).
    at PlaylistController.resetMainLoaderReplaceSegments (http://localhost:8035/apps/memories/js/memories-vendors-node_modules_plyr_dist_plyr_css-node_modules_video_js_dist_video-js_min_css-node_modu-82e78d.js?v=7e8851a5e7ef114c9398:65070:34)
    at PlaylistController.fastQualityChange_ (http://localhost:8035/apps/memories/js/memories-vendors-node_modules_plyr_dist_plyr_css-node_modules_video_js_dist_video-js_min_css-node_modu-82e78d.js?v=7e8851a5e7ef114c9398:65060:10)
    at QualityLevel.enabled_ (http://localhost:8035/apps/memories/js/memories-vendors-node_modules_plyr_dist_plyr_css-node_modules_video_js_dist_video-js_min_css-node_modu-82e78d.js?v=7e8851a5e7ef114c9398:66129:5)
    at QualityLevel.set (http://localhost:8035/apps/memories/js/memories-vendors-node_modules_plyr_dist_plyr_css-node_modules_video_js_dist_video-js_min_css-node_modu-82e78d.js?v=7e8851a5e7ef114c9398:42975:15)
    at VideoContentSetup.changeQuality (http://localhost:8035/apps/memories/js/memories-main.js:60373:40)
```
