### PR TITLE
feat: Public function for updating VHS options

### DIFF
--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -678,7 +678,15 @@ class VhsHandler extends Component {
     this.on(this.tech_, 'play', this.play);
   }
 
-  setOptions_() {
+  /**
+   * Set VHS options based on options from configuration, as well as partial
+   * options to be passed at a later time.
+   *
+   * @param {Object} options A partial chunk of config options
+   */
+  setOptions_(options = {}) {
+    this.options_ = merge(this.options_, options);
+
     // defaults
     this.options_.withCredentials = this.options_.withCredentials || false;
     this.options_.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions === false ? false : true;
@@ -755,6 +763,10 @@ class VhsHandler extends Component {
 
     this.limitRenditionByPlayerDimensions = this.options_.limitRenditionByPlayerDimensions;
     this.useDevicePixelRatio = this.options_.useDevicePixelRatio;
+  }
+  // alias for public method to set options
+  setOptions(options = {}) {
+    this.setOptions_(options);
   }
   /**
    * called when player.src gets called, handle a new source

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -257,6 +257,29 @@ QUnit.test('VhsHandler is referenced by player.tech().vhs', function(assert) {
   );
 });
 
+QUnit.test.only('options are updated when setOptions is called', function(assert) {
+  this.player.src({
+    src: 'manifest/playlist.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.clock.tick(1);
+
+  const vhs = this.player.tech().vhs;
+
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged');
+  assert.equal(
+    this.env.log.warn.args[0][0],
+    'Using the tech directly can be dangerous. I hope you know what you\'re doing.\n' +
+    'See https://github.com/videojs/video.js/issues/2617 for more info.\n',
+    'logged warning'
+  );
+  assert.equal(vhs.options_.withCredentials, false);
+
+  vhs.setOptions({ withCredentials: true });
+
+  assert.equal(vhs.options_.withCredentials, true, 'options are updated');
+});
+
 QUnit.test('starts playing if autoplay is specified', function(assert) {
   this.player.autoplay(true);
   this.player.src({


### PR DESCRIPTION
## Description
 Public function for updating VHS options. This gives the user a way top update VHS config after initialization of the player.

## Specific Changes proposed
* Create `setOptions` function

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
