### PR TITLE
fix: do not call load after mediachange for hls playlist loader

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -673,7 +673,10 @@ export class PlaylistController extends videojs.EventTarget {
         this.requestOptions_.timeout = requestTimeout;
       }
 
-      this.mainPlaylistLoader_.load();
+      if (this.sourceType_ === 'dash') {
+        // we don't want to re-request the same hls playlist right after it was changed
+        this.mainPlaylistLoader_.load();
+      }
 
       // TODO: Create a new event on the PlaylistLoader that signals
       // that the segments have changed in some way and use that to


### PR DESCRIPTION
## Description

During ABR switch or fast quality switch, we call `switchMedia_` which will call `this.mainPlaylistLoader_.media` with a new media. We request a new playlist and trigger a `mediachange` event right after the request.

In playlist controller we listen to the `mediachange` and call `this.mainPlaylistLoader_.load()`

in the load method, we hit the following check
```js
if (media && !media.endList) {
  this.trigger('mediaupdatetimeout');
} else {
  this.trigger('loadedplaylist');
}
```

So for live, we trigger `mediaupdatetimeout` , which means that we need to refresh a live playlist, so we start loading the playlist a second time.

So we load the same playlist immediately (right after it was loaded), so we hit `playlistunchanged` flow.

## Specific Changes proposed
This line was introduced mainly to fix dash-specific issues in this PR:
https://github.com/videojs/http-streaming/pull/1339

so the easiest solution is to call it for dash only.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
