### PR TITLE
fix: use startTime instead of 0 for finiteDuration

### DIFF
--- a/src/util/text-tracks.js
+++ b/src/util/text-tracks.js
@@ -234,7 +234,7 @@ export const addMetadata = ({
   // Map each cue group's endTime to the next group's startTime
   sortedStartTimes.forEach((startTime, idx) => {
     const cueGroup = cuesGroupedByStartTime[startTime];
-    const finiteDuration = isFinite(videoDuration) ? videoDuration : 0;
+    const finiteDuration = isFinite(videoDuration) ? videoDuration : startTime;
     const nextTime = Number(sortedStartTimes[idx + 1]) || finiteDuration;
 
     // Map each cue's endTime the next group's startTime


### PR DESCRIPTION
## Description
We shouldn't set endTime to 0, instead we should set it to the startTime if we don't have a duration.

## Specific Changes proposed
replace 0 with startTime

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
