### PR TITLE
feat: enable playlists with 'usable' keystatus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6903,26 +6903,14 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.2.2.tgz",
-      "integrity": "sha512-QCfB1koOoZw6E5La1cx+W/Yd0EZlRhHMqMr4TAJez0eRTuPDzPM5FWoiOqjyo37W+ISPLzmfJACSbJFEBjbL4Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
+      "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.0.0",
         "@xmldom/xmldom": "^0.8.3",
         "global": "^4.4.0"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
     "m3u8-parser": "^7.1.0",
-    "mpd-parser": "^1.2.2",
+    "mpd-parser": "^1.3.0",
     "mux.js": "7.0.2",
     "video.js": "^7 || ^8"
   },

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -925,21 +925,6 @@ export default class DashPlaylistLoader extends EventTarget {
     }
   }
 
-  // /**
-  //  * Returns the default_KID from a DASH playlist.
-  //  *
-  //  * @param {playlist} playlist to fetch the default_KID from.
-  //  * @return a 32 digit hex string that represents the keyId of the encrypted playlist.
-  //  */
-  // getKID(playlist) {
-  //   if (playlist.contentProtection &&
-  //     playlist.contentProtection.mp4protection &&
-  //     playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
-  //     // default KID is a 32 digit hext string separated by '-'.
-  //     return playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace(/-/g, '');
-  //   }
-  // }
-
   /**
    * Returns the key ID set from a playlist
    *

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -930,6 +930,10 @@ export default class DashPlaylistLoader extends EventTarget {
 
   excludeNonUsablePlaylists() {
     this.mainPlaylistLoader_.main.playlists.forEach((playlist) => {
+      if (!playlist.contentProtection.mp4protection ||
+        !playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
+        return;
+      }
       const playlistKID = playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace('-', '');
       const hasUsableKeystatus = this.keyStatusMap.has(playlistKID) && this.keyStatusMap.get(playlistKID) === 'usable';
 

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -314,7 +314,7 @@ export default class DashPlaylistLoader extends EventTarget {
     this.vhs_ = vhs;
     this.withCredentials = withCredentials;
     this.addMetadataToTextTrack = options.addMetadataToTextTrack;
-    this.keyStatusMap = new Map();
+    this.keyStatusMap_ = new Map();
 
     if (!srcUrlOrPlaylist) {
       throw new Error('A non-empty playlist URL or object is required');
@@ -474,7 +474,7 @@ export default class DashPlaylistLoader extends EventTarget {
     }
 
     this.off();
-    this.keyStatusMap.clear();
+    this.keyStatusMap_.clear();
   }
 
   hasPendingRequest() {
@@ -935,7 +935,7 @@ export default class DashPlaylistLoader extends EventTarget {
         return;
       }
       const playlistKID = playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace('-', '');
-      const hasUsableKeystatus = this.keyStatusMap.has(playlistKID) && this.keyStatusMap.get(playlistKID) === 'usable';
+      const hasUsableKeystatus = this.keyStatusMap_.has(playlistKID) && this.keyStatusMap_.get(playlistKID) === 'usable';
 
       if (!hasUsableKeystatus) {
         playlist.excludeUntil = Infinity;

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -22,7 +22,6 @@ import containerRequest from './util/container-request.js';
 import {toUint8} from '@videojs/vhs-utils/es/byte-helpers';
 import logger from './util/logger';
 import {merge} from './util/vjs-compat';
-import { arrayBufferToHexString } from './util/string.js';
 
 const { EventTarget } = videojs;
 
@@ -314,7 +313,6 @@ export default class DashPlaylistLoader extends EventTarget {
     this.vhs_ = vhs;
     this.withCredentials = withCredentials;
     this.addMetadataToTextTrack = options.addMetadataToTextTrack;
-    this.keyStatusMap_ = new Map();
 
     if (!srcUrlOrPlaylist) {
       throw new Error('A non-empty playlist URL or object is required');
@@ -474,7 +472,6 @@ export default class DashPlaylistLoader extends EventTarget {
     }
 
     this.off();
-    this.keyStatusMap_.clear();
   }
 
   hasPendingRequest() {
@@ -928,29 +925,18 @@ export default class DashPlaylistLoader extends EventTarget {
     }
   }
 
-  excludeNonUsablePlaylists() {
-    this.mainPlaylistLoader_.main.playlists.forEach((playlist) => {
-      if (!playlist.contentProtection.mp4protection ||
-        !playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
-        return;
-      }
-      const playlistKID = playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace(/-/g, '');
-      const hasUsableKeystatus = this.keyStatusMap_.has(playlistKID) && this.keyStatusMap_.get(playlistKID) === 'usable';
-
-      if (!hasUsableKeystatus) {
-        playlist.excludeUntil = Infinity;
-        playlist.lastExcludeReason_ = 'non-usable';
-      } else {
-        delete playlist.excludeUntil;
-        delete playlist.lastExcludeReason_;
-      }
-    });
-  }
-
-  addKeyStatus(keyId, status) {
-    // 32 digit keyId hex string.
-    const keyIdHexString = arrayBufferToHexString(keyId).slice(0, 32);
-
-    this.keyStatusMap_.set(keyIdHexString, status);
+  /**
+   * Returns the default_KID from a DASH playlist.
+   *
+   * @param {playlist} playlist to fetch the default_KID from.
+   * @return a 32 digit hex string that represents the keyId of the encrypted playlist.
+   */
+  getKID(playlist) {
+    if (playlist.contentProtection &&
+      playlist.contentProtection.mp4protection &&
+      playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
+      // default KID is a 32 digit hext string separated by '-'.
+      return playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace(/-/g, '');
+    }
   }
 }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -925,18 +925,40 @@ export default class DashPlaylistLoader extends EventTarget {
     }
   }
 
+  // /**
+  //  * Returns the default_KID from a DASH playlist.
+  //  *
+  //  * @param {playlist} playlist to fetch the default_KID from.
+  //  * @return a 32 digit hex string that represents the keyId of the encrypted playlist.
+  //  */
+  // getKID(playlist) {
+  //   if (playlist.contentProtection &&
+  //     playlist.contentProtection.mp4protection &&
+  //     playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
+  //     // default KID is a 32 digit hext string separated by '-'.
+  //     return playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace(/-/g, '');
+  //   }
+  // }
+
   /**
-   * Returns the default_KID from a DASH playlist.
+   * Returns the key ID set from a playlist
    *
-   * @param {playlist} playlist to fetch the default_KID from.
-   * @return a 32 digit hex string that represents the keyId of the encrypted playlist.
+   * @param {playlist} playlist to fetch the key ID set from.
+   * @return a Set of 32 digit hex strings that represent the unique keyIds for that playlist.
    */
-  getKID(playlist) {
-    if (playlist.contentProtection &&
-      playlist.contentProtection.mp4protection &&
-      playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
-      // default KID is a 32 digit hext string separated by '-'.
-      return playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace(/-/g, '');
+  getKeyIdSet(playlist) {
+    if (playlist.contentProtection) {
+      const keyIds = new Set();
+
+      for (const keysystem in playlist.contentProtection) {
+        // DASH keyIds are separated by dashes.
+        const keyId = playlist.contentProtection[keysystem].attributes['cenc:default_KID'].replace(/-/g, '');
+
+        if (keyId) {
+          keyIds.add(keyId);
+        }
+      }
+      return keyIds;
     }
   }
 }

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -934,7 +934,7 @@ export default class DashPlaylistLoader extends EventTarget {
         !playlist.contentProtection.mp4protection.attributes['cenc:default_KID']) {
         return;
       }
-      const playlistKID = playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace('-', '');
+      const playlistKID = playlist.contentProtection.mp4protection.attributes['cenc:default_KID'].replace(/-/g, '');
       const hasUsableKeystatus = this.keyStatusMap_.has(playlistKID) && this.keyStatusMap_.get(playlistKID) === 'usable';
 
       if (!hasUsableKeystatus) {

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -951,8 +951,13 @@ export default class DashPlaylistLoader extends EventTarget {
       const keyIds = new Set();
 
       for (const keysystem in playlist.contentProtection) {
+        const defaultKID = playlist.contentProtection[keysystem].attributes['cenc:default_KID'];
+
+        if (!defaultKID) {
+          return;
+        }
         // DASH keyIds are separated by dashes.
-        const keyId = playlist.contentProtection[keysystem].attributes['cenc:default_KID'].replace(/-/g, '');
+        const keyId = defaultKID.replace(/-/g, '');
 
         if (keyId) {
           keyIds.add(keyId);

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -953,14 +953,9 @@ export default class DashPlaylistLoader extends EventTarget {
       for (const keysystem in playlist.contentProtection) {
         const defaultKID = playlist.contentProtection[keysystem].attributes['cenc:default_KID'];
 
-        if (!defaultKID) {
-          return;
-        }
-        // DASH keyIds are separated by dashes.
-        const keyId = defaultKID.replace(/-/g, '');
-
-        if (keyId) {
-          keyIds.add(keyId);
+        if (defaultKID) {
+          // DASH keyIds are separated by dashes.
+          keyIds.add(defaultKID.replace(/-/g, ''));
         }
       }
       return keyIds;

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2445,7 +2445,7 @@ export class PlaylistController extends videojs.EventTarget {
     this.addKeyStatus_(keyId, status);
 
     // this gets called a LOT. Unless we want to change contrib-eme we should debounce here.
-    const ONE_SECOND = 1000;
+    const TWO_SECONDS = 2000;
     const debouncePlaylistUpdate = (fn) => {
       let timeoutId;
 
@@ -2453,7 +2453,7 @@ export class PlaylistController extends videojs.EventTarget {
         clearTimeout(timeoutId);
         timeoutId = setTimeout(() => {
           fn.apply(this);
-        }, ONE_SECOND);
+        }, TWO_SECONDS);
       };
     };
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2445,18 +2445,18 @@ export class PlaylistController extends videojs.EventTarget {
     this.addKeyStatus_(keyId, status);
     // this gets called a LOT. Unless we want to change contrib-eme we should debounce here.
     const ONE_SECOND = 1000;
-    const debouncePlaylistUpdate = () => {
+    const debouncePlaylistUpdate = (fn) => {
       let timeoutId;
 
       return () => {
         clearTimeout(timeoutId);
-        timeoutId = setTimeout(() => {
-          this.excludeNonUsablePlaylistsByKeyId_();
-          this.fastQualityChange_();
-        }, ONE_SECOND);
+        timeoutId = setTimeout(fn, ONE_SECOND);
       };
     };
 
-    debouncePlaylistUpdate();
+    debouncePlaylistUpdate(() => {
+      this.excludeNonUsablePlaylistsByKeyId_();
+      this.fastQualityChange_();
+    });
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -979,10 +979,6 @@ export class PlaylistController extends videojs.EventTarget {
    * @private
    */
   fastQualityChange_(media = this.selectPlaylist()) {
-    if (!media) {
-      return;
-    }
-
     if (media === this.mainPlaylistLoader_.media()) {
       this.logger_('skipping fastQualityChange because new media is same as old');
       return;
@@ -2407,12 +2403,14 @@ export class PlaylistController extends videojs.EventTarget {
         return;
       }
       keyIdSet.forEach((key) => {
-        const hasUsableKeyStatus = this.keyStatusMap_.has(key) && this.keyStatusMap_.get(key) === 'usable';
-        const nonUsableExclusion = playlist.lastExcludeReason_ === 'non-usable' && playlist.excludeUntil === Infinity;
+        const USABLE = 'usable';
+        const NON_USABLE = 'non-usable';
+        const hasUsableKeyStatus = this.keyStatusMap_.has(key) && this.keyStatusMap_.get(key) === USABLE;
+        const nonUsableExclusion = playlist.lastExcludeReason_ === NON_USABLE && playlist.excludeUntil === Infinity;
 
         if (!hasUsableKeyStatus) {
           playlist.excludeUntil = Infinity;
-          playlist.lastExcludeReason_ = 'non-usable';
+          playlist.lastExcludeReason_ = NON_USABLE;
         } else if (hasUsableKeyStatus && nonUsableExclusion) {
           delete playlist.excludeUntil;
           delete playlist.lastExcludeReason_;

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2385,7 +2385,7 @@ export class PlaylistController extends videojs.EventTarget {
   }
 
   /**
-   * Iterates through a playlists and check their keyId set and compare with the
+   * Iterates through playlists and check their keyId set and compare with the
    * keyStatusMap, only enable playlists that have a usable key. If the playlist
    * has no keyId leave it enabled by default.
    */
@@ -2411,9 +2411,11 @@ export class PlaylistController extends videojs.EventTarget {
         if (!hasUsableKeyStatus) {
           playlist.excludeUntil = Infinity;
           playlist.lastExcludeReason_ = NON_USABLE;
+          this.logger_(`excluding playlist ${playlist.id} because the key ID ${key} doesn't exist in the keyStatusMap or is not ${USABLE}`);
         } else if (hasUsableKeyStatus && nonUsableExclusion) {
           delete playlist.excludeUntil;
           delete playlist.lastExcludeReason_;
+          this.logger_(`enabling playlist ${playlist.id} because key ID ${key} is ${USABLE}`);
         }
       });
     });
@@ -2442,12 +2444,13 @@ export class PlaylistController extends videojs.EventTarget {
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
     this.excludeNonUsablePlaylistsByKeyId_();
-    const newPlaylist = this.selectPlaylist();
     const oldPlaylist = this.mainPlaylistLoader_.media();
+    const oldId = oldPlaylist ? oldPlaylist.id : undefined;
+    const newPlaylist = this.selectPlaylist();
     const keystatusChange = 'keystatus-change';
 
     if (newPlaylist !== oldPlaylist) {
-      this.logger_(`switching playlist from ${oldPlaylist.id} to ${newPlaylist.id} due to a ${keystatusChange}`);
+      this.logger_(`switching playlists from ${oldId} to ${newPlaylist.id} due to a ${keystatusChange}`);
       this.switchMedia_(newPlaylist, keystatusChange);
     }
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2410,7 +2410,6 @@ export class PlaylistController extends videojs.EventTarget {
         const hasUsableKeyStatus = this.keyStatusMap_.has(key) && this.keyStatusMap_.get(key) === 'usable';
 
         if (!hasUsableKeyStatus) {
-          this.logger_(`playlist has no usable keystatus for keyId ${key} excluding ${playlist.id} for ${playlist.lastExcludeReason_}`);
           playlist.excludeUntil = Infinity;
           playlist.lastExcludeReason_ = 'non-usable';
         } else {
@@ -2444,8 +2443,13 @@ export class PlaylistController extends videojs.EventTarget {
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
     this.excludeNonUsablePlaylistsByKeyId_();
-    const nextPlaylist = this.selectPlaylist();
+    const newPlaylist = this.selectPlaylist();
+    const oldPlaylist = this.mainPlaylistLoader_.media();
+    const keystatusChange = 'keystatus-change';
 
-    this.switchMedia_(nextPlaylist, 'keystatuschange');
+    if (newPlaylist !== oldPlaylist) {
+      this.logger_(`switching playlist from ${oldPlaylist.id} to ${newPlaylist.id} due to a ${keystatusChange}`);
+      this.switchMedia_(newPlaylist, keystatusChange);
+    }
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -29,6 +29,7 @@ import {merge, createTimeRanges} from './util/vjs-compat';
 import { addMetadata, createMetadataTrackIfNotExists, addDateRangeMetadata } from './util/text-tracks';
 import ContentSteeringController from './content-steering-controller';
 import { bufferToHexString } from './util/string.js';
+import { debounce } from 'lodash';
 
 const ABORT_EARLY_EXCLUSION_SECONDS = 10;
 
@@ -2445,18 +2446,10 @@ export class PlaylistController extends videojs.EventTarget {
     this.addKeyStatus_(keyId, status);
     // this gets called a LOT. Unless we want to change contrib-eme we should debounce here.
     const ONE_SECOND = 1000;
-    const debouncePlaylistUpdate = (fn) => {
-      let timeoutId;
 
-      return () => {
-        clearTimeout(timeoutId);
-        timeoutId = setTimeout(fn, ONE_SECOND);
-      };
-    };
-
-    debouncePlaylistUpdate(() => {
+    debounce(() => {
       this.excludeNonUsablePlaylistsByKeyId_();
       this.fastQualityChange_();
-    });
+    }, ONE_SECOND);
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2386,21 +2386,23 @@ export class PlaylistController extends videojs.EventTarget {
 
   excludeNonUsablePlaylistsByKID() {
     this.mainPlaylistLoader_.main.playlists.forEach((playlist) => {
-      const keyId = this.mainPlaylistLoader_.getKID(playlist);
-      // If the playlist doesn't have a keyID lets not exclude it.
+      const keyIdSet = this.mainPlaylistLoader_.getKeyIdSet(playlist);
 
-      if (!keyId) {
+      // If the playlist doesn't have a keyIDs lets not exclude it.
+      if (!keyIdSet.size) {
         return;
       }
-      const hasUsableKeystatus = this.keyStatusMap_.has(keyId) && this.keyStatusMap_.get(keyId) === 'usable';
+      keyIdSet.forEach((key) => {
+        const hasUsableKeystatus = this.keyStatusMap_.has(key) && this.keyStatusMap_.get(key) === 'usable';
 
-      if (!hasUsableKeystatus) {
-        playlist.excludeUntil = Infinity;
-        playlist.lastExcludeReason_ = 'non-usable';
-      } else {
-        delete playlist.excludeUntil;
-        delete playlist.lastExcludeReason_;
-      }
+        if (!hasUsableKeystatus) {
+          playlist.excludeUntil = Infinity;
+          playlist.lastExcludeReason_ = 'non-usable';
+        } else {
+          delete playlist.excludeUntil;
+          delete playlist.lastExcludeReason_;
+        }
+      });
     });
   }
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2443,7 +2443,20 @@ export class PlaylistController extends videojs.EventTarget {
    */
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
-    this.excludeNonUsablePlaylistsByKeyId_();
-    this.fastQualityChange_();
+    // this gets called a LOT. Unless we want to change contrib-eme we should debounce here.
+    const ONE_SECOND = 1000;
+    const debouncePlaylistUpdate = () => {
+      let timeoutId;
+
+      return () => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+          this.excludeNonUsablePlaylistsByKeyId_();
+          this.fastQualityChange_();
+        }, ONE_SECOND);
+      };
+    };
+
+    debouncePlaylistUpdate();
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2402,17 +2402,18 @@ export class PlaylistController extends videojs.EventTarget {
     this.mainPlaylistLoader_.main.playlists.forEach((playlist) => {
       const keyIdSet = this.mainPlaylistLoader_.getKeyIdSet(playlist);
 
-      // If the playlist doesn't have a keyIDs lets not exclude it.
+      // If the playlist doesn't have keyIDs lets not exclude it.
       if (!keyIdSet || !keyIdSet.size) {
         return;
       }
       keyIdSet.forEach((key) => {
         const hasUsableKeyStatus = this.keyStatusMap_.has(key) && this.keyStatusMap_.get(key) === 'usable';
+        const nonUsableExclusion = playlist.lastExcludeReason_ === 'non-usable' && playlist.excludeUntil === Infinity;
 
         if (!hasUsableKeyStatus) {
           playlist.excludeUntil = Infinity;
           playlist.lastExcludeReason_ = 'non-usable';
-        } else {
+        } else if (hasUsableKeyStatus && nonUsableExclusion) {
           delete playlist.excludeUntil;
           delete playlist.lastExcludeReason_;
         }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -405,7 +405,7 @@ export class PlaylistController extends videojs.EventTarget {
   switchMedia_(playlist, cause, delay) {
     const oldMedia = this.media();
     const oldId = oldMedia && (oldMedia.id || oldMedia.uri);
-    const newId = playlist.id || playlist.uri;
+    const newId = playlist && (playlist.id || playlist.uri);
 
     if (oldId && oldId !== newId) {
       this.logger_(`switch media ${oldId} -> ${newId} from ${cause}`);
@@ -2445,13 +2445,10 @@ export class PlaylistController extends videojs.EventTarget {
     this.addKeyStatus_(keyId, status);
     this.excludeNonUsablePlaylistsByKeyId_();
     const oldPlaylist = this.mainPlaylistLoader_.media();
-    const oldId = oldPlaylist ? oldPlaylist.id : undefined;
     const newPlaylist = this.selectPlaylist();
-    const newId = newPlaylist ? newPlaylist.id : undefined;
     const keystatusChange = 'keystatus-change';
 
     if (newPlaylist !== oldPlaylist) {
-      this.logger_(`switching playlists from ${oldId} to ${newId} due to a ${keystatusChange}`);
       this.switchMedia_(newPlaylist, keystatusChange);
     }
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2457,9 +2457,10 @@ export class PlaylistController extends videojs.EventTarget {
       };
     };
 
+    // Call Immediately.
     debouncePlaylistUpdate(() => {
       this.excludeNonUsablePlaylistsByKeyId_();
       this.fastQualityChange_();
-    });
+    })();
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2443,24 +2443,9 @@ export class PlaylistController extends videojs.EventTarget {
    */
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
+    this.excludeNonUsablePlaylistsByKeyId_();
+    const nextPlaylist = this.selectPlaylist();
 
-    // this gets called a LOT. Unless we want to change contrib-eme we should debounce here.
-    const TWO_SECONDS = 2000;
-    const debouncePlaylistUpdate = (fn) => {
-      let timeoutId;
-
-      return () => {
-        clearTimeout(timeoutId);
-        timeoutId = setTimeout(() => {
-          fn.apply(this);
-        }, TWO_SECONDS);
-      };
-    };
-
-    // Call Immediately.
-    debouncePlaylistUpdate(() => {
-      this.excludeNonUsablePlaylistsByKeyId_();
-      this.fastQualityChange_();
-    })();
+    this.switchMedia_(nextPlaylist, 'keystatuschange');
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2447,10 +2447,11 @@ export class PlaylistController extends videojs.EventTarget {
     const oldPlaylist = this.mainPlaylistLoader_.media();
     const oldId = oldPlaylist ? oldPlaylist.id : undefined;
     const newPlaylist = this.selectPlaylist();
+    const newId = newPlaylist ? newPlaylist.id : undefined;
     const keystatusChange = 'keystatus-change';
 
     if (newPlaylist !== oldPlaylist) {
-      this.logger_(`switching playlists from ${oldId} to ${newPlaylist.id} due to a ${keystatusChange}`);
+      this.logger_(`switching playlists from ${oldId} to ${newId} due to a ${keystatusChange}`);
       this.switchMedia_(newPlaylist, keystatusChange);
     }
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2451,7 +2451,9 @@ export class PlaylistController extends videojs.EventTarget {
 
       return () => {
         clearTimeout(timeoutId);
-        timeoutId = setTimeout(fn.apply(this), ONE_SECOND);
+        timeoutId = setTimeout(() => {
+          fn.apply(this);
+        }, ONE_SECOND);
       };
     };
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -977,7 +977,7 @@ export class PlaylistController extends videojs.EventTarget {
    * @private
    */
   fastQualityChange_(media = this.selectPlaylist()) {
-    if (media === this.mainPlaylistLoader_.media()) {
+    if (!media || media === this.mainPlaylistLoader_.media()) {
       this.logger_('skipping fastQualityChange because new media is same as old');
       return;
     }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -28,6 +28,7 @@ import logger from './util/logger';
 import {merge, createTimeRanges} from './util/vjs-compat';
 import { addMetadata, createMetadataTrackIfNotExists, addDateRangeMetadata } from './util/text-tracks';
 import ContentSteeringController from './content-steering-controller';
+import { bufferToHexString } from './util/string.js';
 
 const ABORT_EARLY_EXCLUSION_SECONDS = 10;
 
@@ -2421,14 +2422,14 @@ export class PlaylistController extends videojs.EventTarget {
   }
 
   /**
-   * Adds a keystatus to the keystatus map, tries to convert to string with a TextDecoder if necessary.
+   * Adds a keystatus to the keystatus map, tries to convert to string if necessary.
    *
    * @param {any} keyId the keyId to add a status for
    * @param {string} status the status of the keyId
    */
   addKeyStatus_(keyId, status) {
     const isString = typeof keyId === 'string';
-    const keyIdHexString = isString ? keyId : new TextDecoder().decode(keyId);
+    const keyIdHexString = isString ? keyId : bufferToHexString(keyId);
 
     // 32 digit keyId hex string.
     this.keyStatusMap_.set(keyIdHexString.slice(0, 32), status);

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -1196,18 +1196,23 @@ export default class PlaylistLoader extends EventTarget {
   }
 
   /**
-   * Returns the key ID from a playlist.
+   * Returns the key ID set from a playlist
    *
-   * @param {playlist} playlist to fetch the key ID from.
-   * @return a 32 digit hex string that represents the keyId of the encrypted playlist.
+   * @param {playlist} playlist to fetch the key ID set from.
+   * @return a Set of 32 digit hex strings that represent the unique keyIds for that playlist.
    */
-  getKID(playlist) {
-    // Currently we only parse the keyId for widevine in HLS so only look there.
-    if (playlist.contentProtection &&
-      playlist.contentProtection['com.widevine.alpha'] &&
-      playlist.contentProtection['com.widevine.alpha'].attributes.keyId) {
-      // default KID is a 32 digit hext string often separated by '-'.
-      return playlist.contentProtection['com.widevine.alpha'].attributes.keyId.replace(/-/g, '');
+  getKeyIdSet(playlist) {
+    if (playlist.contentProtection) {
+      const keyIds = new Set();
+
+      for (const keysystem in playlist.contentProtection) {
+        const keyId = playlist.contentProtection[keysystem].attributes.keyId;
+
+        if (keyId) {
+          keyIds.add(keyId);
+        }
+      }
+      return keyIds;
     }
   }
 }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -1194,4 +1194,20 @@ export default class PlaylistLoader extends EventTarget {
 
     return attributes;
   }
+
+  /**
+   * Returns the key ID from a playlist.
+   *
+   * @param {playlist} playlist to fetch the key ID from.
+   * @return a 32 digit hex string that represents the keyId of the encrypted playlist.
+   */
+  getKID(playlist) {
+    // Currently we only parse the keyId for widevine in HLS so only look there.
+    if (playlist.contentProtection &&
+      playlist.contentProtection['com.widevine.alpha'] &&
+      playlist.contentProtection['com.widevine.alpha'].attributes.keyId) {
+      // default KID is a 32 digit hext string often separated by '-'.
+      return playlist.contentProtection['com.widevine.alpha'].attributes.keyId.replace(/-/g, '');
+    }
+  }
 }

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -1,6 +1,3 @@
 export const uint8ToUtf8 = (uintArray) =>
   decodeURIComponent(escape(String.fromCharCode.apply(null, uintArray)));
 
-export const arrayBufferToHexString = (buffer) => {
-  return Array.from(new Uint8Array(buffer)).map((val) => val.toString(16).padStart(2, '0')).join('');
-};

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -2,5 +2,5 @@ export const uint8ToUtf8 = (uintArray) =>
   decodeURIComponent(escape(String.fromCharCode.apply(null, uintArray)));
 
 export const arrayBufferToHexString = (buffer) => {
-  return Array.from(buffer).map((val) => val.toString(16).padStart(2, '0')).join('');
+  return Array.from(new Uint8Array(buffer)).map((val) => val.toString(16).padStart(2, '0')).join('');
 };

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -1,2 +1,6 @@
 export const uint8ToUtf8 = (uintArray) =>
   decodeURIComponent(escape(String.fromCharCode.apply(null, uintArray)));
+
+export const arrayBufferToHexString = (buffer) => {
+  return Array.from(buffer).map((val) => val.toString(16).padStart(2, '0')).join('');
+};

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -1,3 +1,8 @@
 export const uint8ToUtf8 = (uintArray) =>
   decodeURIComponent(escape(String.fromCharCode.apply(null, uintArray)));
 
+export const bufferToHexString = (buffer) => {
+  const uInt8Buffer = new Uint8Array(buffer);
+
+  return Array.from(uInt8Buffer).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+};

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1126,42 +1126,7 @@ class VhsHandler extends Component {
     });
 
     this.player_.tech_.on('keystatuschange', (e) => {
-      if (e.status !== 'output-restricted') {
-        this.playlistController_.updatePlaylistByKeyStatus(e.keyId, e.status);
-        return;
-      }
-
-      const mainPlaylist = this.playlistController_.main();
-
-      if (!mainPlaylist || !mainPlaylist.playlists) {
-        return;
-      }
-
-      const excludedHDPlaylists = [];
-
-      // Assume all HD streams are unplayable and exclude them from ABR selection
-      mainPlaylist.playlists.forEach(playlist => {
-        if (playlist && playlist.attributes && playlist.attributes.RESOLUTION &&
-            playlist.attributes.RESOLUTION.height >= 720) {
-          if (!playlist.excludeUntil || playlist.excludeUntil < Infinity) {
-
-            playlist.excludeUntil = Infinity;
-            excludedHDPlaylists.push(playlist);
-          }
-        }
-      });
-
-      if (excludedHDPlaylists.length) {
-        videojs.log.warn(
-          'DRM keystatus changed to "output-restricted." Removing the following HD playlists ' +
-          'that will most likely fail to play and clearing the buffer. ' +
-          'This may be due to HDCP restrictions on the stream and the capabilities of the current device.',
-          ...excludedHDPlaylists
-        );
-
-        // Clear the buffer before switching playlists, since it may already contain unplayable segments
-        this.playlistController_.fastQualityChange_();
-      }
+      this.playlistController_.updatePlaylistByKeyStatus(e.keyId, e.status);
     });
 
     this.handleWaitingForKey_ = this.handleWaitingForKey_.bind(this);

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1141,7 +1141,7 @@ class VhsHandler extends Component {
       if (e.status !== 'output-restricted') {
         const shouldDisableNonUsablePlaylists = this.options_.disableNonUsablePlaylists &&
           this.playlistController_.mainPlaylistLoader_.addKeyStatus &&
-          this.this.playlistController_.mainPlaylistLoader_.enableOnlyUsablePlaylists;
+          this.playlistController_.mainPlaylistLoader_.enableOnlyUsablePlaylists;
 
         if (!shouldDisableNonUsablePlaylists) {
           return;

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -485,7 +485,7 @@ const removeOnResponseHook = (xhr, callback) => {
   }
 };
 
-const debounce = (callback, timeout = 10) => {
+const debounce = (callback, timeout = 1000) => {
   let timeoutId;
 
   return (...args) => {
@@ -1139,19 +1139,12 @@ class VhsHandler extends Component {
 
     this.player_.tech_.on('keystatuschange', (e) => {
       if (e.status !== 'output-restricted') {
-        const shouldDisableNonUsablePlaylists = this.options_.disableNonUsablePlaylists &&
-          this.playlistController_.mainPlaylistLoader_.addKeyStatus &&
-          this.playlistController_.mainPlaylistLoader_.excludeNonUsablePlaylists;
-
-        if (!shouldDisableNonUsablePlaylists) {
-          return;
-        }
         const debounceExcludeAndChange = debounce(() => {
-          this.playlistController_.mainPlaylistLoader_.excludeNonUsablePlaylists();
+          this.playlistController_.excludeNonUsablePlaylistsByKID();
           this.playlistController_.fastQualityChange_();
         });
 
-        this.playlistController_.mainPlaylistLoader_.addKeyStatus(e.keyId, e.status);
+        this.playlistController_.addKeyStatus(e.keyId, e.status);
         // This is called in a loop for each keystatuseschange event from the MediaKeySession
         // so we need to debounce this so we don't repeatedly filter the playlists.
         debounceExcludeAndChange();

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1141,7 +1141,7 @@ class VhsHandler extends Component {
       if (e.status !== 'output-restricted') {
         const shouldDisableNonUsablePlaylists = this.options_.disableNonUsablePlaylists &&
           this.playlistController_.mainPlaylistLoader_.addKeyStatus &&
-          this.playlistController_.mainPlaylistLoader_.enableOnlyUsablePlaylists;
+          this.playlistController_.mainPlaylistLoader_.excludeNonUsablePlaylists;
 
         if (!shouldDisableNonUsablePlaylists) {
           return;

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -485,17 +485,6 @@ const removeOnResponseHook = (xhr, callback) => {
   }
 };
 
-const debounce = (callback, timeout = 1000) => {
-  let timeoutId;
-
-  return (...args) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => {
-      callback(...args);
-    }, timeout);
-  };
-};
-
 /**
  * Whether the browser has built-in HLS support.
  */
@@ -714,7 +703,6 @@ class VhsHandler extends Component {
     this.options_.cacheEncryptionKeys = this.options_.cacheEncryptionKeys || false;
     this.options_.llhls = this.options_.llhls === false ? false : true;
     this.options_.bufferBasedABR = this.options_.bufferBasedABR || false;
-    this.options_.disableNonUsablePlaylists = true;
 
     if (typeof this.options_.playlistExclusionDuration !== 'number') {
       this.options_.playlistExclusionDuration = 60;
@@ -1139,15 +1127,7 @@ class VhsHandler extends Component {
 
     this.player_.tech_.on('keystatuschange', (e) => {
       if (e.status !== 'output-restricted') {
-        const debounceExcludeAndChange = debounce(() => {
-          this.playlistController_.excludeNonUsablePlaylistsByKID();
-          this.playlistController_.fastQualityChange_();
-        });
-
-        this.playlistController_.addKeyStatus(e.keyId, e.status);
-        // This is called in a loop for each keystatuseschange event from the MediaKeySession
-        // so we need to debounce this so we don't repeatedly filter the playlists.
-        debounceExcludeAndChange();
+        this.playlistController_.updatePlaylistByKeyStatus(e.keyId, e.status);
         return;
       }
 

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -44,7 +44,7 @@ QUnit.module('DASH Playlist Loader: unit', {
   }
 });
 
-QUnit.test('can getKID from a playlist', function(assert) {
+QUnit.test('can getKeyIdSet from a playlist', function(assert) {
   const loader = new DashPlaylistLoader('variant.mpd', this.fakeVhs);
   const keyId = '188743e1-bd62-400e-92d9-748f8c753d1a';
   // We currently only pass keyId for widevine content protection.

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -44,6 +44,25 @@ QUnit.module('DASH Playlist Loader: unit', {
   }
 });
 
+QUnit.test('can getKID from a playlist', function(assert) {
+  const loader = new DashPlaylistLoader('variant.mpd', this.fakeVhs);
+  const keyId = '188743e1-bd62-400e-92d9-748f8c753d1a';
+  // We currently only pass keyId for widevine content protection.
+  const playlist = {
+    contentProtection: {
+      mp4protection: {
+        attributes: {
+          'cenc:default_KID': keyId
+        }
+      }
+    }
+  };
+  const keyIdSet = loader.getKeyIdSet(playlist);
+
+  assert.ok(keyIdSet.size);
+  assert.ok(keyIdSet.has(keyId.replace(/-/g, '')), 'keyId is expected hex string');
+});
+
 QUnit.test('updateMain: returns falsy when there are no changes', function(assert) {
   const main = {
     playlists: {

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -4864,6 +4864,140 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
   }, 'calls expected function when not passed a playlist');
 });
 
+QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
+  // string keyId
+  const keyIdEncoded = new TextEncoder().encode('a6fcfb2a857c4227adb5a5f51aa27632');
+  const status = 'usable';
+  const pc = this.playlistController;
+  let excludeNonUsablePlaylistsByKeyIdCalled = 0;
+
+  pc.addKeyStatus_ = (id, st) => {
+    assert.equal(id, keyIdEncoded, 'addKeyStatus_ called with expected keyId');
+    assert.equal(st, status, 'addKeyStatus_ called with expected status');
+  };
+
+  pc.excludeNonUsablePlaylistsByKeyId_ = () => {
+    excludeNonUsablePlaylistsByKeyIdCalled++;
+  };
+
+  pc.updatePlaylistByKeyStatus(keyIdEncoded, status);
+  assert.equal(excludeNonUsablePlaylistsByKeyIdCalled, 1, 'excludeNonUsablePlaylistsByKeyIdCalled called once');
+});
+
+QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
+  // string keyId
+  const keyId = 'a6fcfb2a857c4227adb5a5f51aa27632';
+  const status = 'usable';
+  const pc = this.playlistController;
+
+  pc.addKeyStatus_(keyId, status);
+
+  assert.equal(pc.keyStatusMap_.size, 1, 'map is expected size');
+  assert.equal(pc.keyStatusMap_.get(keyId), status, 'keyId has expected status');
+
+  // test a non-string keyId
+  const keyId2 = 'd0bebaf8a3cb4c52bae03d20a71e3df3';
+  const keyIdArrayBuffer = new TextEncoder().encode(keyId2);
+
+  pc.addKeyStatus_(keyIdArrayBuffer, 'usable');
+
+  assert.equal(pc.keyStatusMap_.size, 2, 'map is expected size');
+  assert.equal(pc.keyStatusMap_.get(keyId2), status, 'keyId has expected status');
+  // Uint8 keyid.
+});
+
+QUnit.test('dispose clears the keyStatusMap', function(assert) {
+  // string keyId
+  const keyId = 'd0bebaf8a3cb4c52bae03d20a71e3df3';
+  const status = 'usable';
+  const pc = this.playlistController;
+
+  pc.addKeyStatus_(keyId, status);
+
+  assert.equal(pc.keyStatusMap_.size, 1, 'map is expected size');
+  assert.equal(pc.keyStatusMap_.get(keyId), status, 'keyId has expected status');
+
+  pc.dispose();
+
+  assert.equal(pc.keyStatusMap_.size, 0, 'map is expected size');
+});
+
+QUnit.test('excludeNonUsablePlaylistsByKeyId_ excludes non usable HLS playlists', function(assert) {
+  // included playlist
+  const includedKeyId = 'd0bebaf8a3cb4c52bae03d20a71e3df3';
+  const includedStatus = 'usable';
+  const pc = this.playlistController;
+  const includedPlaylist = {
+    contentProtection: {
+      'com.widevine.alpha': {
+        attributes: {
+          keyId: includedKeyId
+        }
+      }
+    }
+  };
+
+  // excluded playlist
+  const excludedPlaylist = {
+    contentProtection: {
+      'com.microsoft.playready': {
+        attributes: {
+          keyId: '89256e53dbe544e9afba38d2ca17d176'
+        }
+      }
+    }
+  };
+
+  pc.mainPlaylistLoader_.main = { playlists: [includedPlaylist, excludedPlaylist] };
+
+  // add included key
+  pc.addKeyStatus_(includedKeyId, includedStatus);
+
+  pc.excludeNonUsablePlaylistsByKeyId_();
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[1].excludeUntil, Infinity, 'excludeUntil is Infinity');
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[1].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
+});
+
+QUnit.test('excludeNonUsablePlaylistsByKeyId_ excludes non usable DASH playlists', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'dash'
+  };
+  const pc = new PlaylistController(options);
+
+  // excluded playlist
+  const excludedPlaylist = {
+    contentProtection: {
+      'com.widevine.alpha': {
+        attributes: {}
+      }
+    }
+  };
+
+  // included playlist
+  const includedKeyId = 'd0bebaf8a3cb4c52bae03d20a71e3df3';
+  const includedStatus = 'usable';
+  const includedPlaylist = {
+    contentProtection: {
+      mp4protection: {
+        attributes: {
+          'cenc:default_KID': '89256e53dbe544e9afba38d2ca17d176'
+        }
+      }
+    }
+  };
+
+  pc.mainPlaylistLoader_.main = { playlists: [includedPlaylist, excludedPlaylist] };
+
+  // add included key
+  pc.addKeyStatus_(includedKeyId, includedStatus);
+
+  pc.excludeNonUsablePlaylistsByKeyId_();
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[0].excludeUntil, Infinity, 'excludeUntil is Infinity');
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[0].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
+});
+
 QUnit.module('PlaylistController codecs', {
   beforeEach(assert) {
     sharedHooks.beforeEach.call(this, assert);

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -4864,16 +4864,25 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
   }, 'calls expected function when not passed a playlist');
 });
 
-QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
+QUnit.test('updatePlaylistByKeyStatus calls the expected functions', function(assert) {
   // string keyId
-  const keyIdString = 'a6fcfb2a857c4227adb5a5f51aa27632';
+  const keyIdArrayBuffer = new Uint8Array([31, 21, 116, 48, 29, 163,
+    79, 139, 188, 200, 47, 76, 45, 21, 81, 184]).buffer;
   const status = 'usable';
   const pc = this.playlistController;
+  let excludeCalls = 0;
 
   pc.addKeyStatus_ = (id, st) => {
-    assert.equal(id, keyIdString, 'addKeyStatus_ called with expected keyId');
+    assert.equal(id, keyIdArrayBuffer, 'addKeyStatus_ called with expected keyId');
     assert.equal(st, status, 'addKeyStatus_ called with expected status');
   };
+
+  pc.excludeNonUsablePlaylistsByKeyId_ = () => {
+    excludeCalls++;
+  };
+
+  pc.updatePlaylistByKeyStatus(keyIdArrayBuffer, status);
+  assert.equal(excludeCalls, 1, 'excludeNonUsablePlaylistsByKeyId_ called once');
 });
 
 QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -4866,13 +4866,13 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
 
 QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
   // string keyId
-  const keyIdEncoded = new TextEncoder().encode('a6fcfb2a857c4227adb5a5f51aa27632');
+  const keyIdString = 'a6fcfb2a857c4227adb5a5f51aa27632';
   const status = 'usable';
   const pc = this.playlistController;
   let excludeNonUsablePlaylistsByKeyIdCalled = 0;
 
   pc.addKeyStatus_ = (id, st) => {
-    assert.equal(id, keyIdEncoded, 'addKeyStatus_ called with expected keyId');
+    assert.equal(id, keyIdString, 'addKeyStatus_ called with expected keyId');
     assert.equal(st, status, 'addKeyStatus_ called with expected status');
   };
 
@@ -4880,7 +4880,7 @@ QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
     excludeNonUsablePlaylistsByKeyIdCalled++;
   };
 
-  pc.updatePlaylistByKeyStatus(keyIdEncoded, status);
+  pc.updatePlaylistByKeyStatus(keyIdString, status);
   assert.equal(excludeNonUsablePlaylistsByKeyIdCalled, 1, 'excludeNonUsablePlaylistsByKeyIdCalled called once');
 });
 
@@ -4896,8 +4896,9 @@ QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
   assert.equal(pc.keyStatusMap_.get(keyId), status, 'keyId has expected status');
 
   // test a non-string keyId
-  const keyId2 = 'd0bebaf8a3cb4c52bae03d20a71e3df3';
-  const keyIdArrayBuffer = new TextEncoder().encode(keyId2);
+  const keyId2 = '1f1574301da34f8bbcc82f4c2d1551b8';
+  const keyIdArrayBuffer = new Uint8Array([31, 21, 116, 48, 29, 163,
+    79, 139, 188, 200, 47, 76, 45, 21, 81, 184]).buffer;
 
   pc.addKeyStatus_(keyIdArrayBuffer, 'usable');
 

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -4869,19 +4869,11 @@ QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {
   const keyIdString = 'a6fcfb2a857c4227adb5a5f51aa27632';
   const status = 'usable';
   const pc = this.playlistController;
-  let excludeNonUsablePlaylistsByKeyIdCalled = 0;
 
   pc.addKeyStatus_ = (id, st) => {
     assert.equal(id, keyIdString, 'addKeyStatus_ called with expected keyId');
     assert.equal(st, status, 'addKeyStatus_ called with expected status');
   };
-
-  pc.excludeNonUsablePlaylistsByKeyId_ = () => {
-    excludeNonUsablePlaylistsByKeyIdCalled++;
-  };
-
-  pc.updatePlaylistByKeyStatus(keyIdString, status);
-  assert.equal(excludeNonUsablePlaylistsByKeyIdCalled, 1, 'excludeNonUsablePlaylistsByKeyIdCalled called once');
 });
 
 QUnit.test('addKeyStatus_ adds keyId and status to the Map', function(assert) {

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -30,6 +30,25 @@ QUnit.module('Playlist Loader', function(hooks) {
     this.env.restore();
   });
 
+  QUnit.test('can getKID from a playlist', function(assert) {
+    const loader = new PlaylistLoader('variant.m3u8', this.fakeVhs);
+    const keyId = '800AACAA522958AE888062B5695DB6BF';
+    // We currently only pass keyId for widevine content protection.
+    const playlist = {
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            keyId
+          }
+        }
+      }
+    };
+    const keyIdSet = loader.getKeyIdSet(playlist);
+
+    assert.ok(keyIdSet.size);
+    assert.ok(keyIdSet.has(keyId), 'keyId is expected hex string');
+  });
+
   QUnit.test('updateSegments copies over properties', function(assert) {
     assert.deepEqual(
       [

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -30,7 +30,7 @@ QUnit.module('Playlist Loader', function(hooks) {
     this.env.restore();
   });
 
-  QUnit.test('can getKID from a playlist', function(assert) {
+  QUnit.test('can getKeyIdSet from a playlist', function(assert) {
     const loader = new PlaylistLoader('variant.m3u8', this.fakeVhs);
     const keyId = '800AACAA522958AE888062B5695DB6BF';
     // We currently only pass keyId for widevine content protection.

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4912,15 +4912,24 @@ QUnit.test('eme handles keystatuschange where status is usable', function(assert
   };
 
   const excludes = [];
+  let updatePlaylistByKeyStatusCalled = 0;
+  const keyIdEncoded = new TextEncoder().encode('303E3FF1CAC36019B9265CBFF45C82F2');
+
+  this.player.tech_.vhs.playlistController_.updatePlaylistByKeyStatus = (keyId, status) => {
+    updatePlaylistByKeyStatusCalled++;
+    assert.equal(keyIdEncoded, keyId, 'keyId is expected value');
+    assert.equal(status, 'usable', 'status is expected value');
+  };
 
   this.player.tech_.vhs.playlistController_.excludePlaylist = (exclude) => {
     excludes.push(exclude);
   };
 
   this.player.tech_.vhs.playlistController_.sourceUpdater_.trigger('createdsourcebuffers');
-  this.player.tech_.trigger({type: 'keystatuschange', status: 'usable'});
+  this.player.tech_.trigger({type: 'keystatuschange', keyId: keyIdEncoded, status: 'usable'});
 
   assert.deepEqual(excludes, [], 'did not exclude anything');
+  assert.equal(updatePlaylistByKeyStatusCalled, 1, 'updatePlaylistByKeyStatusCalled called once');
 });
 
 QUnit.test('eme waitingforkey event triggers another setup', function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4913,7 +4913,7 @@ QUnit.test('eme handles keystatuschange where status is usable', function(assert
 
   const excludes = [];
   let updatePlaylistByKeyStatusCalled = 0;
-  const keyIdEncoded = new TextEncoder().encode('303E3FF1CAC36019B9265CBFF45C82F2');
+  const keyIdEncoded = '303E3FF1CAC36019B9265CBFF45C82F2';
 
   this.player.tech_.vhs.playlistController_.updatePlaylistByKeyStatus = (keyId, status) => {
     updatePlaylistByKeyStatusCalled++;


### PR DESCRIPTION
## Description
Only enable playlists with a 'usable' keystatus when playing DASH with DRM.

## Specific Changes proposed
Reference the playlist keyId after getting a `keystatuschange` event from contrib-eme and only enable encrypted playlists that we have a matching usable keyId for.

Note: This PR includes changes from #1461

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
