### PR TITLE
chore: update mpd-parser to v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6903,26 +6903,14 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.2.2.tgz",
-      "integrity": "sha512-QCfB1koOoZw6E5La1cx+W/Yd0EZlRhHMqMr4TAJez0eRTuPDzPM5FWoiOqjyo37W+ISPLzmfJACSbJFEBjbL4Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
+      "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.0.0",
         "@xmldom/xmldom": "^0.8.3",
         "global": "^4.4.0"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
     "m3u8-parser": "^7.1.0",
-    "mpd-parser": "^1.2.2",
+    "mpd-parser": "^1.3.0",
     "mux.js": "7.0.2",
     "video.js": "^7 || ^8"
   },


### PR DESCRIPTION
## Description
Update mpd-parser to v1.3.0

## Specific Changes proposed
update the package.json and package-lock.json to 1.3.0 for the mpd-parser

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
