### PR TITLE
fix: check if change to the provided type is supported

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -280,8 +280,13 @@ const actions = {
 
     sourceUpdater.logger_(`changing ${type}Buffer codec from ${sourceUpdater.codecs[type]} to ${codec}`);
 
-    sourceBuffer.changeType(mime);
-    sourceUpdater.codecs[type] = codec;
+    // check if change to the provided type is supported
+    try {
+      sourceBuffer.changeType(mime);
+      sourceUpdater.codecs[type] = codec;
+    } catch (e) {
+      videojs.log.warn(`Failed to changeType on ${type}Buffer`, e);
+    }
   }
 };
 


### PR DESCRIPTION
## Description
This change will fix an error on change to the provided codec which is not supported.
Just warn about it and do not freeze the video.
