### PR TITLE
fix: toLowerCase keyIds from manifest and use fastQualityChange

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -940,7 +940,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
         if (defaultKID) {
           // DASH keyIds are separated by dashes.
-          keyIds.add(defaultKID.replace(/-/g, ''));
+          keyIds.add(defaultKID.replace(/-/g, '').toLowerCase());
         }
       }
       return keyIds;

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1710,6 +1710,7 @@ export class PlaylistController extends videojs.EventTarget {
     this.mainPlaylistLoader_.dispose();
     this.mainSegmentLoader_.dispose();
     this.contentSteeringController_.dispose();
+    this.keyStatusMap_.clear();
 
     if (this.loadOnPlay_) {
       this.tech_.off('play', this.loadOnPlay_);

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -979,7 +979,7 @@ export class PlaylistController extends videojs.EventTarget {
    * @private
    */
   fastQualityChange_(media = this.selectPlaylist()) {
-    if (media === this.mainPlaylistLoader_.media()) {
+    if (media && media === this.mainPlaylistLoader_.media()) {
       this.logger_('skipping fastQualityChange because new media is same as old');
       return;
     }
@@ -1710,7 +1710,6 @@ export class PlaylistController extends videojs.EventTarget {
     this.mainPlaylistLoader_.dispose();
     this.mainSegmentLoader_.dispose();
     this.contentSteeringController_.dispose();
-    this.keyStatusMap_.clear();
 
     if (this.loadOnPlay_) {
       this.tech_.off('play', this.loadOnPlay_);
@@ -2444,12 +2443,6 @@ export class PlaylistController extends videojs.EventTarget {
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
     this.excludeNonUsablePlaylistsByKeyId_();
-    const oldPlaylist = this.mainPlaylistLoader_.media();
-    const newPlaylist = this.selectPlaylist();
-    const keystatusChange = 'keystatus-change';
-
-    if (newPlaylist !== oldPlaylist) {
-      this.switchMedia_(newPlaylist, keystatusChange);
-    }
+    this.fastQualityChange_();
   }
 }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -1209,7 +1209,7 @@ export default class PlaylistLoader extends EventTarget {
         const keyId = playlist.contentProtection[keysystem].attributes.keyId;
 
         if (keyId) {
-          keyIds.add(keyId);
+          keyIds.add(keyId.toLowerCase());
         }
       }
       return keyIds;

--- a/test/dash-playlist-loader.test.js
+++ b/test/dash-playlist-loader.test.js
@@ -47,6 +47,8 @@ QUnit.module('DASH Playlist Loader: unit', {
 QUnit.test('can getKeyIdSet from a playlist', function(assert) {
   const loader = new DashPlaylistLoader('variant.mpd', this.fakeVhs);
   const keyId = '188743e1-bd62-400e-92d9-748f8c753d1a';
+  // Test uppercase keyId from playlist.
+  const uppercaseKeyId = '800AACAA-5229-58AE-8880-62B5695DB6BF';
   // We currently only pass keyId for widevine content protection.
   const playlist = {
     contentProtection: {
@@ -57,10 +59,15 @@ QUnit.test('can getKeyIdSet from a playlist', function(assert) {
       }
     }
   };
-  const keyIdSet = loader.getKeyIdSet(playlist);
+  let keyIdSet = loader.getKeyIdSet(playlist);
 
   assert.ok(keyIdSet.size);
   assert.ok(keyIdSet.has(keyId.replace(/-/g, '')), 'keyId is expected hex string');
+
+  playlist.contentProtection.mp4protection.attributes['cenc:default_KID'] = uppercaseKeyId;
+  keyIdSet = loader.getKeyIdSet(playlist);
+
+  assert.ok(keyIdSet.has(uppercaseKeyId.replace(/-/g, '').toLowerCase()), 'keyId is expected lowercase hex string');
 });
 
 QUnit.test('updateMain: returns falsy when there are no changes', function(assert) {

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -46,7 +46,7 @@ QUnit.module('Playlist Loader', function(hooks) {
     const keyIdSet = loader.getKeyIdSet(playlist);
 
     assert.ok(keyIdSet.size);
-    assert.ok(keyIdSet.has(keyId), 'keyId is expected hex string');
+    assert.ok(keyIdSet.has(keyId.toLowerCase()), 'keyId is expected hex string');
   });
 
   QUnit.test('updateSegments copies over properties', function(assert) {

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4871,7 +4871,7 @@ QUnit.test('eme handles keystatuschange where status is output-restricted', func
 
   this.player.tech_.vhs.playlistController_.switchMedia_ = (playlist, cause) => {
     assert.equal(playlist, playlists[2], 'playlist is expected playlist');
-    assert.equal(cause, 'keystatus-change', 'playlist is changed for expected cause');
+    assert.equal(cause, 'fast-quality', 'playlist is changed for expected cause');
     switchMediaCalled++;
   };
 


### PR DESCRIPTION
## Description
Manifests with uppercase keyIds were not matching with keyIds coming from the MediaKeyStatusMap. Also occasionally we would buffer encrypted content that we may not have a key for, we need to call fastQualityChange to clear the buffer before switching playlists.

## Specific Changes proposed
Add `toLowerCase` to the keyId from the manifest when passing the keyIdSet for playlist filtering and call `fastQualityChange` instead of `switchMedia` then fix tests.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
