### PR TITLE
fix: select next if we are at the of the current segment

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -511,24 +511,7 @@ export const getMediaInfoForTime = function({
 
     time -= partAndSegment.duration;
 
-    if (exactManifestTimings) {
-      if (time > 0) {
-        continue;
-      }
-
-      if (time === 0) {
-        // we are exactly at the end of the current segment
-        // if we passed current time -> it means that we already played current segment
-        // if we passed buffered.end -> it means that this segment is already loaded and buffered
-
-        // we should select the next segment if we have one:
-        if (i !== partsAndSegments.length - 1) {
-          continue;
-        }
-      }
-    } else if ((time - TIME_FUDGE_FACTOR) >= 0) {
-      continue;
-    } else if (time === 0) {
+    if (time === 0) {
       // we are exactly at the end of the current segment
       // if we passed current time -> it means that we already played current segment
       // if we passed buffered.end -> it means that this segment is already loaded and buffered
@@ -537,6 +520,14 @@ export const getMediaInfoForTime = function({
       if (i !== partsAndSegments.length - 1) {
         continue;
       }
+    }
+
+    if (exactManifestTimings) {
+      if (time > 0) {
+        continue;
+      }
+    } else if ((time - TIME_FUDGE_FACTOR) >= 0) {
+      continue;
     }
 
     return {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -512,14 +512,31 @@ export const getMediaInfoForTime = function({
     time -= partAndSegment.duration;
 
     if (exactManifestTimings) {
-      if (time >= 0) {
+      if (time > 0) {
         continue;
+      }
+
+      if (time === 0) {
+        // we are exactly at the end of the current segment
+        // if we passed current time -> it means that we already played current segment
+        // if we passed buffered.end -> it means that this segment is already loaded and buffered
+
+        // we should select the next segment if we have one:
+        if (i !== partsAndSegments.length - 1) {
+          continue;
+        }
       }
     } else if ((time - TIME_FUDGE_FACTOR) >= 0) {
       continue;
     } else if (time === 0) {
-      // we are exactly at the end of the current segment, we should load next one
-      continue;
+      // we are exactly at the end of the current segment
+      // if we passed current time -> it means that we already played current segment
+      // if we passed buffered.end -> it means that this segment is already loaded and buffered
+
+      // we should select the next segment if we have one:
+      if (i !== partsAndSegments.length - 1) {
+        continue;
+      }
     }
 
     return {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -512,10 +512,13 @@ export const getMediaInfoForTime = function({
     time -= partAndSegment.duration;
 
     if (exactManifestTimings) {
-      if (time > 0) {
+      if (time >= 0) {
         continue;
       }
     } else if ((time - TIME_FUDGE_FACTOR) >= 0) {
+      continue;
+    } else if (time === 0) {
+      // we are exactly at the end of the current segment, we should load next one
       continue;
     }
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1433,14 +1433,15 @@ export const LoaderCommonFactory = ({
       // force segmentIndex 4 and part 2 to be choosen
       loader.currentTime_ = () => 46;
       // make the previous part indepenent so we go back to it
-      playlist.segments[4].parts[1].independent = true;
+      playlist.segments[4].parts[2].independent = true;
+      // debugger;
       const segmentInfo = loader.chooseNextRequest_();
 
-      assert.equal(segmentInfo.partIndex, 1, 'still chooses partIndex 1');
+      assert.equal(segmentInfo.partIndex, 2, 'still chooses partIndex 2');
       assert.equal(segmentInfo.mediaIndex, 4, 'same segment');
 
       // force segmentIndex 4 and part 0 to be choosen
-      loader.currentTime_ = () => 42;
+      loader.currentTime_ = () => 40;
       // make the previous part independent
       playlist.segments[3].parts[4].independent = true;
       const segmentInfo2 = loader.chooseNextRequest_();
@@ -1466,7 +1467,7 @@ export const LoaderCommonFactory = ({
       playlist.segments[4].parts[1].independent = true;
       const segmentInfo = loader.chooseNextRequest_();
 
-      assert.equal(segmentInfo.partIndex, 2, 'chooses part 2');
+      assert.equal(segmentInfo.partIndex, 3, 'chooses part 3');
       assert.equal(segmentInfo.mediaIndex, 4, 'same segment');
     });
 
@@ -1491,7 +1492,7 @@ export const LoaderCommonFactory = ({
       playlist.segments[4].parts[1].independent = true;
       const segmentInfo = loader.chooseNextRequest_();
 
-      assert.equal(segmentInfo.partIndex, 2, 'chooses part 2');
+      assert.equal(segmentInfo.partIndex, 3, 'chooses part 3');
       assert.equal(segmentInfo.mediaIndex, 4, 'same segment');
     });
 

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -1403,8 +1403,8 @@ QUnit.module('Playlist', function() {
 
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 4}),
-          {segmentIndex: 0, startTime: 0, partIndex: null},
-          'rounds down exact matches'
+          {segmentIndex: 1, startTime: 4, partIndex: null},
+          'rounds up exact matches'
         );
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 3.7}),
@@ -1474,7 +1474,7 @@ QUnit.module('Playlist', function() {
         );
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 154, startTime: 150}),
-          {segmentIndex: 0, startTime: 150, partIndex: null},
+          {segmentIndex: 1, startTime: 154, partIndex: null},
           'calculates earlier segment on exact boundary match'
         );
         assert.deepEqual(
@@ -1533,19 +1533,19 @@ QUnit.module('Playlist', function() {
 
       assert.deepEqual(
         this.getMediaInfoForTime({currentTime: 10, startTime: 0}),
-        {segmentIndex: 2, startTime: 9, partIndex: 0},
+        {segmentIndex: 2, startTime: 10, partIndex: 1},
         'returns expected part/segment'
       );
 
       assert.deepEqual(
         this.getMediaInfoForTime({currentTime: 11, startTime: 0}),
-        {segmentIndex: 2, startTime: 10, partIndex: 1},
+        {segmentIndex: 2, startTime: 11, partIndex: 2},
         'returns expected part/segment'
       );
 
       assert.deepEqual(
         this.getMediaInfoForTime({currentTime: 11, segmentIndex: -15}),
-        {segmentIndex: 2, startTime: 10, partIndex: 1},
+        {segmentIndex: 2, startTime: 11, partIndex: 2},
         'returns expected part/segment'
       );
     });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1601,7 +1601,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
         assert.equal(
           loader.pendingSegment_.timestampOffset,
-          60,
+          70,
           'timestamp offset is nonzero'
         );
         assert.equal(loader.state, 'WAITING', 'state is waiting on segment');

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -710,7 +710,7 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
         };
 
         loader.currentTime_ = () => {
-          return 30;
+          return 20;
         };
 
         loader.playlist(playlist);


### PR DESCRIPTION
## Description
Assume we have the following playlist:

``` shell
#EXTINF:6.000,
segment-1.ts
#EXTINF:6.000,
segment-2.ts
#EXTINF:6.000,
segment-3.ts
#EXTINF:6.000,
segment-4.ts
#EXTINF:6.000,
segment-5.ts
#EXTINF:6.000,
segment-6.ts
...
```

Assume we switch rendition based on bandwidth update. 
We are selecting the next segment to load based on the buffered.end (assume current buffered is [0 - 12]).

Currently, we select `segment-2.ts`, but it is already buffered.

or assume we switch rendition based on a fast quality switch.
We are selecting the next segment to load based on the current time (current time is 12).

Currently, we select `segment-2.ts` but it is already played.

in both cases, we should select the next segment (`segment-3.ts`)

## Specific Changes proposed
Select the next segment when we are at the exact segment.end boundary.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
