### PR TITLE
fix: keyId filtering loadedplaylist listener and improvements

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2409,9 +2409,8 @@ export class PlaylistController extends videojs.EventTarget {
         const hasUsableKeyStatus = this.keyStatusMap_.has(key) && this.keyStatusMap_.get(key) === USABLE;
         const nonUsableExclusion = playlist.lastExcludeReason_ === NON_USABLE && playlist.excludeUntil === Infinity;
 
-        // Lets add a failsafe here where we won't exclude the last possible playlist and try and play.
         if (!hasUsableKeyStatus) {
-          if (!nonUsableExclusion) {
+          if (!playlist.excludeUntil === Infinity) {
             playlist.excludeUntil = Infinity;
             playlist.lastExcludeReason_ = NON_USABLE;
             this.logger_(`excluding playlist ${playlist.id} because the key ID ${key} doesn't exist in the keyStatusMap or is not ${USABLE}`);

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2446,7 +2446,7 @@ export class PlaylistController extends videojs.EventTarget {
     this.excludeNonUsablePlaylistsByKeyId_();
     this.fastQualityChange_();
     // Listen to loadedplaylist with a single listener and check for new contentProtection elements when a playlist is updated.
-    this.off('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
-    this.on('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
+    this.mainPlaylistLoader_.off('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
+    this.mainPlaylistLoader_.on('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2443,10 +2443,14 @@ export class PlaylistController extends videojs.EventTarget {
    */
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
+    this.excludeNonUsableThenChangePlaylist_();
+    // Listen to loadedplaylist with a single listener and check for new contentProtection elements when a playlist is updated.
+    this.mainPlaylistLoader_.off('loadedplaylist', this.excludeNonUsableThenChangePlaylist_.bind(this));
+    this.mainPlaylistLoader_.on('loadedplaylist', this.excludeNonUsableThenChangePlaylist_.bind(this));
+  }
+
+  excludeNonUsableThenChangePlaylist_() {
     this.excludeNonUsablePlaylistsByKeyId_();
     this.fastQualityChange_();
-    // Listen to loadedplaylist with a single listener and check for new contentProtection elements when a playlist is updated.
-    this.mainPlaylistLoader_.off('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
-    this.mainPlaylistLoader_.on('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2433,8 +2433,8 @@ export class PlaylistController extends videojs.EventTarget {
         const excludedForNonUsableKey = playlist.excludeUntil === Infinity && playlist.lastExcludeReason_ === NON_USABLE;
 
         if (isNonHD && excludedForNonUsableKey) {
+          // Only delete the excludeUntil so we don't try and re-exclude these playlists.
           delete playlist.excludeUntil;
-          delete playlist.lastExcludeReason_;
           videojs.log.warn(`enabling non-HD playlist ${playlist.id} because all playlists were excluded due to ${NON_USABLE} keyIds`);
         }
       });

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2410,7 +2410,7 @@ export class PlaylistController extends videojs.EventTarget {
         const nonUsableExclusion = playlist.lastExcludeReason_ === NON_USABLE && playlist.excludeUntil === Infinity;
 
         if (!hasUsableKeyStatus) {
-          if (!playlist.excludeUntil === Infinity) {
+          if (playlist.excludeUntil !== Infinity) {
             playlist.excludeUntil = Infinity;
             playlist.lastExcludeReason_ = NON_USABLE;
             this.logger_(`excluding playlist ${playlist.id} because the key ID ${key} doesn't exist in the keyStatusMap or is not ${USABLE}`);

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2410,7 +2410,8 @@ export class PlaylistController extends videojs.EventTarget {
         const nonUsableExclusion = playlist.lastExcludeReason_ === NON_USABLE && playlist.excludeUntil === Infinity;
 
         if (!hasUsableKeyStatus) {
-          if (playlist.excludeUntil !== Infinity) {
+          // Only exclude playlists that haven't already been excluded as non-usable.
+          if (!nonUsableExclusion && playlist.lastExcludeReason_ !== NON_USABLE) {
             playlist.excludeUntil = Infinity;
             playlist.lastExcludeReason_ = NON_USABLE;
             this.logger_(`excluding playlist ${playlist.id} because the key ID ${key} doesn't exist in the keyStatusMap or is not ${USABLE}`);
@@ -2434,7 +2435,7 @@ export class PlaylistController extends videojs.EventTarget {
         if (isNonHD && excludedForNonUsableKey) {
           // Only delete the excludeUntil so we don't try and re-exclude these playlists.
           delete playlist.excludeUntil;
-          videojs.log.warn(`enabling non-HD playlist ${playlist.id} because all playlists were excluded due to ${NON_USABLE} keyIds`);
+          videojs.log.warn(`enabling non-HD playlist ${playlist.id} because all playlists were excluded due to ${NON_USABLE} key IDs`);
         }
       });
     }
@@ -2451,7 +2452,7 @@ export class PlaylistController extends videojs.EventTarget {
     const keyIdHexString = isString ? keyId : bufferToHexString(keyId);
     const formattedKeyIdString = keyIdHexString.slice(0, 32).toLowerCase();
 
-    this.logger_(`KeyStatus ${status} with keyId ${formattedKeyIdString} added to the keyStatusMap`);
+    this.logger_(`KeyStatus '${status}' with key ID ${formattedKeyIdString} added to the keyStatusMap`);
     this.keyStatusMap_.set(formattedKeyIdString, status);
   }
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2410,7 +2410,7 @@ export class PlaylistController extends videojs.EventTarget {
         const nonUsableExclusion = playlist.lastExcludeReason_ === NON_USABLE && playlist.excludeUntil === Infinity;
 
         // Lets add a failsafe here where we won't exclude the last possible playlist and try and play.
-        if (!hasUsableKeyStatus) {
+        if (!hasUsableKeyStatus && !nonUsableExclusion) {
           playlist.excludeUntil = Infinity;
           playlist.lastExcludeReason_ = NON_USABLE;
           excludedPlaylistCount++;

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2450,9 +2450,10 @@ export class PlaylistController extends videojs.EventTarget {
   addKeyStatus_(keyId, status) {
     const isString = typeof keyId === 'string';
     const keyIdHexString = isString ? keyId : bufferToHexString(keyId);
+    const formattedKeyIdString = keyIdHexString.slice(0, 32).toLowerCase();
 
-    // 32 digit keyId hex string.
-    this.keyStatusMap_.set(keyIdHexString.slice(0, 32), status);
+    this.logger_(`KeyStatus ${status} with keyId ${formattedKeyIdString} added to the keyStatusMap`);
+    this.keyStatusMap_.set(formattedKeyIdString, status);
   }
 
   /**
@@ -2463,7 +2464,9 @@ export class PlaylistController extends videojs.EventTarget {
    */
   updatePlaylistByKeyStatus(keyId, status) {
     this.addKeyStatus_(keyId, status);
-    this.excludeNonUsableThenChangePlaylist_();
+    if (!this.waitingForFastQualityPlaylistReceived_) {
+      this.excludeNonUsableThenChangePlaylist_();
+    }
     // Listen to loadedplaylist with a single listener and check for new contentProtection elements when a playlist is updated.
     this.mainPlaylistLoader_.off('loadedplaylist', this.excludeNonUsableThenChangePlaylist_.bind(this));
     this.mainPlaylistLoader_.on('loadedplaylist', this.excludeNonUsableThenChangePlaylist_.bind(this));

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2445,5 +2445,8 @@ export class PlaylistController extends videojs.EventTarget {
     this.addKeyStatus_(keyId, status);
     this.excludeNonUsablePlaylistsByKeyId_();
     this.fastQualityChange_();
+    // Listen to loadedplaylist with a single listener and check for new contentProtection elements when a playlist is updated.
+    this.off('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
+    this.on('loadedplaylist', this.excludeNonUsablePlaylistsByKeyId_.bind(this));
   }
 }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -2411,7 +2411,7 @@ export class PlaylistController extends videojs.EventTarget {
 
         if (!hasUsableKeyStatus) {
           // Only exclude playlists that haven't already been excluded as non-usable.
-          if (!nonUsableExclusion && playlist.lastExcludeReason_ !== NON_USABLE) {
+          if (playlist.excludeUntil !== Infinity && playlist.lastExcludeReason_ !== NON_USABLE) {
             playlist.excludeUntil = Infinity;
             playlist.lastExcludeReason_ = NON_USABLE;
             this.logger_(`excluding playlist ${playlist.id} because the key ID ${key} doesn't exist in the keyStatusMap or is not ${USABLE}`);

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -5061,6 +5061,59 @@ QUnit.test('excludeNonUsablePlaylistsByKeyId_ re includes non usable DASH playli
   });
 });
 
+QUnit.test('excludeNonUsablePlaylistsByKeyId_ re-includes SD playlists when all playlists are excluded', function(assert) {
+  const options = {
+    src: 'test',
+    tech: this.player.tech_,
+    sourceType: 'dash'
+  };
+  const pc = new PlaylistController(options);
+  const origWarn = videojs.log.warn;
+  const warnings = [];
+
+  videojs.log.warn = (text) => warnings.push(text);
+
+  const excludedPlaylist = {
+    contentProtection: {
+      mp4protection: {
+        attributes: {
+          'cenc:default_KID': 'd0bebaf8a3cb4c52bae03d20a71e3df3'
+        }
+      }
+    },
+    attributes: {
+      RESOLUTION: {
+        height: 480
+      }
+    }
+  };
+
+  const includedPlaylist = {
+    contentProtection: {
+      mp4protection: {
+        attributes: {
+          'cenc:default_KID': '89256e53dbe544e9afba38d2ca17d176'
+        }
+      }
+    },
+    attributes: {
+      RESOLUTION: {
+        height: 360
+      }
+    }
+  };
+
+  pc.mainPlaylistLoader_.main = { playlists: [includedPlaylist, excludedPlaylist] };
+  pc.excludeNonUsablePlaylistsByKeyId_();
+
+  assert.notOk(pc.mainPlaylistLoader_.main.playlists[0].excludeUntil, 'excludeUntil is Infinity');
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[0].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
+  assert.notOk(pc.mainPlaylistLoader_.main.playlists[1].excludeUntil, 'excludeUntil is Infinity');
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[1].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
+  assert.equal(warnings.length, 2, 're-include warning for both playlists');
+  videojs.log.warn = origWarn;
+});
+
 QUnit.module('PlaylistController codecs', {
   beforeEach(assert) {
     sharedHooks.beforeEach.call(this, assert);

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -5073,7 +5073,7 @@ QUnit.test('excludeNonUsablePlaylistsByKeyId_ re-includes SD playlists when all 
 
   videojs.log.warn = (text) => warnings.push(text);
 
-  const excludedPlaylist = {
+  const reIncludedPlaylist1 = {
     contentProtection: {
       mp4protection: {
         attributes: {
@@ -5088,7 +5088,7 @@ QUnit.test('excludeNonUsablePlaylistsByKeyId_ re-includes SD playlists when all 
     }
   };
 
-  const includedPlaylist = {
+  const reIncludedPlaylist2 = {
     contentProtection: {
       mp4protection: {
         attributes: {
@@ -5103,14 +5103,31 @@ QUnit.test('excludeNonUsablePlaylistsByKeyId_ re-includes SD playlists when all 
     }
   };
 
-  pc.mainPlaylistLoader_.main = { playlists: [includedPlaylist, excludedPlaylist] };
+  const excludedPlaylist = {
+    contentProtection: {
+      mp4protection: {
+        attributes: {
+          'cenc:default_KID': '89256e53dbe544e9afba38d2ca17d176'
+        }
+      }
+    },
+    attributes: {
+      RESOLUTION: {
+        height: 1080
+      }
+    }
+  };
+
+  pc.mainPlaylistLoader_.main = { playlists: [reIncludedPlaylist1, reIncludedPlaylist2, excludedPlaylist] };
   pc.excludeNonUsablePlaylistsByKeyId_();
 
-  assert.notOk(pc.mainPlaylistLoader_.main.playlists[0].excludeUntil, 'excludeUntil is Infinity');
+  assert.notOk(pc.mainPlaylistLoader_.main.playlists[0].excludeUntil, 'excludeUntil is not Infinity');
   assert.equal(pc.mainPlaylistLoader_.main.playlists[0].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
-  assert.notOk(pc.mainPlaylistLoader_.main.playlists[1].excludeUntil, 'excludeUntil is Infinity');
+  assert.notOk(pc.mainPlaylistLoader_.main.playlists[1].excludeUntil, 'excludeUntil is not Infinity');
   assert.equal(pc.mainPlaylistLoader_.main.playlists[1].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
   assert.equal(warnings.length, 2, 're-include warning for both playlists');
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[2].excludeUntil, Infinity, 'excludeUntil is Infinity');
+  assert.equal(pc.mainPlaylistLoader_.main.playlists[2].lastExcludeReason_, 'non-usable', 'lastExcludeReason is non-usable');
   videojs.log.warn = origWarn;
 });
 


### PR DESCRIPTION
## Description
After doing some further testing with HLS and playlist exclusion by keyId, it became apparent some more fixes were needed to properly request and filter all possible variants.

I also added a fallback mechanism and additional logging. I was testing another asset with no matching keys and it seemed necessary to at least _TRY_ and play the non-HD playlists if we have previously excluded them due to non-usable or non-matching keyIds.

## Specific Changes proposed
Listening to `loadedplaylist` and calling `excludeNonUsablePlaylistsByKeyId_` and `fastQualityChange` when a new playlist is loaded. This allows the `playlist-controller` to check the keyId in the loaded or refreshed playlist for an HLS variant, or a refreshed DASH manifest.

Also, add a conditional after the playlist exclusion loop that checks if we excluded all of the playlists due to non-usable status or non-matching keys and re-includes all the SD playlists and logs a warning. This provides VHS with a bit more resilience against unexpected manifests or license data.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
