### PR TITLE
fix: account for difference between duration info in the playlist and the actual duration

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -511,8 +511,16 @@ export const getMediaInfoForTime = function({
 
     time -= partAndSegment.duration;
 
-    if (time === 0) {
-      // we are exactly at the end of the current segment
+    if (time === 0 || (time + TIME_FUDGE_FACTOR) >= 0) {
+      // 1) We are exactly at the end of the current segment.
+      // 2) We are extremely close to the end of the current segment (The difference is less than  1 / 30).
+      //    We may encounter this situation when
+      //    we don't have exact match between segment duration info in the manifest and the actual duration of the segment
+      //    For example:
+      //    We appended 3 segments 10 seconds each, meaning we should have 30 sec buffered,
+      //    but we the actual buffered is 29.99999
+      //
+      // In both cases:
       // if we passed current time -> it means that we already played current segment
       // if we passed buffered.end -> it means that this segment is already loaded and buffered
 

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -511,7 +511,11 @@ export const getMediaInfoForTime = function({
 
     time -= partAndSegment.duration;
 
-    if (time === 0 || (time + TIME_FUDGE_FACTOR) >= 0) {
+    const canUseFudgeFactor = partAndSegment.duration > TIME_FUDGE_FACTOR;
+    const isExactlyAtTheEnd = time === 0;
+    const isExtremelyCloseToTheEnd = canUseFudgeFactor && (time + TIME_FUDGE_FACTOR >= 0);
+
+    if (isExactlyAtTheEnd || isExtremelyCloseToTheEnd) {
       // 1) We are exactly at the end of the current segment.
       // 2) We are extremely close to the end of the current segment (The difference is less than  1 / 30).
       //    We may encounter this situation when


### PR DESCRIPTION
## Description
we should account for the difference between the duration info in the manifest and the actual duration of the segment when selecting next segment after quality change.

Assume we have the following playlist:

```shell
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-TARGETDURATION:10
#EXTINF:10.000,
segment-1.ts
#EXTINF:10.000,
segment-2.ts
#EXTINF:10.000,
segment-3.ts
#EXTINF:10.000,
segment-4.ts
#EXT-X-ENDLIST
```

Assume we already appended two segments, so `bufferend.end` should be `20`, but we don't have an exact duration match between the playlist and the actual segment duration, so we receive it as `19.99999..`. 
Currently, we select segment-2.ts instead of segment-3.ts because we do not account for this timestamp fluctuation.

## Specific Changes proposed
Check whether we hit timestamp fluctuation by adding `TIME_FUDGE_FACTOR` (1 / 30).

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
