### PR TITLE
fix: changeType on full codec change only

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -275,14 +275,24 @@ const actions = {
     }
 
     // do not update codec if we don't need to.
-    if (sourceUpdater.codecs[type] === codec) {
+    // Only update if we change the codec base.
+    // For example, going from avc1.640028 to avc1.64001f does not require a changeType call.
+    const newCodecBase = codec.substring(0, codec.indexOf('.'));
+    const oldCodec = sourceUpdater.codecs[type];
+    const oldCodecBase = oldCodec.substring(0, oldCodec.indexOf('.'));
+
+    if (oldCodecBase === newCodecBase) {
       return;
     }
 
     sourceUpdater.logger_(`changing ${type}Buffer codec from ${sourceUpdater.codecs[type]} to ${codec}`);
 
-    sourceBuffer.changeType(mime);
-    sourceUpdater.codecs[type] = codec;
+    try {
+      sourceBuffer.changeType(mime);
+      sourceUpdater.codecs[type] = codec;
+    } catch (e) {
+      videojs.log.warn(`Failed to changeType on ${type}Buffer`, e);
+    }
   }
 };
 


### PR DESCRIPTION
## Description
Call changeType only when the codec base has changed.

## Specific Changes proposed
Parse the codec base from the new codec and the existing codec for the given track and compare that to determine if we need to call changeType on the source buffer.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
