### PR TITLE
docs: removing duplicated step

### DIFF
--- a/docs/multiple-alternative-audio-tracks.md
+++ b/docs/multiple-alternative-audio-tracks.md
@@ -91,6 +91,5 @@ Corresponding AudioTrackList when media-group-1 is used (before any tracks have 
 1. `HLS` sends the `label` for the new `AudioTrack` to `PlaylistController`s `useAudio` function
 1. `PlaylistController` turns off the current audio `PlaylistLoader` if it is on
 1. `PlaylistController` maps the `label` to the `PlaylistLoader` containing the audio
-1. `PlaylistController` maps the `label` to the `PlaylistLoader` containing the audio
 1. `PlaylistController` turns on that `PlaylistLoader` and the Corresponding `SegmentLoader` (main or audio only)
 1. `MediaSource`/`mux.js` determine how to mux


### PR DESCRIPTION
## Description
Looking through docs I found a duplicated step

## Specific Changes proposed
Remove duplicated step in multiple-alternative-audio-tracks doc

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
