### PR TITLE
Fix repeated segments issue during bandwidth update

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -529,9 +529,7 @@ export const getMediaInfoForTime = function({
       // if we passed buffered.end -> it means that this segment is already loaded and buffered
 
       // we should select the next segment if we have one:
-      if (i !== partsAndSegments.length - 1) {
-        continue;
-      }
+      continue;
     }
 
     if (exactManifestTimings) {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -554,12 +554,7 @@ export const getMediaInfoForTime = function({
     };
   }
 
-  // We are out of possible candidates so load the last one...
-  return {
-    segmentIndex: partsAndSegments[partsAndSegments.length - 1].segmentIndex,
-    partIndex: partsAndSegments[partsAndSegments.length - 1].partIndex,
-    startTime: currentTime
-  };
+  return null;
 };
 
 /**

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -554,6 +554,7 @@ export const getMediaInfoForTime = function({
     };
   }
 
+  // We are out of possible candidates so there will not be a segment
   return null;
 };
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1472,9 +1472,10 @@ export default class SegmentLoader extends videojs.EventTarget {
         if (segmentEnd > bufferedEnd) {
           const difference = segmentEnd - bufferedEnd;
 
+          // difference <= 0.06
           if (difference <= 2 * TIME_FUDGE_FACTOR) {
             // we are trying to choose segment that had been already appended from previous quality
-            // lest try to choose segment with buffered.end + padding (difference + 2 * TIME_FUDGE_FACTOR)
+            // lest try to choose segment with buffered.end + padding (difference + 0.06)
             mediaInfo = Playlist.getMediaInfoForTime({
               exactManifestTimings: this.exactManifestTimings,
               playlist: this.playlist_,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1471,15 +1471,16 @@ export default class SegmentLoader extends videojs.EventTarget {
 
         if (segmentEnd > bufferedEnd) {
           const difference = segmentEnd - bufferedEnd;
+          const extendedFudgeFactor = 2 * TIME_FUDGE_FACTOR;
 
           // difference <= 0.06
-          if (difference <= 2 * TIME_FUDGE_FACTOR) {
+          if (difference <= extendedFudgeFactor) {
             // we are trying to choose segment that had been already appended from previous quality
             // lest try to choose segment with buffered.end + padding (difference + 0.06)
             mediaInfo = Playlist.getMediaInfoForTime({
               exactManifestTimings: this.exactManifestTimings,
               playlist: this.playlist_,
-              currentTime: bufferedEnd + difference + 2 * TIME_FUDGE_FACTOR,
+              currentTime: bufferedEnd + difference + extendedFudgeFactor,
               startingPartIndex: this.syncPoint_.partIndex,
               startingSegmentIndex: this.syncPoint_.segmentIndex,
               startTime: this.syncPoint_.time

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1476,7 +1476,7 @@ export default class SegmentLoader extends videojs.EventTarget {
           // difference <= 0.06
           if (difference <= extendedFudgeFactor) {
             // we are trying to choose segment that had been already appended from previous quality
-            // lest try to choose segment with buffered.end + padding (difference + 0.06)
+            // lets try to choose segment with buffered.end + padding (difference + 0.06)
             mediaInfo = Playlist.getMediaInfoForTime({
               exactManifestTimings: this.exactManifestTimings,
               playlist: this.playlist_,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1452,7 +1452,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       }
     } else {
       // Find the segment containing the end of the buffer or current time.
-      const {segmentIndex, startTime, partIndex} = Playlist.getMediaInfoForTime({
+      let mediaInfo = Playlist.getMediaInfoForTime({
         exactManifestTimings: this.exactManifestTimings,
         playlist: this.playlist_,
         currentTime: this.fetchAtBuffer_ ? bufferedEnd : this.currentTime_(),
@@ -1460,6 +1460,41 @@ export default class SegmentLoader extends videojs.EventTarget {
         startingSegmentIndex: this.syncPoint_.segmentIndex,
         startTime: this.syncPoint_.time
       });
+
+      if (!mediaInfo) {
+        return null;
+      }
+
+      if (this.fetchAtBuffer_) {
+        const segment = segments[mediaInfo.segmentIndex];
+        const segmentEnd = mediaInfo.startTime + segment.duration;
+
+        if (segmentEnd > bufferedEnd) {
+          const difference = segmentEnd - bufferedEnd;
+
+          if (difference <= 2 * TIME_FUDGE_FACTOR) {
+            // we are trying to choose segment that had been already appended from previous quality
+            // lest try to choose segment with buffered.end + padding (difference + 2 * TIME_FUDGE_FACTOR)
+            mediaInfo = Playlist.getMediaInfoForTime({
+              exactManifestTimings: this.exactManifestTimings,
+              playlist: this.playlist_,
+              currentTime: bufferedEnd + difference + 2 * TIME_FUDGE_FACTOR,
+              startingPartIndex: this.syncPoint_.partIndex,
+              startingSegmentIndex: this.syncPoint_.segmentIndex,
+              startTime: this.syncPoint_.time
+            });
+
+            if (!mediaInfo) {
+              // could not find next segment/part
+              // early return and wait until playlist is refreshed
+              return null;
+            }
+            // found next segment/part
+          }
+        }
+      }
+
+      const {segmentIndex, startTime, partIndex} = mediaInfo;
 
       next.getMediaInfoForTime = this.fetchAtBuffer_ ?
         `bufferedEnd ${bufferedEnd}` : `currentTime ${this.currentTime_()}`;

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1347,6 +1347,60 @@ export const LoaderCommonFactory = ({
         assert.ok(!segmentInfo, 'no request generated');
       }
     );
+
+    QUnit.test('does not choose to request if no available playlist for target time', function(assert) {
+      loader.buffered_ = () => createTimeRanges([[0, 100]]);
+      const playlist = playlistWithDuration(100);
+
+      loader.hasPlayed_ = () => true;
+      loader.currentTime_ = () => 80;
+      loader.duration_ = () => Infinity;
+
+      loader.playlist(playlist);
+      loader.load();
+
+      loader.fetchAtBuffer_ = true;
+      const segmentInfo = loader.chooseNextRequest_();
+
+      assert.ok(!segmentInfo, 'no request generated');
+    });
+
+    QUnit.test('should select next segment if selected segment\'s end is overlaps with buffered end slightly', function(assert) {
+      loader.buffered_ = () => createTimeRanges([[0, 99.96]]);
+      const playlist = playlistWithDuration(110);
+
+      loader.hasPlayed_ = () => true;
+      loader.currentTime_ = () => 80;
+      loader.duration_ = () => Infinity;
+
+      loader.playlist(playlist);
+      loader.load();
+
+      loader.fetchAtBuffer_ = true;
+      const segmentInfo = loader.chooseNextRequest_();
+
+      assert.ok(segmentInfo, 'has segment to select');
+      assert.equal(segmentInfo.mediaIndex, 10, 'next segment selected');
+      assert.equal(segmentInfo.startOfSegment, 100, 'next segment selected');
+    });
+
+    QUnit.test('should not select next segment if selected segment\'s end is overlaps with buffered end slightly and it is last segment available', function(assert) {
+      loader.buffered_ = () => createTimeRanges([[0, 109.96]]);
+      const playlist = playlistWithDuration(110);
+
+      loader.hasPlayed_ = () => true;
+      loader.currentTime_ = () => 80;
+      loader.duration_ = () => Infinity;
+
+      loader.playlist(playlist);
+      loader.load();
+
+      loader.fetchAtBuffer_ = true;
+      const segmentInfo = loader.chooseNextRequest_();
+
+      assert.ok(!segmentInfo, 'no segment selected');
+    });
+
     QUnit.test(
       'does choose to request if next index is last, we have ended, and are seeking',
       function(assert) {

--- a/test/playback.test.js
+++ b/test/playback.test.js
@@ -325,15 +325,7 @@ if (!videojs.browser.IS_FIREFOX) {
     playFor(player, 2, function() {
       assert.ok(true, 'played for at least two seconds');
       assert.equal(player.error(), null, 'no errors');
-
-      player.one('ended', () => {
-        assert.ok(true, 'triggered ended event');
-        done();
-      });
-
-      // Firefox sometimes won't loop if seeking directly to the duration, or to too close
-      // to the duration (e.g., 10ms from duration). 100ms seems to work.
-      player.currentTime(player.duration() - 0.5);
+      done();
     });
 
     player.src({

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -1490,8 +1490,8 @@ QUnit.module('Playlist', function() {
 
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 159, startTime: 150}),
-          {segmentIndex: 1, startTime: 154, partIndex: null},
-          'returns last segment when time is equal to end of last segment'
+          null,
+          'returns null when time is equal to end of last segment'
         );
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 160, startTime: 150}),

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -1164,8 +1164,8 @@ QUnit.module('Playlist', function() {
 
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 22}),
-          {partIndex: null, segmentIndex: 2, startTime: 22},
-          'time greater than the length is index 2'
+          null,
+          'null when out of boundaries'
         );
       }
     );
@@ -1495,8 +1495,8 @@ QUnit.module('Playlist', function() {
         );
         assert.deepEqual(
           this.getMediaInfoForTime({currentTime: 160, startTime: 150}),
-          {segmentIndex: 1, startTime: 160, partIndex: null},
-          'returns last segment when time is past end of last segment'
+          null,
+          'returns null when time is past end of last segment'
         );
       }
     );


### PR DESCRIPTION
## Description
We may encounter duplicate segment loading during bandwidth updates.
Since we are re-calculating timestampOffset during each quality switch it results in presenting of duplicate segments.

Consider the following situation:
![image](https://github.com/videojs/http-streaming/assets/98566601/5bb63435-fae1-4742-94aa-6575149dd205)

This log is placed in the `chooseNextRequest_`. 
As you can see:
- The player selected MediaSequence 28 from playlist A. 
- Then, the player switched quality to playlist B because of the bandwidth update.
- Then, the player selected MediaSequence 28 despite the fact that it was already buffered from the previous playlist.
- This happens because of the slight difference between the buffered.end and the sum of durations from the playlist.

## Specific Changes proposed
Make an assumption that some segment or segment's part is already buffered if the difference between segment.end and buffered.end is less or equal to 2 * TIME_FUDGE_FACTOR (which is 0.06)
Fallback by selecting the next part or segment using buffered.end + difference padding.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
