### PR TITLE
chore(demo): Remove error on iOS on demo page

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -438,7 +438,7 @@
     var steeringManifestEl = document.querySelector('.steering-manifest');
 
     player.one('loadedmetadata', function() {
-      var steeringController = player.tech_.vhs.playlistController_.contentSteeringController_;
+      var steeringController = player.tech_.vhs && player.tech_.vhs.playlistController_.contentSteeringController_;
 
       if (!steeringController) {
         return;


### PR DESCRIPTION
## Description
Removes an error on the demo page with native playback from an unguarded call to property on `player.tech_.vhs`

## Specific Changes proposed
Using `&&` since this page should be usable on old Chrome.