### PR TITLE
chore: update mux.js to v7.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6925,9 +6925,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
-      "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+      "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "global": "^4.4.0",
     "m3u8-parser": "^7.1.0",
     "mpd-parser": "^1.3.0",
-    "mux.js": "7.0.2",
+    "mux.js": "7.0.3",
     "video.js": "^7 || ^8"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

update mux.js to v7.0.3

This includes a fix for some unexpected 608 caption behavior.


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
