### PR TITLE
fix: llHLS does not need forcedTimestampOffset

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1240,8 +1240,9 @@ bufferedEnd: ${lastBufferedEnd(this.buffered_())}
     // this is mainly to sync timing-info when switching between renditions with and without timestamp-rollover,
     // so we don't want it for DASH or fragmented mp4 segments.
     const isFmp4 = this.currentMediaInfo_ && this.currentMediaInfo_.isFmp4;
+    const isHlsTs = this.sourceType_ === 'hls' && !isFmp4;
 
-    if (this.sourceType_ === 'hls' && !isFmp4) {
+    if (isHlsTs) {
       this.shouldForceTimestampOffsetAfterResync_ = true;
     }
     this.callQueue_ = [];

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1238,8 +1238,10 @@ bufferedEnd: ${lastBufferedEnd(this.buffered_())}
     this.syncPoint_ = null;
     this.isPendingTimestampOffset_ = false;
     // this is mainly to sync timing-info when switching between renditions with and without timestamp-rollover,
-    // so we don't want it for DASH
-    if (this.sourceType_ === 'hls') {
+    // so we don't want it for DASH or fragmented mp4 segments.
+    const isFmp4 = this.currentMediaInfo_ && this.currentMediaInfo_.isFmp4;
+
+    if (this.sourceType_ === 'hls' && !isFmp4) {
       this.shouldForceTimestampOffsetAfterResync_ = true;
     }
     this.callQueue_ = [];


### PR DESCRIPTION
## Description
timestampOffset was being reset on LL-HLS quality changes. We only want to force timestampOffset changes on rendition switches for `.ts` segments due to the timestamp rollover problem in those containers.

## Specific Changes proposed
Check if the current media is fmp4, if it is don't force the timestampOffset reset after a resync of the segment loader.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
