### PR TITLE
fix: enableFunction not passing playlist to fastQualityChange

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -21,7 +21,7 @@
       rep.playlist.disabled = rep.id !== id;
     });
 
-    window.pc.fastQualityChange_();
+    window.pc.fastQualityChange_(selectedOption);
   });
   var isManifestObjectType = function(url) {
     return (/application\/vnd\.videojs\.vhs\+json/).test(url);

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -30,7 +30,7 @@ const enableFunction = (loader, playlistID, changePlaylistFn) => (enable) => {
 
   if (enable !== currentlyEnabled && !incompatible) {
     // Ensure the outside world knows about our changes
-    changePlaylistFn();
+    changePlaylistFn(playlist);
     if (enable) {
       loader.trigger('renditionenabled');
     } else {


### PR DESCRIPTION
## Description
Our rendition mixin `enableFunction` is used to select a rendition/variant for playback. This function uses the playlist controller `fastQualityChange_` to do this switch, however we were not passing the playlist during this call, resulting in inconsistent quality switches due to the next playlist coming from a `selectPlaylist()` call instead of user selection.

## Specific Changes proposed
Pass playlist as a parameter during the `fastQualityChange_` /`changePlaylistFn` call

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
