### PR TITLE
fix: use paren media sequence sync for audio and vtt, since they are opt-in features and can be enabled after main init.

### DIFF
--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -5,7 +5,7 @@
 import {sumDurations, getPartsAndSegments} from './playlist';
 import videojs from 'video.js';
 import logger from './util/logger';
-import MediaSequenceSync from './util/media-sequence-sync';
+import {MediaSequenceSync, DependantMediaSequenceSync} from './util/media-sequence-sync';
 
 // The maximum gap allowed between two media sequence tags when trying to
 // synchronize expired playlist segments.
@@ -233,11 +233,11 @@ export default class SyncController extends videojs.EventTarget {
     //  For some reason this map helps with syncing between quality switch for MPEG-DASH as well.
     //  Moreover if we disable this map for MPEG-DASH - quality switch will be broken.
     //  MPEG-DASH should have its own separate sync strategy
-    this.mediaSequenceStorage_ = {
-      main: new MediaSequenceSync(),
-      audio: new MediaSequenceSync(),
-      vtt: new MediaSequenceSync()
-    };
+    const main = new MediaSequenceSync();
+    const audio = new DependantMediaSequenceSync(main);
+    const vtt = new DependantMediaSequenceSync(main);
+
+    this.mediaSequenceStorage_ = {main, audio, vtt};
     this.logger_ = logger('SyncController');
   }
 

--- a/src/util/media-sequence-sync.js
+++ b/src/util/media-sequence-sync.js
@@ -79,11 +79,11 @@ class SyncInfoData {
   }
 }
 
-export default class MediaSequenceSync {
+export class MediaSequenceSync {
   constructor() {
     /**
      * @type {Map<number, SyncInfoData>}
-     * @private
+     * @protected
      */
     this.storage_ = new Map();
     this.diagnostics_ = '';
@@ -158,6 +158,10 @@ export default class MediaSequenceSync {
     }
 
     return null;
+  }
+
+  getSyncInfoForMediaSequence(mediaSequence) {
+    return this.storage_.get(mediaSequence);
   }
 
   updateStorage_(segments, startingMediaSequence, startingTime) {
@@ -242,5 +246,27 @@ export default class MediaSequenceSync {
 
   isReliablePlaylist_(mediaSequence, segments) {
     return mediaSequence !== undefined && mediaSequence !== null && Array.isArray(segments) && segments.length;
+  }
+}
+
+export class DependantMediaSequenceSync extends MediaSequenceSync {
+  constructor(parent) {
+    super();
+
+    this.parent_ = parent;
+  }
+
+  calculateBaseTime_(mediaSequence, fallback) {
+    if (!this.storage_.size) {
+      const info = this.parent_.getSyncInfoForMediaSequence(mediaSequence);
+
+      if (info) {
+        return info.segmentSyncInfo.start;
+      }
+
+      return 0;
+    }
+
+    return super.calculateBaseTime_(mediaSequence, fallback);
   }
 }


### PR DESCRIPTION
## Description
`audio` and `vtt` segment loaders are opt-in features and can be enabled after the `main` start. (eg: via UI)
We should align the media sequence start time with the `main` for them.

## Specific Changes proposed
Use `parent` for `vtt` and `audio` media sequence storages.
`parent` should be `main`.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
