### PR TITLE
chore: update contrib-eme to v5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9250,13 +9250,12 @@
       }
     },
     "videojs-contrib-eme": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-5.0.1.tgz",
-      "integrity": "sha512-mkmGVfXgkMLf5BYO/WA35Nc1yObFb5oF8kNimD2/wc6U/Kk0VHBsdVU4QAfPvpZ4EFbnblsqxT6nQ4q2pl9zTg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-5.3.1.tgz",
+      "integrity": "sha512-grcg8y6EvBOu4sprCKR8nHfjqt7hjnvshX3DnO46VizNqM6JBt99dePL54dO3iMIBElYMRCNC08GFOMqXqpYPA==",
       "dev": true,
       "requires": {
-        "global": "^4.3.2",
-        "video.js": "^6 || ^7 || ^8"
+        "global": "^4.3.2"
       }
     },
     "videojs-contrib-quality-levels": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "shelljs": "^0.8.5",
     "sinon": "^8.1.1",
     "url-toolkit": "^2.2.1",
-    "videojs-contrib-eme": "^5.0.1",
+    "videojs-contrib-eme": "^5.3.1",
     "videojs-contrib-quality-levels": "^4.0.0",
     "videojs-generate-karma-config": "^8.0.1",
     "videojs-generate-rollup-config": "^7.0.0",


### PR DESCRIPTION
## Description
update the peer dependency `videojs-contrib-eme` to v5.3.1

## Specific Changes proposed
update `videojs-contrib-eme` to v5.3.1

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
