### PR TITLE
fix: requestId init tag

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -852,10 +852,6 @@ const waitForCompletion = ({
       segment.endOfAllRequests = Date.now();
       if (segment.map && segment.map.encryptedBytes && !segment.map.bytes) {
         triggerSegmentEventFn({ type: 'segmentdecryptionstart', segment });
-        // add -init to the "id" to differentiate between segment
-        // and init segment decryption, just in case they happen
-        // at the same time at some point in the future.
-        segment.requestId += '-init';
         return decrypt({ decryptionWorker,
           // add -init to the "id" to differentiate between segment
           // and init segment decryption, just in case they happen

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -757,7 +757,8 @@ QUnit.test('init segment with key has bytes decrypted', function(assert) {
             bytes: new Uint32Array([0, 0, 0, 1])
           }
         }
-      }
+      },
+      requestId: 'foo.bar.id'
     },
     trackInfoFn(segment, _trackInfo) {
       trackInfo = _trackInfo;
@@ -779,6 +780,7 @@ QUnit.test('init segment with key has bytes decrypted', function(assert) {
         16,
         'key bytes are readable'
       );
+      assert.equal(segmentData.requestId, 'foo.bar.id', 'requestId is expected value');
 
       // verify stats
       assert.equal(segmentData.stats.bytesReceived, 6198, '6198 bytes');


### PR DESCRIPTION
## Description
When handling a encrypted init segment `-init` was being added to the `requestId` erroneously. 

## Specific Changes proposed
- Remove the `-init` addition, as it is added to the id below when the request is made without changing the actual requestId itself.
- Add a test to ensure requestId is unchanged when decrypting an init segment.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
