### PR TITLE
fix: videoTimestampOffset in sourceUpdater

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -818,7 +818,7 @@ export default class SourceUpdater extends videojs.EventTarget {
     if (typeof offset !== 'undefined' &&
         this.videoBuffer &&
         // no point in updating if it's the same
-        this.videoTimestampOffset !== offset) {
+        this.videoTimestampOffset_ !== offset) {
       pushQueue({
         type: 'video',
         sourceUpdater: this,


### PR DESCRIPTION
## Description
fix videoTimestampOffset comparison

## Specific Changes proposed
add `_` to `this.videoTimestampOffset` so we compare the value instead of the function. 😁 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
