### PR TITLE
chore: Update codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: npm run test
 
     - name: coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         files: './test/dist/coverage/coverage-final.json'


### PR DESCRIPTION
Updates to v4 of codecov which is more robust with uploads from PRs from forks.