### PR TITLE
fix: fastQualitySwitch stability

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -42,7 +42,6 @@ export default class PlaybackWatcher extends videojs.EventTarget {
     this.liveRangeSafeTimeDelta = options.liveRangeSafeTimeDelta;
     this.media = options.media;
     this.playedRanges_ = [];
-    this.stuckTimeout_ = null;
 
     this.consecutiveUpdates = 0;
     this.lastRecordedTime = null;
@@ -500,6 +499,7 @@ export default class PlaybackWatcher extends videojs.EventTarget {
       this.skipTheGap_(currentTime);
       return true;
     }
+
     // All checks failed. Returning false to indicate failure to correct waiting
     return false;
   }

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1059,12 +1059,7 @@ export class PlaylistController extends videojs.EventTarget {
 
   runFastQualitySwitch_() {
     this.waitingForFastQualityPlaylistReceived_ = false;
-    // Delete all buffered data to allow an immediate quality switch, then seek to give
-    // the browser a kick to remove any cached frames from the previous rendtion (.04 seconds
-    // ahead was roughly the minimum that will accomplish this across a variety of content
-    // in IE and Edge, but seeking in place is sufficient on all other browsers)
-    // Edge/IE bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14600375/
-    // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=651904
+    // Delete all buffered data to allow an immediate quality switch.
     this.mainSegmentLoader_.pause();
     this.mainSegmentLoader_.resetEverything(() => {
       this.mainSegmentLoader_.load();

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1067,7 +1067,7 @@ export class PlaylistController extends videojs.EventTarget {
     // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=651904
     this.mainSegmentLoader_.pause();
     this.mainSegmentLoader_.resetEverything(() => {
-      this.tech_.setCurrentTime(this.tech_.currentTime());
+      this.mainSegmentLoader_.load();
     });
 
     // don't need to reset audio as it is reset when media changes

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -777,55 +777,6 @@ QUnit.test('loadVttJs should be passed to the vttSegmentLoader and rejected on v
   });
 });
 
-QUnit.test('seeks in place for fast quality switch on non-IE/Edge browsers', function(assert) {
-  let seeks = 0;
-
-  this.playlistController.mediaSource.trigger('sourceopen');
-  // main
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
-
-  const segmentLoader = this.playlistController.mainSegmentLoader_;
-
-  return requestAndAppendSegment({
-    request: this.requests.shift(),
-    segmentLoader,
-    clock: this.clock
-  }).then(() => {
-    // media is changed
-    this.playlistController.selectPlaylist = () => {
-      const playlists = this.playlistController.main().playlists;
-      const currentPlaylist = this.playlistController.media();
-
-      return playlists.find((playlist) => playlist !== currentPlaylist);
-    };
-
-    this.player.tech_.on('seeking', function() {
-      seeks++;
-    });
-
-    const timeBeforeSwitch = this.player.currentTime();
-
-    // mock buffered values so removes are processed
-    segmentLoader.sourceUpdater_.audioBuffer.buffered = createTimeRanges([[0, 10]]);
-    segmentLoader.sourceUpdater_.videoBuffer.buffered = createTimeRanges([[0, 10]]);
-
-    this.playlistController.runFastQualitySwitch_();
-    // trigger updateend to indicate the end of the remove operation
-    segmentLoader.sourceUpdater_.audioBuffer.trigger('updateend');
-    segmentLoader.sourceUpdater_.videoBuffer.trigger('updateend');
-    this.clock.tick(1);
-
-    assert.equal(
-      this.player.currentTime(),
-      timeBeforeSwitch,
-      'current time remains the same on fast quality switch'
-    );
-    assert.equal(seeks, 1, 'seek event occurs on fast quality switch');
-  });
-});
-
 QUnit.test('basic timeToLoadedData, mediaAppends, appendsToLoadedData stats', function(assert) {
   this.player.tech_.trigger('loadstart');
   this.playlistController.mediaSource.trigger('sourceopen');


### PR DESCRIPTION
## Description
Currently, our fastQualitySwitch triggers a full video/main buffer clear twice. This is because we clear the buffer first with a `resetEverything` call on the mainSegmentLoader, then once that removal is complete we call `setCurrentTime` which calls `resetEverything` on all active segment loaders, clearing all the other buffers as well. This is causing some instability, specifically when a quality change occurs at or near a discontinuity.

## Specific Changes proposed
Instead of calling `setCurrentTime` after a fastQualitySwitch, lets just call `load` on the mainSegmentLoader.
Note: There were 2 browser bugs that seemed to require a `setCurrentTime` call according to the comments, but after checking both URLs, those bugs seem to no longer be relevant, so we should be safe removing this part and only calling load.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
