### PR TITLE
fix: remove extra abort call

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -428,7 +428,6 @@ export const fixBadTimelineChange = (segmentLoader) => {
     return;
   }
   segmentLoader.pause();
-  segmentLoader.abort_();
   segmentLoader.resetEverything();
   segmentLoader.load();
 };

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -521,13 +521,9 @@ QUnit.test('fixBadTimelineChange calls pause, resetEverything and load on a segm
   let pauseCalls = 0;
   let resetEverythingCalls = 0;
   let loadCalls = 0;
-  let abortCalls = 0;
   let mockSegmentLoader = {
     pause() {
       pauseCalls++;
-    },
-    abort_() {
-      abortCalls++;
     },
     resetEverything() {
       resetEverythingCalls++;
@@ -548,7 +544,6 @@ QUnit.test('fixBadTimelineChange calls pause, resetEverything and load on a segm
   assert.equal(pauseCalls, 1, 'calls pause once');
   assert.equal(resetEverythingCalls, 1, 'calls resetEverything once');
   assert.equal(loadCalls, 1, 'calls load once');
-  assert.equal(abortCalls, 1, 'calls abort once');
 });
 
 QUnit.module('safeBackBufferTrimTime');


### PR DESCRIPTION
## Description
Remove extra abort_ call.

## Specific Changes proposed
remove an extra abort call in `fixBadTimelineChanges`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
