### PR TITLE
fix: audio segment on incorrect timeline

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -929,6 +929,31 @@ export class PlaylistController extends videojs.EventTarget {
       this.onEndOfStream();
     });
 
+    // In DASH, there is the possibility of the video segment and the audio segment
+    // at a current time to be on different timelines. When this occurs, the player
+    // forwards playback to a point where these two segment types are back on the same
+    // timeline. This time will be just after the end of the audio segment that is on
+    // a previous timeline.
+    this.timelineChangeController_.on('audioTimelineBehind', () => {
+      const mainPendingTimelineChange = this.timelineChangeController_.pendingTimelineChange({ type: 'main' });
+
+      // Adjust the pending audio timeline to match the main timeline
+      this.timelineChangeController_.pendingTimelineChange({ to: mainPendingTimelineChange.to, from: mainPendingTimelineChange.from, type: 'audio' });
+
+      const segmentInfo = this.audioSegmentLoader_.pendingSegment_;
+
+      if (!segmentInfo || !segmentInfo.segment || !segmentInfo.segment.syncInfo) {
+        return;
+      }
+
+      // Update the current time to just after the faulty audio segment.
+      // This moves playback to a spot where both audio and video segments
+      // are on the same timeline.
+      const newTime = segmentInfo.segment.syncInfo.end + 0.01;
+
+      this.tech_.setCurrentTime(newTime);
+    });
+
     this.mainSegmentLoader_.on('earlyabort', (event) => {
       // never try to early abort with the new ABR algorithm
       if (this.bufferBasedABR) {

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -934,25 +934,27 @@ export class PlaylistController extends videojs.EventTarget {
     // forwards playback to a point where these two segment types are back on the same
     // timeline. This time will be just after the end of the audio segment that is on
     // a previous timeline.
-    this.timelineChangeController_.on('audioTimelineBehind', () => {
-      const mainPendingTimelineChange = this.timelineChangeController_.pendingTimelineChange({ type: 'main' });
+    if (this.sourceType_ === 'dash') {
+      this.timelineChangeController_.on('audioTimelineBehind', () => {
+        const mainPendingTimelineChange = this.timelineChangeController_.pendingTimelineChange({ type: 'main' });
 
-      // Adjust the pending audio timeline to match the main timeline
-      this.timelineChangeController_.pendingTimelineChange({ to: mainPendingTimelineChange.to, from: mainPendingTimelineChange.from, type: 'audio' });
+        // Adjust the pending audio timeline to match the main timeline
+        this.timelineChangeController_.pendingTimelineChange({ to: mainPendingTimelineChange.to, from: mainPendingTimelineChange.from, type: 'audio' });
 
-      const segmentInfo = this.audioSegmentLoader_.pendingSegment_;
+        const segmentInfo = this.audioSegmentLoader_.pendingSegment_;
 
-      if (!segmentInfo || !segmentInfo.segment || !segmentInfo.segment.syncInfo) {
-        return;
-      }
+        if (!segmentInfo || !segmentInfo.segment || !segmentInfo.segment.syncInfo) {
+          return;
+        }
 
-      // Update the current time to just after the faulty audio segment.
-      // This moves playback to a spot where both audio and video segments
-      // are on the same timeline.
-      const newTime = segmentInfo.segment.syncInfo.end + 0.01;
+        // Update the current time to just after the faulty audio segment.
+        // This moves playback to a spot where both audio and video segments
+        // are on the same timeline.
+        const newTime = segmentInfo.segment.syncInfo.end + 0.01;
 
-      this.tech_.setCurrentTime(newTime);
-    });
+        this.tech_.setCurrentTime(newTime);
+      });
+    }
 
     this.mainSegmentLoader_.on('earlyabort', (event) => {
       // never try to early abort with the new ABR algorithm

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -936,11 +936,6 @@ export class PlaylistController extends videojs.EventTarget {
     // a previous timeline.
     if (this.sourceType_ === 'dash') {
       this.timelineChangeController_.on('audioTimelineBehind', () => {
-        const mainPendingTimelineChange = this.timelineChangeController_.pendingTimelineChange({ type: 'main' });
-
-        // Adjust the pending audio timeline to match the main timeline
-        this.timelineChangeController_.pendingTimelineChange({ to: mainPendingTimelineChange.to, from: mainPendingTimelineChange.from, type: 'audio' });
-
         const segmentInfo = this.audioSegmentLoader_.pendingSegment_;
 
         if (!segmentInfo || !segmentInfo.segment || !segmentInfo.segment.syncInfo) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -450,11 +450,7 @@ const isAudioTimelineBehind = (segmentLoader) => {
   const pendingMainTimelineChange = segmentLoader.timelineChangeController_.pendingTimelineChange({ type: 'main' });
   const hasPendingTimelineChanges = pendingAudioTimelineChange && pendingMainTimelineChange;
 
-  if (hasPendingTimelineChanges && pendingAudioTimelineChange.to < pendingMainTimelineChange.to) {
-    return true;
-  }
-
-  return false;
+  return hasPendingTimelineChanges && pendingAudioTimelineChange.to < pendingMainTimelineChange.to;
 };
 
 /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -475,7 +475,8 @@ const checkAndFixTimelines = (segmentLoader) => {
   });
 
   if (waitingForTimelineChange && shouldFixBadTimelineChanges(segmentLoader.timelineChangeController_)) {
-    if (isAudioTimelineBehind(segmentLoader)) {
+    // Audio being behind should only happen on DASH sources.
+    if (segmentLoader.sourceType_ === 'dash' && isAudioTimelineBehind(segmentLoader)) {
       segmentLoader.timelineChangeController_.trigger('audioTimelineBehind');
       return;
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -413,6 +413,11 @@ export const shouldFixBadTimelineChanges = (timelineChangeController) => {
   const pendingAudioTimelineChange = timelineChangeController.pendingTimelineChange({ type: 'audio' });
   const pendingMainTimelineChange = timelineChangeController.pendingTimelineChange({ type: 'main' });
   const hasPendingTimelineChanges = pendingAudioTimelineChange && pendingMainTimelineChange;
+
+  if (hasPendingTimelineChanges && pendingAudioTimelineChange.to < pendingMainTimelineChange.to) {
+    timelineChangeController.trigger('audioTimelineBehind');
+  }
+
   const differentPendingChanges = hasPendingTimelineChanges && pendingAudioTimelineChange.to !== pendingMainTimelineChange.to;
   const isNotInitialPendingTimelineChange = hasPendingTimelineChanges && pendingAudioTimelineChange.from !== -1 && pendingMainTimelineChange.from !== -1;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -475,7 +475,7 @@ const checkAndFixTimelines = (segmentLoader) => {
   });
 
   if (waitingForTimelineChange && shouldFixBadTimelineChanges(segmentLoader.timelineChangeController_)) {
-    if (isAudioTimelineBehind) {
+    if (isAudioTimelineBehind(segmentLoader)) {
       segmentLoader.timelineChangeController_.trigger('audioTimelineBehind');
       return;
     }

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -2647,6 +2647,52 @@ QUnit.test(
   }
 );
 
+QUnit.test(
+  'setCurrentTime is not called on audioTimelineBehind when there is no pending segment',
+  function(assert) {
+    const options = {
+      src: 'test',
+      tech: this.player.tech_,
+      sourceType: 'dash',
+      player_: this.player
+    };
+    const pc = new PlaylistController(options);
+    const tech = this.player.tech_;
+    const setCurrentTimeSpy = sinon.spy(tech, 'setCurrentTime');
+
+    pc.timelineChangeController_.trigger('audioTimelineBehind');
+
+    assert.notOk(setCurrentTimeSpy.called, 'setCurrentTime not called');
+  }
+);
+
+QUnit.test(
+  'setCurrentTime to after audio segment when audioTimelineBehind is triggered',
+  function(assert) {
+    const options = {
+      src: 'test',
+      tech: this.player.tech_,
+      sourceType: 'dash',
+      player_: this.player
+    };
+    const pc = new PlaylistController(options);
+    const tech = this.player.tech_;
+    const setCurrentTimeSpy = sinon.spy(tech, 'setCurrentTime');
+
+    pc.audioSegmentLoader_.pendingSegment_ = {
+      segment: {
+        syncInfo: {
+          end: 10
+        }
+      }
+    };
+
+    pc.timelineChangeController_.trigger('audioTimelineBehind');
+
+    assert.ok(setCurrentTimeSpy.calledWith(10.01), 'sets current time to just after the end of the audio segment');
+  }
+);
+
 QUnit.test('calls to update cues on new media', function(assert) {
   const origVhsOptions = videojs.options.vhs;
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1789,10 +1789,11 @@ QUnit.module('SegmentLoader', function(hooks) {
       });
     });
 
-    QUnit.test('triggers event when audio timeline is behind on bad timelines', function(assert) {
+    QUnit.test('triggers event when DASH audio timeline is behind main', function(assert) {
       loader.dispose();
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
-        loaderType: 'audio'
+        loaderType: 'audio',
+        sourceType: 'dash'
       }), {});
 
       loader.timelineChangeController_.pendingTimelineChange = ({ type }) => {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1663,7 +1663,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       });
     });
 
-    QUnit.test('hasEnoughInfoToLoad_ calls fixBadTimelineChange', function(assert) {
+    QUnit.test('fixBadTimelineChange on load', function(assert) {
       loader.dispose();
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'audio'
@@ -1722,7 +1722,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       });
     });
 
-    QUnit.test('hasEnoughInfoToAppend_ calls fixBadTimelineChange', function(assert) {
+    QUnit.test('fixBadTimelineChange on append', function(assert) {
       loader.dispose();
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'main'
@@ -1786,6 +1786,47 @@ QUnit.module('SegmentLoader', function(hooks) {
         assert.equal(pauseCalls, 1, '1 pause call expected');
         assert.equal(loadCalls, 2, '2 load calls expected');
         assert.equal(resetEverythingCalls, 2, '1 load calls expected');
+      });
+    });
+
+    QUnit.test('triggers event when audio timeline is behind on bad timelines', function(assert) {
+      loader.dispose();
+      loader = new SegmentLoader(LoaderCommonSettings.call(this, {
+        loaderType: 'audio'
+      }), {});
+
+      loader.timelineChangeController_.pendingTimelineChange = ({ type }) => {
+        if (type === 'audio') {
+          return {
+            from: 0,
+            to: 5
+          };
+        } else if (type === 'main') {
+          return {
+            from: 0,
+            to: 10
+          };
+        }
+      };
+
+      const triggerSpy = sinon.spy(loader.timelineChangeController_, 'trigger');
+
+      const playlist = playlistWithDuration(20);
+
+      playlist.discontinuityStarts = [1];
+      loader.getCurrentMediaInfo_ = () => {
+        return {
+          hasVideo: true,
+          hasAudio: true,
+          isMuxed: true
+        };
+      };
+
+      return this.setupMediaSource(loader.mediaSource_, loader.sourceUpdater_).then(() => {
+        loader.playlist(playlist);
+        loader.load();
+        this.clock.tick(1);
+        assert.ok(triggerSpy.calledWith('audioTimelineBehind'), 'audio timeline behind event is triggered');
       });
     });
 


### PR DESCRIPTION
## Description

Currently there is an edge case in DASH where certain points of audio segments and video segments do not always exist on the same timeline.

Example: We seek to `100` seconds into the video. There is an audio segment that is from 98-100.25 seconds, and the video segment is from 100-109.95. The audio segment is on a timeline from 90-99.99, and the video segment is on a timeline from 110-119.99. We fall into a loop in this scenario because VHS catches that we have bad timelines, but we do not do anything to fix it in this scenario.

This change allows us to check for this specific scenario. When we attempt to load an audio segment that is on a prior timeline to the video segment, we will now force the player forward to just past the faulty audio segment. This ensures that the audio and video segments will now be on the same timeline.

## Specific Changes proposed

- Moves the `fixBadTimeline` logic outside of the `hasEnoughInfoToLoad_` and `hasEnoughInfoToAppend_` functions so we do not have unexpected actions on a function that should just return a boolean.
- Create an event for when the audio segment is on a prior timeline to what the main video segment is on.
- Update the pending audio timeline change, and set the `currentTime` to just after the end of the faulty audio segment.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
