### PR TITLE
chore: update m3u8-parser, vhs-utils and aes-decrypter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,6 +1791,18 @@
         "mpd-parser": "^1.3.0",
         "mux.js": "7.0.3",
         "video.js": "^7 || ^8"
+      },
+      "dependencies": {
+        "@videojs/vhs-utils": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
+          "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "global": "^4.4.0",
+            "url-toolkit": "^2.2.1"
+          }
+        }
       }
     },
     "@videojs/update-changelog": {
@@ -1809,13 +1821,12 @@
       }
     },
     "@videojs/vhs-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
-      "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
+      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
+        "global": "^4.4.0"
       }
     },
     "@videojs/xhr": {
@@ -6281,25 +6292,13 @@
       }
     },
     "m3u8-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
-      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
+      "integrity": "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.1.1",
         "global": "^4.4.0"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        }
       }
     },
     "magic-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,6 +1802,29 @@
             "global": "^4.4.0",
             "url-toolkit": "^2.2.1"
           }
+        },
+        "aes-decrypter": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
+          "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "^3.0.5",
+            "global": "^4.4.0",
+            "pkcs7": "^1.0.4"
+          },
+          "dependencies": {
+            "@videojs/vhs-utils": {
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+              "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "global": "^4.4.0",
+                "url-toolkit": "^2.2.1"
+              }
+            }
+          }
         }
       }
     },
@@ -1895,26 +1918,14 @@
       "dev": true
     },
     "aes-decrypter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
-      "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.2.tgz",
+      "integrity": "sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.1.1",
         "global": "^4.4.0",
         "pkcs7": "^1.0.4"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        }
       }
     },
     "agent-base": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@videojs/vhs-utils": "^4.1.1",
-    "aes-decrypter": "4.0.1",
+    "aes-decrypter": "^4.0.2",
     "global": "^4.4.0",
     "m3u8-parser": "^7.2.0",
     "mpd-parser": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/vhs-utils": "4.0.0",
+    "@videojs/vhs-utils": "^4.1.1",
     "aes-decrypter": "4.0.1",
     "global": "^4.4.0",
-    "m3u8-parser": "^7.1.0",
+    "m3u8-parser": "^7.2.0",
     "mpd-parser": "^1.3.0",
     "mux.js": "7.0.3",
     "video.js": "^7 || ^8"


### PR DESCRIPTION
## Description
m3u8-parsrer to 7.3.0
vhs-utils to 4.1.1
aes-decrypter to 4.0.2

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
