### PR TITLE
fix: allow vtt rollover with MPEGTS of 0

### DIFF
--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -494,9 +494,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
 
     segmentInfo.cues.forEach((cue) => {
       const duration = cue.endTime - cue.startTime;
-      const startTime = MPEGTS === 0 ?
-        cue.startTime + diff :
-        this.handleRollover_(cue.startTime + diff, mappingObj.time);
+      const startTime = this.handleRollover_(cue.startTime + diff, mappingObj.time);
 
       cue.startTime = Math.max(startTime, 0);
       cue.endTime = Math.max(startTime + duration, 0);


### PR DESCRIPTION
## Description
Allow `handleRollover` to be called on vtt segments when the `MPEGTS` value from the `X-TIMESTAMP-MAP` tag is 0

## Specific Changes proposed
Remove the `MPEGTS === 0` check and associated ternary.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
