### PR TITLE
fix: audio segment on incorrect timeline HLS

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -937,27 +937,25 @@ export class PlaylistController extends videojs.EventTarget {
       this.onEndOfStream();
     });
 
-    // In DASH, there is the possibility of the video segment and the audio segment
+    // There is the possibility of the video segment and the audio segment
     // at a current time to be on different timelines. When this occurs, the player
     // forwards playback to a point where these two segment types are back on the same
     // timeline. This time will be just after the end of the audio segment that is on
     // a previous timeline.
-    if (this.sourceType_ === 'dash') {
-      this.timelineChangeController_.on('audioTimelineBehind', () => {
-        const segmentInfo = this.audioSegmentLoader_.pendingSegment_;
+    this.timelineChangeController_.on('audioTimelineBehind', () => {
+      const segmentInfo = this.audioSegmentLoader_.pendingSegment_;
 
-        if (!segmentInfo || !segmentInfo.segment || !segmentInfo.segment.syncInfo) {
-          return;
-        }
+      if (!segmentInfo || !segmentInfo.segment || !segmentInfo.segment.syncInfo) {
+        return;
+      }
 
-        // Update the current time to just after the faulty audio segment.
-        // This moves playback to a spot where both audio and video segments
-        // are on the same timeline.
-        const newTime = segmentInfo.segment.syncInfo.end + 0.01;
+      // Update the current time to just after the faulty audio segment.
+      // This moves playback to a spot where both audio and video segments
+      // are on the same timeline.
+      const newTime = segmentInfo.segment.syncInfo.end + 0.01;
 
-        this.tech_.setCurrentTime(newTime);
-      });
-    }
+      this.tech_.setCurrentTime(newTime);
+    });
 
     this.mainSegmentLoader_.on('earlyabort', (event) => {
       // never try to early abort with the new ABR algorithm

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -475,8 +475,7 @@ const checkAndFixTimelines = (segmentLoader) => {
   });
 
   if (waitingForTimelineChange && shouldFixBadTimelineChanges(segmentLoader.timelineChangeController_)) {
-    // Audio being behind should only happen on DASH sources.
-    if (segmentLoader.sourceType_ === 'dash' && isAudioTimelineBehind(segmentLoader)) {
+    if (isAudioTimelineBehind(segmentLoader)) {
       segmentLoader.timelineChangeController_.trigger('audioTimelineBehind');
       return;
     }

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1789,7 +1789,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       });
     });
 
-    QUnit.test('triggers event when DASH audio timeline is behind main', function(assert) {
+    QUnit.test('triggers event when audio timeline is behind main', function(assert) {
       loader.dispose();
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'audio',


### PR DESCRIPTION
## Description

Related to https://github.com/videojs/http-streaming/pull/1530

This fixes an issue that was previously thought to just happen in DASH above. Now, in HLS, if the audio segment in on a previous timeline to the video segment, we will push playback to where they are both on the same timeline.

## Specific Changes proposed
- Removes the DASH safeguards in the audio segment behind timeline logic so this covers HLS as well.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
