### PR TITLE
feat: Add support for ManagedMediaSource 'startstreaming' and 'endstream' event handling

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -192,7 +192,6 @@ export class PlaylistController extends videojs.EventTarget {
     this.playlistExclusionDuration = playlistExclusionDuration;
     this.maxPlaylistRetries = maxPlaylistRetries;
     this.enableLowInitialPlaylist = enableLowInitialPlaylist;
-    this.hasManagedMediaSource_ = false;
 
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack(
@@ -216,7 +215,6 @@ export class PlaylistController extends videojs.EventTarget {
       // Airplay source not yet implemented. Remote playback must be disabled.
       this.tech_.el_.disableRemotePlayback = true;
       this.mediaSource = new window.ManagedMediaSource();
-      this.hasManagedMediaSource_ = true;
 
       videojs.log('Using ManagedMediaSource');
     } else if (window.MediaSource) {
@@ -226,22 +224,18 @@ export class PlaylistController extends videojs.EventTarget {
     this.handleDurationChange_ = this.handleDurationChange_.bind(this);
     this.handleSourceOpen_ = this.handleSourceOpen_.bind(this);
     this.handleSourceEnded_ = this.handleSourceEnded_.bind(this);
+    this.load = this.load.bind(this);
+    this.pause = this.pause.bind(this);
 
     this.mediaSource.addEventListener('durationchange', this.handleDurationChange_);
 
     // load the media source into the player
     this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen_);
     this.mediaSource.addEventListener('sourceended', this.handleSourceEnded_);
+    this.mediaSource.addEventListener('startstreaming', this.load);
+    this.mediaSource.addEventListener('endstreaming', this.pause);
     // we don't have to handle sourceclose since dispose will handle termination of
     // everything, and the MediaSource should not be detached without a proper disposal
-
-    if (this.hasManagedMediaSource_) {
-      this.handleStartStreaming_ = this.handleStartStreaming_.bind(this);
-      this.handleEndStreaming_ = this.handleEndStreaming_.bind(this);
-
-      this.mediaSource.addEventListener('startstreaming', this.handleStartStreaming_);
-      this.mediaSource.addEventListener('endstreaming', this.handleEndStreaming_);
-    }
 
     this.seekable_ = createTimeRanges();
     this.hasPlayed_ = false;
@@ -1249,26 +1243,6 @@ export class PlaylistController extends videojs.EventTarget {
 
     cues[cues.length - 1].endTime = isNaN(duration) || Math.abs(duration) === Infinity ?
       Number.MAX_VALUE : duration;
-  }
-
-  /**
-   * Handle the startstreaming event on the ManagedMediaSource.
-   * This event indicates that segment loading should be started/resumed.
-   *
-   * @private
-   */
-  handleStartStreaming_() {
-    this.load();
-  }
-
-  /**
-   * Handle the endstreaming event on the ManagedMediaSource.
-   * This event indicates that segment loading should be paused.
-   *
-   * @private
-   */
-  handleEndStreaming_() {
-    this.pause();
   }
 
   /**

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -7704,19 +7704,28 @@ QUnit.test('ManagedMediaSource startstreaming and endstreaming events start and 
   };
 
   const controller = new PlaylistController(options);
-  const loadSpy = sinon.spy(controller.mainSegmentLoader_, 'load');
-  const pauseSpy = sinon.spy(controller.mainSegmentLoader_, 'pause');
 
-  assert.ok(loadSpy.notCalled, 'Segment loading not started yet');
-  assert.ok(pauseSpy.notCalled, 'Segment loading has not been paused');
+  controller.mediaTypes_.AUDIO.activePlaylistLoader = {};
+  controller.mediaTypes_.SUBTITLES.activePlaylistLoader = {};
+
+  const mainLoadSpy = sinon.spy(controller.mainSegmentLoader_, 'load');
+  const audioLoadSpy = sinon.spy(controller.audioSegmentLoader_, 'load');
+  const subtitleLoadSpy = sinon.spy(controller.subtitleSegmentLoader_, 'load');
+  const mainPauseSpy = sinon.spy(controller.mainSegmentLoader_, 'pause');
+  const audioPauseSpy = sinon.spy(controller.audioSegmentLoader_, 'pause');
+  const subtitlePauseSpy = sinon.spy(controller.subtitleSegmentLoader_, 'pause');
 
   controller.mediaSource.trigger('startstreaming');
 
-  assert.ok(loadSpy.calledOnce, 'Segment loading started on startstreaming event');
+  assert.ok(mainLoadSpy.calledOnce, 'Segment loading started on startstreaming event');
+  assert.ok(audioLoadSpy.calledOnce, 'Audio segment loading started on startstreaming event');
+  assert.ok(subtitleLoadSpy.calledOnce, 'Subtitle segment loading started on startstreaming event');
 
   controller.mediaSource.trigger('endstreaming');
 
-  assert.ok(pauseSpy.calledOnce, 'Segment loading paused on endstreaming event');
+  assert.ok(mainPauseSpy.calledOnce, 'Main segment loading paused on endstreaming event');
+  assert.ok(audioPauseSpy.calledOnce, 'Audio segment loading paused on endstreaming event');
+  assert.ok(subtitlePauseSpy.calledOnce, 'Subtitle segment loading paused on endstreaming event');
 
   mms.restore();
 });

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -7704,8 +7704,8 @@ QUnit.test('ManagedMediaSource startstreaming and endstreaming events start and 
   };
 
   const controller = new PlaylistController(options);
-  const loadSpy = sinon.spy(controller, 'load');
-  const pauseSpy = sinon.spy(controller, 'pause');
+  const loadSpy = sinon.spy(controller.mainSegmentLoader_, 'load');
+  const pauseSpy = sinon.spy(controller.mainSegmentLoader_, 'pause');
 
   assert.ok(loadSpy.notCalled, 'Segment loading not started yet');
   assert.ok(pauseSpy.notCalled, 'Segment loading has not been paused');

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -7693,3 +7693,30 @@ QUnit.test('uses ManagedMediaSource only when opted in', function(assert) {
   mmsSpy.restore();
   mms.restore();
 });
+
+QUnit.test('ManagedMediaSource startstreaming and endstreaming events start and pause segment loading respectively', function(assert) {
+  const mms = useFakeManagedMediaSource();
+  const options = {
+    src: 'test.m3u8',
+    tech: this.player.tech_,
+    player_: this.player,
+    experimentalUseMMS: true
+  };
+
+  const controller = new PlaylistController(options);
+  const loadSpy = sinon.spy(controller, 'load');
+  const pauseSpy = sinon.spy(controller, 'pause');
+
+  assert.ok(loadSpy.notCalled, 'Segment loading not started yet');
+  assert.ok(pauseSpy.notCalled, 'Segment loading has not been paused');
+
+  controller.mediaSource.trigger('startstreaming');
+
+  assert.ok(loadSpy.calledOnce, 'Segment loading started on startstreaming event');
+
+  controller.mediaSource.trigger('endstreaming');
+
+  assert.ok(pauseSpy.calledOnce, 'Segment loading paused on endstreaming event');
+
+  mms.restore();
+});


### PR DESCRIPTION
## Description
This PR adds onto the experimental support for `ManagedMediaSource`. When the user agent determines that a ManagedMediaSource has enough data buffered to ensure uninterrupted playback, or does not have enough to ensure it, it will fire a `endstreaming` or `startstreaming` event, indicating that the player should stop loading new segments or start loading new segments, respectively.

## Specific Changes proposed
Add 2 new event handlers for `startstreaming` and `endstreaming`. The former will call `playlistController.load()`, which was a preexisting method that calls `load()` on all active segment loaders. The latter calls `playlistController.pause()`, which is a new method that calls `pause()` on all active segment loaders.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors

## References
https://www.w3.org/TR/media-source-2/#dom-managedmediasource-streaming
https://github.com/w3c/media-source/issues/320

