### PR TITLE
feat: Add Airplay support when overriding native HLS in Safari/iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "video.js": "^7 || ^8"
   },
   "peerDependencies": {
-    "video.js": "^8.14.0"
+    "video.js": "^8.19.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.21.0",

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1079,7 +1079,14 @@ class VhsHandler extends Component {
 
     this.mediaSourceUrl_ = window.URL.createObjectURL(this.playlistController_.mediaSource);
 
-    this.tech_.src(this.mediaSourceUrl_);
+    // If we are playing HLS with MSE in Safari, add source elements for both the blob and manifest URLs.
+    // The latter will enable Airplay playback on receiver devices.
+    if ((videojs.browser.IS_ANY_SAFARI || videojs.browser.IS_IOS) && this.options_.overrideNative && this.options_.sourceType === 'hls') {
+      this.tech_.addSourceElement(this.mediaSourceUrl_);
+      this.tech_.addSourceElement(this.source_.src);
+    } else {
+      this.tech_.src(this.mediaSourceUrl_);
+    }
   }
 
   createKeySessions_() {

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -1081,7 +1081,12 @@ class VhsHandler extends Component {
 
     // If we are playing HLS with MSE in Safari, add source elements for both the blob and manifest URLs.
     // The latter will enable Airplay playback on receiver devices.
-    if ((videojs.browser.IS_ANY_SAFARI || videojs.browser.IS_IOS) && this.options_.overrideNative && this.options_.sourceType === 'hls') {
+    if ((
+      videojs.browser.IS_ANY_SAFARI || videojs.browser.IS_IOS) &&
+      this.options_.overrideNative &&
+      this.options_.sourceType === 'hls' &&
+      typeof this.tech_.addSourceElement === 'function'
+    ) {
       this.tech_.addSourceElement(this.mediaSourceUrl_);
       this.tech_.addSourceElement(this.source_.src);
     } else {


### PR DESCRIPTION
## Description
**Note:** This depends on https://github.com/videojs/video.js/pull/8886. Before we merge this, we will need a new Video.js release and then have to bump the peer dependency version in this package.

This PR adds Airplay support when overriding native HLS in Safari and/or iOS by using two `source` elements, one for the MediaSource URL object and one for the Airplay-compatible manifest URL.

From the Webkit guide on [Airplay and MSE](https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay): 
> When Safari detects that an alternative source is available in addition to the MediaSource URL object, it will display the familiar AirPlay icon to the video player control. Should the user select AirPlay, it will switch over from MSE to the AirPlay-compatible URL.


## Specific Changes proposed
If we are playing HLS with MSE in Safari or iOS, set the source by adding two `<source>` elements-- one for the Media Source blob and one for the HLS manifest that will be used for Airplay. Preserve the existing behavior in all other cases.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
