### PR TITLE
Multi period dash VOD fixes

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -384,6 +384,7 @@ export default class DashPlaylistLoader extends EventTarget {
     // playlist lacks sidx or sidx segments were added to this playlist already.
     if (!playlist.sidx || !sidxKey || this.mainPlaylistLoader_.sidxMapping_[sidxKey]) {
       // keep this function async
+      window.clearTimeout(this.mediaRequest_);
       this.mediaRequest_ = window.setTimeout(() => cb(false), 0);
       return;
     }
@@ -553,6 +554,7 @@ export default class DashPlaylistLoader extends EventTarget {
   haveMetadata({startingState, playlist}) {
     this.state = 'HAVE_METADATA';
     this.loadedPlaylists_[playlist.id] = playlist;
+    window.clearTimeout(this.mediaRequest_);
     this.mediaRequest_ = null;
 
     // This will trigger loadedplaylist
@@ -629,6 +631,7 @@ export default class DashPlaylistLoader extends EventTarget {
     // We don't need to request the main manifest again
     // Call this asynchronously to match the xhr request behavior below
     if (!this.isMain_) {
+      window.clearTimeout(this.mediaRequest_);
       this.mediaRequest_ = window.setTimeout(() => this.haveMain_(), 0);
       return;
     }
@@ -773,6 +776,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
   handleMain_() {
     // clear media request
+    window.clearTimeout(this.mediaRequest_);
     this.mediaRequest_ = null;
 
     const oldMain = this.mainPlaylistLoader_.main;

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -304,6 +304,8 @@ export default class DashPlaylistLoader extends EventTarget {
   constructor(srcUrlOrPlaylist, vhs, options = { }, mainPlaylistLoader) {
     super();
 
+    this.isPaused_ = true;
+
     this.mainPlaylistLoader_ = mainPlaylistLoader || this;
     if (!mainPlaylistLoader) {
       this.isMain_ = true;
@@ -343,6 +345,10 @@ export default class DashPlaylistLoader extends EventTarget {
     } else {
       this.childPlaylist_ = srcUrlOrPlaylist;
     }
+  }
+
+  get isPaused() {
+    return this.isPaused_;
   }
 
   requestErrored_(err, request, startingState) {
@@ -466,6 +472,7 @@ export default class DashPlaylistLoader extends EventTarget {
   }
 
   dispose() {
+    this.isPaused_ = true;
     this.trigger('dispose');
     this.stopRequest();
     this.loadedPlaylists_ = {};
@@ -571,6 +578,8 @@ export default class DashPlaylistLoader extends EventTarget {
   }
 
   pause() {
+    this.isPaused_ = true;
+
     if (this.mainPlaylistLoader_.createMupOnMedia_) {
       this.off('loadedmetadata', this.mainPlaylistLoader_.createMupOnMedia_);
       this.mainPlaylistLoader_.createMupOnMedia_ = null;
@@ -590,6 +599,8 @@ export default class DashPlaylistLoader extends EventTarget {
   }
 
   load(isFinalRendition) {
+    this.isPaused_ = false;
+
     window.clearTimeout(this.mediaUpdateTimeout);
     this.mediaUpdateTimeout = null;
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1136,7 +1136,18 @@ export class PlaylistController extends videojs.EventTarget {
       this.mainSegmentLoader_.load();
     });
 
-    // don't need to reset audio as it is reset when media changes
+    if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
+      this.audioSegmentLoader_.pause();
+      this.audioSegmentLoader_.resetEverything(() => {
+        this.audioSegmentLoader_.load();
+      });
+    }
+    if (this.mediaTypes_.SUBTITLES.activePlaylistLoader) {
+      this.subtitleSegmentLoader_.pause();
+      this.subtitleSegmentLoader_.resetEverything(() => {
+        this.subtitleSegmentLoader_.load();
+      });
+    }
   }
 
   /**

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -29,6 +29,7 @@ import {merge, createTimeRanges} from './util/vjs-compat';
 import { addMetadata, createMetadataTrackIfNotExists, addDateRangeMetadata } from './util/text-tracks';
 import ContentSteeringController from './content-steering-controller';
 import { bufferToHexString } from './util/string.js';
+import {debounce} from './util/fn';
 
 const ABORT_EARLY_EXCLUSION_SECONDS = 10;
 
@@ -151,6 +152,11 @@ const shouldSwitchToMedia = function({
 export class PlaylistController extends videojs.EventTarget {
   constructor(options) {
     super();
+
+    // Adding a slight debounce to avoid duplicate calls during rapid quality changes, for example:
+    // When selecting quality from the quality list,
+    // where we may have multiple bandwidth profiles for the same vertical resolution.
+    this.fastQualityChange_ = debounce(this.fastQualityChange_.bind(this), 100);
 
     const {
       src,

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -701,7 +701,16 @@ export class PlaylistController extends videojs.EventTarget {
 
       if (this.sourceType_ === 'dash') {
         // we don't want to re-request the same hls playlist right after it was changed
-        this.mainPlaylistLoader_.load();
+
+        // Initially it was implemented as workaround to restart playlist loader for live
+        // when playlist loader is paused because of playlist exclusions:
+        // see: https://github.com/videojs/http-streaming/pull/1339
+        // but this introduces duplicate "loadedplaylist" event.
+        // Ideally we want to re-think playlist loader life-cycle events,
+        // but simply checking "paused" state should help a lot
+        if (this.mainPlaylistLoader_.isPaused) {
+          this.mainPlaylistLoader_.load();
+        }
       }
 
       // TODO: Create a new event on the PlaylistLoader that signals

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -980,7 +980,19 @@ export class PlaylistController extends videojs.EventTarget {
     this.timelineChangeController_.on('fixBadTimelineChange', () => {
       // pause, reset-everything and load for all segment-loaders
       this.logger_('Fix bad timeline change. Restarting al segment loaders...');
-      this.setCurrentTime(this.tech_.currentTime());
+      this.mainSegmentLoader_.pause();
+      this.mainSegmentLoader_.resetEverything();
+      if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
+        this.audioSegmentLoader_.pause();
+        this.audioSegmentLoader_.resetEverything();
+      }
+      if (this.mediaTypes_.SUBTITLES.activePlaylistLoader) {
+        this.subtitleSegmentLoader_.pause();
+        this.subtitleSegmentLoader_.resetEverything();
+      }
+
+      // start segment loader loading in case they are paused
+      this.load();
     });
 
     this.mainSegmentLoader_.on('earlyabort', (event) => {
@@ -1130,24 +1142,19 @@ export class PlaylistController extends videojs.EventTarget {
 
   runFastQualitySwitch_() {
     this.waitingForFastQualityPlaylistReceived_ = false;
-    // Delete all buffered data to allow an immediate quality switch.
     this.mainSegmentLoader_.pause();
-    this.mainSegmentLoader_.resetEverything(() => {
-      this.mainSegmentLoader_.load();
-    });
-
+    this.mainSegmentLoader_.resetEverything();
     if (this.mediaTypes_.AUDIO.activePlaylistLoader) {
       this.audioSegmentLoader_.pause();
-      this.audioSegmentLoader_.resetEverything(() => {
-        this.audioSegmentLoader_.load();
-      });
+      this.audioSegmentLoader_.resetEverything();
     }
     if (this.mediaTypes_.SUBTITLES.activePlaylistLoader) {
       this.subtitleSegmentLoader_.pause();
-      this.subtitleSegmentLoader_.resetEverything(() => {
-        this.subtitleSegmentLoader_.load();
-      });
+      this.subtitleSegmentLoader_.resetEverything();
     }
+
+    // start segment loader loading in case they are paused
+    this.load();
   }
 
   /**

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -977,6 +977,12 @@ export class PlaylistController extends videojs.EventTarget {
       this.tech_.setCurrentTime(newTime);
     });
 
+    this.timelineChangeController_.on('fixBadTimelineChange', () => {
+      // pause, reset-everything and load for all segment-loaders
+      this.logger_('Fix bad timeline change. Restarting al segment loaders...');
+      this.setCurrentTime(this.tech_.currentTime());
+    });
+
     this.mainSegmentLoader_.on('earlyabort', (event) => {
       // never try to early abort with the new ABR algorithm
       if (this.bufferBasedABR) {

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -39,8 +39,9 @@ const enableFunction = (loader, playlistID, changePlaylistFn) => (enable) => {
 
   if (enable !== currentlyEnabled && !incompatible) {
     // Ensure the outside world knows about our changes
-    changePlaylistFn(playlist);
     if (enable) {
+      // call fast quality change only when the playlist is enabled
+      changePlaylistFn(playlist);
       loader.trigger({ type: 'renditionenabled', metadata});
     } else {
       loader.trigger({ type: 'renditiondisabled', metadata});

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -424,21 +424,6 @@ export const shouldFixBadTimelineChanges = (timelineChangeController) => {
 };
 
 /**
- * Fixes certain bad timeline scenarios by resetting the loader.
- *
- * @param {SegmentLoader} segmentLoader
- */
-export const fixBadTimelineChange = (segmentLoader) => {
-  if (!segmentLoader) {
-    return;
-  }
-
-  segmentLoader.pause();
-  segmentLoader.resetEverything();
-  segmentLoader.load();
-};
-
-/**
  * Check if the pending audio timeline change is behind the
  * pending main timeline change.
  *
@@ -480,7 +465,7 @@ const checkAndFixTimelines = (segmentLoader) => {
       return;
     }
 
-    fixBadTimelineChange(segmentLoader);
+    segmentLoader.timelineChangeController_.trigger('fixBadTimelineChange');
   }
 };
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1104,7 +1104,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-
     if (this.playlist_ &&
       this.playlist_.endList &&
       newPlaylist.endList &&

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -857,6 +857,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       if (this.pendingSegment_) {
         this.pendingSegment_ = null;
       }
+      this.timelineChangeController_.clearPendingTimelineChange(this.loaderType_);
       return;
     }
 
@@ -1102,6 +1103,15 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (!newPlaylist) {
       return;
     }
+
+    if (this.playlist_ &&
+      this.playlist_.endList &&
+      newPlaylist.endList &&
+      this.playlist_.uri === newPlaylist.uri) {
+      // skip update if both prev and new are vod and have the same URI
+      return;
+    }
+
     const oldPlaylist = this.playlist_;
     const segmentInfo = this.pendingSegment_;
 

--- a/src/util/fn.js
+++ b/src/util/fn.js
@@ -1,0 +1,11 @@
+export const debounce = (callback, wait) => {
+  let timeoutId = null;
+
+  return (...args) => {
+    clearTimeout(timeoutId);
+
+    timeoutId = setTimeout(() => {
+      callback.apply(null, args);
+    }, wait);
+  };
+};

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -4859,6 +4859,7 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
   };
 
   pc.fastQualityChange_(pc.main().playlists[1]);
+  this.clock.tick(110);
   pc.runFastQualitySwitch_();
   assert.deepEqual(calls, {
     resetEverything: 1,
@@ -4868,6 +4869,7 @@ QUnit.test('can pass or select a playlist for fastQualityChange', function(asser
   }, 'calls expected function when passed a playlist');
 
   pc.fastQualityChange_();
+  this.clock.tick(110);
   pc.runFastQualitySwitch_();
   assert.deepEqual(calls, {
     resetEverything: 2,

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -726,7 +726,9 @@ QUnit.test('resets everything for a fast quality change then calls load', functi
 
   segmentLoader.remove = (start, end, doneFn) => {
     assert.equal(end, Infinity, 'on a remove all, end should be Infinity');
-    doneFn && doneFn();
+    if (doneFn) {
+      doneFn();
+    }
     origRemove.call(segmentLoader, start, end, doneFn);
   };
 

--- a/test/playlist-controller.test.js
+++ b/test/playlist-controller.test.js
@@ -726,8 +726,7 @@ QUnit.test('resets everything for a fast quality change then calls load', functi
 
   segmentLoader.remove = (start, end, doneFn) => {
     assert.equal(end, Infinity, 'on a remove all, end should be Infinity');
-    assert.ok(doneFn);
-    doneFn();
+    doneFn && doneFn();
     origRemove.call(segmentLoader, start, end, doneFn);
   };
 

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -294,7 +294,7 @@ QUnit.test(
 
     renditions[1].enabled(false);
 
-    assert.equal(pc.fastQualityChange_.calls, 2, 'fastQualityChange_ was called twice');
+    assert.equal(pc.fastQualityChange_.calls, 1, 'fastQualityChange_ was called once');
   }
 );
 

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -4920,6 +4920,9 @@ QUnit.test('eme handles keystatuschange where status is output-restricted', func
   assert.equal(playlists[0].excludeUntil, Infinity, 'first HD playlist excluded');
   assert.equal(playlists[1].excludeUntil, Infinity, 'second HD playlist excluded');
   assert.equal(playlists[2].excludeUntil, undefined, 'non-HD playlist not excluded');
+
+  this.clock.tick(110);
+
   assert.equal(switchMediaCalled, 1, 'switchMedia_ called once');
 });
 


### PR DESCRIPTION
## Specific Changes proposed

- Clear timeout for media request in dash playlist loader. This fixes the incorrect clearing logic for the media request timeout in the dash playlist loader.
- Add light debounce for fast quality change. This fixes duplicate calls during rapid quality switching.
For example, when we select quality from the quality list with multiple bandwidth profiles for the same vertical resolution, it will call for fast quality changes for multiple playlists one by one.
- Add `isPaused` for the dash playlist loader. This fixes duplicate load calls when `mediachange` is fired. See this PR for more info https://github.com/videojs/http-streaming/pull/1339)
- Call fast quality change only if a playlist is selected. This fixes duplicate calls when selecting quality from the quality list.
- Ignore duplicate playlist updates in the segment-loader.
- Move fixBadTimelineChanged logic from playlist-controller level to reset all segment-loaders.
- Clear all segment loaders during fast quality change.



## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
