### PR TITLE
fix: playlists wrongfully excluded on iOS when using ManagedMediaSource

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -192,7 +192,7 @@ export class PlaylistController extends videojs.EventTarget {
     this.playlistExclusionDuration = playlistExclusionDuration;
     this.maxPlaylistRetries = maxPlaylistRetries;
     this.enableLowInitialPlaylist = enableLowInitialPlaylist;
-    this.experimentalUseMMS_ = experimentalUseMMS;
+    this.usingManagedMediaSource_ = false;
 
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack(
@@ -216,6 +216,7 @@ export class PlaylistController extends videojs.EventTarget {
       // Airplay source not yet implemented. Remote playback must be disabled.
       this.tech_.el_.disableRemotePlayback = true;
       this.mediaSource = new window.ManagedMediaSource();
+      this.usingManagedMediaSource_ = true;
 
       videojs.log('Using ManagedMediaSource');
     } else if (window.MediaSource) {
@@ -1959,7 +1960,7 @@ export class PlaylistController extends videojs.EventTarget {
     }
 
     // fmp4 relies on browser support, while ts relies on muxer support
-    const supportFunction = (isFmp4, codec) => (isFmp4 ? browserSupportsCodec(codec, this.experimentalUseMMS_) : muxerSupportsCodec(codec));
+    const supportFunction = (isFmp4, codec) => (isFmp4 ? browserSupportsCodec(codec, this.usingManagedMediaSource_) : muxerSupportsCodec(codec));
     const unsupportedCodecs = {};
     let unsupportedAudio;
 
@@ -2101,11 +2102,11 @@ export class PlaylistController extends videojs.EventTarget {
       const codecs = codecsForPlaylist(this.main, variant);
       const unsupported = [];
 
-      if (codecs.audio && !muxerSupportsCodec(codecs.audio) && !browserSupportsCodec(codecs.audio, this.experimentalUseMMS_)) {
+      if (codecs.audio && !muxerSupportsCodec(codecs.audio) && !browserSupportsCodec(codecs.audio, this.usingManagedMediaSource_)) {
         unsupported.push(`audio codec ${codecs.audio}`);
       }
 
-      if (codecs.video && !muxerSupportsCodec(codecs.video) && !browserSupportsCodec(codecs.video, this.experimentalUseMMS_)) {
+      if (codecs.video && !muxerSupportsCodec(codecs.video) && !browserSupportsCodec(codecs.video, this.usingManagedMediaSource_)) {
         unsupported.push(`video codec ${codecs.video}`);
       }
 

--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -192,6 +192,7 @@ export class PlaylistController extends videojs.EventTarget {
     this.playlistExclusionDuration = playlistExclusionDuration;
     this.maxPlaylistRetries = maxPlaylistRetries;
     this.enableLowInitialPlaylist = enableLowInitialPlaylist;
+    this.experimentalUseMMS_ = experimentalUseMMS;
 
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack(
@@ -1958,7 +1959,7 @@ export class PlaylistController extends videojs.EventTarget {
     }
 
     // fmp4 relies on browser support, while ts relies on muxer support
-    const supportFunction = (isFmp4, codec) => (isFmp4 ? browserSupportsCodec(codec) : muxerSupportsCodec(codec));
+    const supportFunction = (isFmp4, codec) => (isFmp4 ? browserSupportsCodec(codec, this.experimentalUseMMS_) : muxerSupportsCodec(codec));
     const unsupportedCodecs = {};
     let unsupportedAudio;
 
@@ -2100,11 +2101,11 @@ export class PlaylistController extends videojs.EventTarget {
       const codecs = codecsForPlaylist(this.main, variant);
       const unsupported = [];
 
-      if (codecs.audio && !muxerSupportsCodec(codecs.audio) && !browserSupportsCodec(codecs.audio)) {
+      if (codecs.audio && !muxerSupportsCodec(codecs.audio) && !browserSupportsCodec(codecs.audio, this.experimentalUseMMS_)) {
         unsupported.push(`audio codec ${codecs.audio}`);
       }
 
-      if (codecs.video && !muxerSupportsCodec(codecs.video) && !browserSupportsCodec(codecs.video)) {
+      if (codecs.video && !muxerSupportsCodec(codecs.video) && !browserSupportsCodec(codecs.video, this.experimentalUseMMS_)) {
         unsupported.push(`video codec ${codecs.video}`);
       }
 


### PR DESCRIPTION
## Description
The `browserSupportsCodec()` [vhs-utils](https://github.com/videojs/vhs-utils/blob/ad87c8bff2581431a7c8b64a9d78e266c16fe086/src/codecs.js#L215-L224) method was recently updated to support cases where `ManagedMediaSource` is supported and in use. This is accomplished by passing a 2nd argument `withMMS` that defaults to `false`. Invocations in VHS weren't passing this 2nd arg, resulting in cases where VHS thought errantly that supported codecs were not supported, resulting in playlists being wrongly excluded.

## Specific Changes proposed
- Add flag in PlaylistController indicating whether a `ManagedMediaSource` is being used
- Pass that value to `browserSupportsCodec()` calls

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
