### PR TITLE
Updated link in readme leading to Decode Timestamp doc at w3.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ This option defaults to `false`.
 ##### useDtsForTimestampOffset
 * Type: `boolean`,
 * Default: `false`
-* Use [Decode Timestamp](https://www.w3.org/TR/media-source/#decode-timestamp) instead of [Presentation Timestamp](https://www.w3.org/TR/media-source/#presentation-timestamp) for [timestampOffset](https://www.w3.org/TR/media-source/#dom-sourcebuffer-timestampoffset) calculation. This option was introduced to align with DTS-based browsers. This option affects only transmuxed data (eg: transport stream). For more info please check the following [issue](https://github.com/videojs/http-streaming/issues/1247).  
+* Use [Decode Timestamp](https://www.w3.org/TR/media-source/#dfn-decode-timestamp) instead of [Presentation Timestamp](https://www.w3.org/TR/media-source/#presentation-timestamp) for [timestampOffset](https://www.w3.org/TR/media-source/#dom-sourcebuffer-timestampoffset) calculation. This option was introduced to align with DTS-based browsers. This option affects only transmuxed data (eg: transport stream). For more info please check the following [issue](https://github.com/videojs/http-streaming/issues/1247).  
 
 ##### useForcedSubtitles
 * Type: `boolean`


### PR DESCRIPTION
## Description
Heya, fixed a link in the Readme. Had to open this a couple of times in the last two days and it bothered me...
btw: Thanks for the nice Documentation with all the links! :-)

## Specific Changes proposed
fixed a link in the Readme

## Requirements Checklist
- [/] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
