### PR TITLE
fix: clamp seekable end to start instead of 0

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -1702,12 +1702,8 @@ export class PlaylistController extends videojs.EventTarget {
 
       const liveEdgeDelay = Vhs.Playlist.liveEdgeDelay(this.mainPlaylistLoader_.main, media);
 
-      // Make sure our seekable end is not negative
-      const calculatedEnd = Math.max(0, end - liveEdgeDelay);
-
-      if (calculatedEnd < start) {
-        return null;
-      }
+      // Make sure our seekable end is not less than the seekable start
+      const calculatedEnd = Math.max(start, end - liveEdgeDelay);
 
       return createTimeRanges([[start, calculatedEnd]]);
     }


### PR DESCRIPTION
## Description
We clamped the calculated seekable end (the true seekable end minus the liveEdgeDelay) to 0 instead of the seekable start, which resulted in the possibility of having seekable ranges like `[5, 0]`, where the end is less than the start.

## Specific Changes proposed
We should clamp the calculated seekable end to the start instead of 0 to prevent this possibility.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
