### PR TITLE
fix: Fix getStreamingNetworkErrorMetadata to support videojs 7

### DIFF
--- a/src/error-codes.js
+++ b/src/error-codes.js
@@ -10,6 +10,11 @@ export const getStreamingNetworkErrorMetadata = ({ requestType, request, error, 
     uri: request.uri,
     requestType
   };
+
+  if (!videojs.hasOwnProperty('Error')) {
+    return errorMetadata;
+  }
+
   const isBadStatusOrParseFailure = (isBadStatus && !isFailure) || parseFailure;
 
   if (error && isFailure) {


### PR DESCRIPTION
## Description
https://github.com/videojs/http-streaming/issues/1566 

## Specific Changes proposed
Added property existing checking to avoid exception if you use 7th version of the videojs

## Requirements Checklist
- [x] Bug fixed
- [ ] Reviewed by Two Core Contributors
