### PR TITLE
fix: correct errorMetadata property name from 'erroType' to 'errorType'

### DIFF
--- a/src/error-codes.js
+++ b/src/error-codes.js
@@ -19,7 +19,7 @@ export const getStreamingNetworkErrorMetadata = ({ requestType, request, error, 
   } else if (request.aborted) {
     errorMetadata.errorType = videojs.Error.NetworkRequestAborted;
   } else if (request.timedout) {
-    errorMetadata.erroType = videojs.Error.NetworkRequestTimeout;
+    errorMetadata.errorType = videojs.Error.NetworkRequestTimeout;
   } else if (isBadStatusOrParseFailure) {
     const errorType = parseFailure ? videojs.Error.NetworkBodyParserFailed : videojs.Error.NetworkBadStatus;
 


### PR DESCRIPTION
## Description
The erroType property in request.timedout is incorrectly named.

While reviewing error-handling behavior, I noticed an inconsistency in the property name. 🔍 Based on the surrounding code context, it should be errorType.

This fix ensures consistency with other error return formats😀

## Specific Changes proposed
correct errorMetadata property name from `erroType` to `errorType`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
