### PR TITLE
feat: Update media-segment-request.js for customize transforming the response data

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -317,15 +317,23 @@ const handleSegmentResponse = ({
     return finishProcessingFn(errorObj, segment);
   }
   triggerSegmentEventFn({ type: 'segmentloaded', segment });
+
+  // because the 'response' and 'responseText' property from XMLHttpRequest is readonly,
+  // add two customize read-write property: videojsCustomizedResponse,videojsCustomizedResponseText to request object.
+  let destResponse = request.videojsCustomizedResponse ? request.videojsCustomizedResponse : request.response;
+  // 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text'
+  let destResponseText = request.videojsCustomizedResponseText ? request.videojsCustomizedResponseText :
+          (responseType === '' || responseType === 'text' ? null : request.responseText);
+  
   const newBytes =
     // although responseText "should" exist, this guard serves to prevent an error being
     // thrown for two primary cases:
     // 1. the mime type override stops working, or is not implemented for a specific
     //    browser
     // 2. when using mock XHR libraries like sinon that do not allow the override behavior
-    (responseType === 'arraybuffer' || !request.responseText) ?
-      request.response :
-      stringToArrayBuffer(request.responseText.substring(segment.lastReachedChar || 0));
+    (responseType === 'arraybuffer' || !destResponseText) ?
+      destResponse :
+      stringToArrayBuffer(destResponseText.substring(segment.lastReachedChar || 0));
 
   segment.stats = getRequestStats(request);
 


### PR DESCRIPTION
Because the 'response' and 'responseText' property from XMLHttpRequest is readonly, add two customize read-write property: videojsCustomizedResponse,videojsCustomizedResponseText to request object. So can customize transform the response data through videojs.Vhs.xhr.onResponse. eg: request.videojsCustomizedResponse=newResponseData

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
