### PR TITLE
fix: prevent errors in getKeyIdSet if `playlist.contentProtection` object is incomplete

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -1317,17 +1317,21 @@ export default class PlaylistLoader extends EventTarget {
    * @return a Set of 32 digit hex strings that represent the unique keyIds for that playlist.
    */
   getKeyIdSet(playlist) {
-    if (playlist.contentProtection) {
-      const keyIds = new Set();
+    const keyIds = new Set();
 
-      for (const keysystem in playlist.contentProtection) {
-        const keyId = playlist.contentProtection[keysystem].attributes.keyId;
-
-        if (keyId) {
-          keyIds.add(keyId.toLowerCase());
-        }
-      }
+    if (!playlist || !playlist.contentProtection) {
       return keyIds;
     }
+
+    for (const keysystem in playlist.contentProtection) {
+      if (playlist.contentProtection[keysystem] &&
+          playlist.contentProtection[keysystem].attributes &&
+          playlist.contentProtection[keysystem].attributes.keyId) {
+        const keyId = playlist.contentProtection[keysystem].attributes.keyId;
+
+        keyIds.add(keyId.toLowerCase());
+      }
+    }
+    return keyIds;
   }
 }

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -49,6 +49,39 @@ QUnit.module('Playlist Loader', function(hooks) {
     assert.ok(keyIdSet.has(keyId.toLowerCase()), 'keyId is expected hex string');
   });
 
+  QUnit.test('does not error if keyId or keysystem.attributes is missing', function(assert) {
+    assert.expect(6);
+    const loader = new PlaylistLoader('variant.m3u8', this.fakeVhs);
+    const playlists = [
+      {
+        contentProtection: {
+          'fake.keysystem': {}
+        }
+      },
+      {
+        contentProtection: {
+          'fake.keysystem': {
+            attributes: {}
+          }
+        }
+      }
+    ];
+
+    let errorHappened = false;
+
+    for (const playlist of playlists) {
+      let keyIdSet;
+
+      try {
+        keyIdSet = loader.getKeyIdSet(playlist);
+      } catch (e) {
+        errorHappened = true;
+      }
+      assert.notOk(errorHappened, 'no error was thrown');
+      assert.notOk(keyIdSet.size, 'keyIdSet is empty');
+    }
+  });
+
   QUnit.test('updateSegments copies over properties', function(assert) {
     assert.deepEqual(
       [


### PR DESCRIPTION

## Description
When attempting to playback a HLS source with Fairplay, Playready and Widevine DRM, I'm seeing errors coming from `getKeyIdSet` because it looks like Fairplay and Playready support are only partially implemented in m3u8-parser.
 When `getKeyIdSet` is looping the available playlists, `playlist.contentProtection[keysystem].attributes` and `playlist.contentProtection[keysystem].attributes.keyId` can be missing. 

## Specific Changes proposed
This change checks we can get a value for keyId before attempting to assign it.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
