### PR TITLE
fix: add release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ jobs:
     env:
       NETLIFY_BASE: 'videojs-http-streaming.netlify.app'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

https://github.com/videojs/http-streaming/actions/runs/16449154568/job/46489360362

Looks like the http-streaming release workflow may be suffering the same issues as [video.js](https://github.com/videojs/video.js/blob/main/CHANGELOG.md#8233-2025-04-16) earlier in the year.  I've copied the permissions over, hopefully that fixes it 🤞 