### PR TITLE
fix: Safari playback stall with overrideNative and experimentalUseMMS

### DIFF
--- a/src/playlist-controller.js
+++ b/src/playlist-controller.js
@@ -254,7 +254,13 @@ export class PlaylistController extends videojs.EventTarget {
       label: 'segment-metadata'
     }, false).track;
 
-    this.segmentMetadataTrack_.mode = 'hidden';
+    // Only disable segment metadata track in Safari/iOS when using overrideNative HLS
+    if ((videojs.browser.IS_ANY_SAFARI || videojs.browser.IS_IOS) &&
+      this.sourceType_ === 'hls') {
+      this.segmentMetadataTrack_.mode = 'disabled';
+    } else {
+      this.segmentMetadataTrack_.mode = 'hidden';
+    }
 
     this.decrypter_ = new Decrypter();
     this.sourceUpdater_ = new SourceUpdater(this.mediaSource);


### PR DESCRIPTION
## Description
Safari playback does not start when using overrideNative together with experimentalUseMMS.

This appears to be caused by setting the segment metadata track mode to hidden, which can stall playback in Safari when using Managed Media Source.

Disabling the metadata track in this specific scenario prevents Safari from processing it and allows playback to start normally.

Fixes #1600

This behavior seems specific to Safari when using MMS. Other browsers (Chrome, Firefox) do not appear to be affected by this issue.

## Specific Changes proposed

- Detect Safari/iOS when using `overrideNative` + `experimentalUseMMS`
- Set `segmentMetadataTrack_.mode = 'disabled'` instead of `hidden` in this specific scenario
- Keep the existing behavior (`hidden`) for all other browsers and configurations

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
