### PR TITLE
Do not lower measured bandwidth with Network Information API

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ This option defaults to `false`.
 ##### useNetworkInformationApi
 * Type: `boolean`,
 * Default: `true`
-* Use [window.networkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink) to estimate the network's bandwidth. Per mdn, _The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure_. Given this, if bandwidth estimates from both the player and networkInfo are >= 10 Mbps, the player will use the larger of the two values as its bandwidth estimate.
+* Use [window.networkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink) to estimate the network's bandwidth. Per mdn, _The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure_. Given this, before media segment stats are available, if bandwidth estimates from both the player and networkInfo are >= 10 Mbps, the player will use the larger of the two values as its bandwidth estimate. Once media segment stats are available, the player uses the larger of the player estimate and the networkInfo estimate so networkInfo does not lower a player-specific bandwidth estimate.
 
 ##### useDtsForTimestampOffset
 * Type: `boolean`,

--- a/src/videojs-http-streaming.js
+++ b/src/videojs-http-streaming.js
@@ -873,15 +873,21 @@ class VhsHandler extends Component {
       },
       bandwidth: {
         get() {
-          let playerBandwidthEst = this.playlistController_.mainSegmentLoader_.bandwidth;
+          const mainSegmentLoader = this.playlistController_.mainSegmentLoader_;
+          let playerBandwidthEst = mainSegmentLoader.bandwidth;
 
           const networkInformation = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
           const tenMbpsAsBitsPerSecond = 10e6;
+          const hasSegmentBandwidthEstimate = !isNaN(mainSegmentLoader.roundTrip);
 
           if (this.options_.useNetworkInformationApi && networkInformation) {
             // downlink returns Mbps
             // https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink
             const networkInfoBandwidthEstBitsPerSec = networkInformation.downlink * 1000 * 1000;
+
+            if (hasSegmentBandwidthEstimate) {
+              return Math.max(playerBandwidthEst, networkInfoBandwidthEstBitsPerSec);
+            }
 
             // downlink maxes out at 10 Mbps. In the event that both networkInformationApi and the player
             // estimate a bandwidth greater than 10 Mbps, use the larger of the two estimates to ensure that

--- a/test/videojs-http-streaming.test.js
+++ b/test/videojs-http-streaming.test.js
@@ -1096,6 +1096,60 @@ QUnit.module('NetworkInformationApi', hooks => {
   );
 
   QUnit.test(
+    'bandwidth does not use network-information-api to lower bandwidth after media segment stats are available',
+    function(assert) {
+      this.resetNavigatorConnection({
+        downlink: 1.5
+      });
+      this.player = createPlayer({ html5: { vhs: { useNetworkInformationApi: true } } });
+      this.player.src({
+        src: 'manifest/main.m3u8',
+        type: 'application/vnd.apple.mpegurl'
+      });
+
+      this.clock.tick(1);
+
+      const mainSegmentLoader = this.player.tech_.vhs.playlistController_.mainSegmentLoader_;
+
+      mainSegmentLoader.bandwidth = 20e6;
+      mainSegmentLoader.roundTrip = 100;
+
+      assert.strictEqual(
+        this.player.tech_.vhs.bandwidth,
+        20e6,
+        'bandwidth getter returned the higher player-estimated bandwidth value after media segment stats'
+      );
+    }
+  );
+
+  QUnit.test(
+    'bandwidth can use network-information-api to raise bandwidth after media segment stats are available',
+    function(assert) {
+      this.resetNavigatorConnection({
+        downlink: 9
+      });
+      this.player = createPlayer({ html5: { vhs: { useNetworkInformationApi: true } } });
+      this.player.src({
+        src: 'manifest/main.m3u8',
+        type: 'application/vnd.apple.mpegurl'
+      });
+
+      this.clock.tick(1);
+
+      const mainSegmentLoader = this.player.tech_.vhs.playlistController_.mainSegmentLoader_;
+
+      mainSegmentLoader.bandwidth = 2e6;
+      mainSegmentLoader.roundTrip = 100;
+
+      assert.strictEqual(
+        this.player.tech_.vhs.bandwidth,
+        9e6,
+        'bandwidth getter returned the higher network-information-api bandwidth value after media segment stats'
+      );
+    }
+  );
+
+  QUnit.test(
     'bandwidth uses player-estimated bandwidth when networkInformation is not supported',
     function(assert) {
       // Nullify the `connection` property on Navigator


### PR DESCRIPTION
## Description
Fixes #1604.

When `useNetworkInformationApi` is enabled, VHS currently uses `navigator.connection.downlink` as the public `bandwidth` value whenever Network Information API data is present, except for the existing `>= 10 Mbps` special case. That can let a lower generic browser-level estimate override a higher player-specific bandwidth estimate after VHS has downloaded media segments.

This change keeps the Network Information API behavior before media segment stats are available, and still allows it to raise the estimate afterward. Once the media segment loader has a player-specific estimate, however, Network Information API no longer lowers that value.

## Specific Changes proposed
- Track whether the main segment loader has a bandwidth estimate from media segment stats.
- Preserve the existing Network Information API behavior before media segment stats are available.
- After media segment stats are available, use the larger of the player estimate and the Network Information API estimate.
- Add unit coverage for both post-segment-stats cases:
  - Network Information API lower than the player estimate.
  - Network Information API higher than the player estimate.
- Update the `useNetworkInformationApi` README entry to describe the post-segment-stats behavior.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors

Validation:
- `npm run lint`
- `CI_TEST_TYPE=unit npm run build-test`
- `CI_TEST_TYPE=unit npx karma start scripts/karma.conf.js --single-run --browsers ChromeHeadless`
